### PR TITLE
Array to object fix

### DIFF
--- a/client/src/components/Panels/Common/ToolSearch.vue
+++ b/client/src/components/Panels/Common/ToolSearch.vue
@@ -7,6 +7,8 @@ import axios from "axios";
 import { getAppRoot } from "onload/loadConfig";
 import { getGalaxyInstance } from "app";
 import DelayedInput from "components/Common/DelayedInput";
+import MockAdapter from "axios-mock-adapter";
+import testToolsSearchResponse from "./../../ToolsView/testData/toolsSearch";
 
 export default {
     name: "ToolSearch",
@@ -48,12 +50,26 @@ export default {
                     this.$emit("onResults", this.favoritesResults);
                 } else {
                     this.loading = true;
+
+                    let axiosMock;
+                    axiosMock = new MockAdapter(axios);
+                    axiosMock.onGet(`${getAppRoot()}api/tools`).reply(200, testToolsSearchResponse);
+
                     axios
                         .get(`${getAppRoot()}api/tools`, {
                             params: { q, view: this.currentPanelView },
                         })
                         .then((response) => {
                             this.loading = false;
+
+                            if (axiosMock) {
+                                let toolID = [];
+                                (response.data).forEach(function(tool) {
+                                    toolID.push(tool.id);
+                                });
+                                response.data = toolID;
+                            }
+
                             this.$emit("onResults", response.data);
                         })
                         .catch((err) => {

--- a/client/src/components/Panels/utilities.js
+++ b/client/src/components/Panels/utilities.js
@@ -6,17 +6,15 @@ export function filterToolSections(layout, results) {
             if (section.elems) {
                 section.elems.forEach((el) => {
                     if (
-                        (!el.text && results.includes(el.id)) ||
-                        (el.tool_shed_repository && results.includes(el.tool_shed_repository.name))
+                        (!el.text && toolNameExistsInResults(el.id, results)) ||
+                        (el.tool_shed_repository && toolNameExistsInResults(el.tool_shed_repository.name, results))
                     ) {
                         toolRes.push(el);
                     }
                 });
             }
-            // sort tools in section by rank in results
-            toolRes.sort((tool1, tool2) => {
-                return results.indexOf(tool1.id) - results.indexOf(tool2.id);
-            });
+
+            toolRes = sortToolsByResultsScore(toolRes, results);
 
             return {
                 ...section,
@@ -34,7 +32,7 @@ export function filterToolSections(layout, results) {
                 if (sect1.elems.length == 0 || sect2.elems.length == 0) {
                     return 0;
                 }
-                return results.indexOf(sect1.elems[0].id) - results.indexOf(sect2.elems[0].id);
+                return results.indexOf(sect1.elems[0].id) - results.indexOf(sect2.elems[0].id); //TODO may need updates to Object
             });
     } else {
         return layout;
@@ -56,8 +54,8 @@ export function filterTools(layout, results) {
             if (section.elems) {
                 section.elems.forEach((el) => {
                     if (
-                        (!el.text && results.includes(el.id)) ||
-                        (el.tool_shed_repository && results.includes(el.tool_shed_repository.name))
+                        (!el.text && toolNameExistsInResults(el.id, results)) ||
+                        (el.tool_shed_repository && toolNameExistsInResults(el.tool_shed_repository.name, results))
                     ) {
                         toolsResults.push(el);
                     }
@@ -66,9 +64,10 @@ export function filterTools(layout, results) {
                 toolsResults.push(section);
             }
         });
-        return toolsResults.sort((tool1, tool2) => {
-            return results.indexOf(tool1.id) - results.indexOf(tool2.id);
-        });
+
+        toolsResults = sortToolsByResultsScore(toolsResults, results);
+
+        return toolsResults;
     } else {
         return layout;
     }
@@ -83,4 +82,24 @@ function normalize_results(results) {
         }
     });
     return norm_results;
+}
+
+/** 
+ * Where `results` is an Array of Objects 
+ */
+function sortToolsByResultsScore(tools, results) {
+    tools.sort((tool1, tool2) => {
+        return results.indexOf(tool1.score) - results.indexOf(tool2.score);
+    });
+
+    return tools;
+}
+
+/** 
+ * Where `results` is an Array of Objects 
+ */
+function toolNameExistsInResults(toolname, results) {
+    let matchedTools = results.filter((r) => r.id === toolname);
+
+    return matchedTools && matchedTools.length > 0;
 }

--- a/client/src/components/ToolsView/testData/toolsSearch.json
+++ b/client/src/components/ToolsView/testData/toolsSearch.json
@@ -1,0 +1,21648 @@
+[
+    {
+      "name": "NCBI Datasets Genomes",
+      "id": "datasets_download_genome",
+      "description": "download genome sequence, annotation and metadata",
+      "tool_shed_repository": "ncbi_datasets",
+      "panel_section_name": "Get Data",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/ncbi_datasets/datasets_download_genome/13.4.0"
+    },
+    {
+      "name": "NCBI Accession Download",
+      "id": "ncbi_acc_download",
+      "description": "Download sequences from GenBank/RefSeq by accession through the NCBI ENTREZ API",
+      "tool_shed_repository": "ncbi_acc_download",
+      "panel_section_name": "Get Data",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/ncbi_acc_download/ncbi_acc_download/0.2.7+galaxy0"
+    },
+    {
+      "name": "UniProt",
+      "id": "uniprotxml_downloader",
+      "description": "download proteome as XML or fasta",
+      "tool_shed_repository": "uniprotxml_downloader",
+      "panel_section_name": "Get Data",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/uniprotxml_downloader/uniprotxml_downloader/2.2.0"
+    },
+    {
+      "name": "Unipept",
+      "id": "unipept",
+      "description": "retrieve taxonomy for peptides",
+      "tool_shed_repository": "unipept",
+      "panel_section_name": "Get Data",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/unipept/unipept/4.5.0"
+    },
+    {
+      "name": "IEDB",
+      "id": "iedb_api",
+      "description": "MHC Binding prediction",
+      "tool_shed_repository": "iedb_api",
+      "panel_section_name": "Get Data",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/iedb_api/iedb_api/2.15.2"
+    },
+    {
+      "name": "Download and Extract Reads in BAM",
+      "id": "sam_dump",
+      "description": "format from NCBI SRA",
+      "tool_shed_repository": "sra_tools",
+      "panel_section_name": "Get Data",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/sra_tools/sam_dump/2.11.0+galaxy0"
+    },
+    {
+      "name": "Protein Database Downloader",
+      "id": "dbbuilder",
+      "description": "",
+      "tool_shed_repository": "dbbuilder",
+      "panel_section_name": "Get Data",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/dbbuilder/dbbuilder/0.3.2"
+    },
+    {
+      "name": "Download and Generate Pileup Format",
+      "id": "sra_pileup",
+      "description": "from NCBI SRA",
+      "tool_shed_repository": "sra_tools",
+      "panel_section_name": "Get Data",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/sra_tools/sra_pileup/2.10.3"
+    },
+    {
+      "name": "Get species occurrences data",
+      "id": "spocc_occ",
+      "description": "from GBIF, ALA, iNAT and others",
+      "tool_shed_repository": "spocc_occ",
+      "panel_section_name": "Animal Detection on Acoustic Recordings",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/ecology/spocc_occ/spocc_occ/0.9.0"
+    },
+    {
+      "name": "NCBI ESearch",
+      "id": "ncbi_eutils_esearch",
+      "description": "search NCBI Databases by text query",
+      "tool_shed_repository": "ncbi_eutils_esearch",
+      "panel_section_name": "Get Data",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/ncbi_eutils_esearch/ncbi_eutils_esearch/1.2"
+    },
+    {
+      "name": "NCBI EGQuery",
+      "id": "ncbi_eutils_egquery",
+      "description": "Provides the number of records retrieved in all Entrez databases by a single text query.",
+      "tool_shed_repository": "ncbi_eutils_egquery",
+      "panel_section_name": "Get Data",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/ncbi_eutils_egquery/ncbi_eutils_egquery/1.2"
+    },
+    {
+      "name": "NCBI ECitMatch",
+      "id": "ncbi_eutils_ecitmatch",
+      "description": "search NCBI for citations in PubMed",
+      "tool_shed_repository": "ncbi_eutils_ecitmatch",
+      "panel_section_name": "Get Data",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/ncbi_eutils_ecitmatch/ncbi_eutils_ecitmatch/1.2"
+    },
+    {
+      "name": "NCBI EPost",
+      "id": "ncbi_eutils_epost",
+      "description": "post UIDs to NCBI History Server",
+      "tool_shed_repository": "ncbi_eutils_epost",
+      "panel_section_name": "Get Data",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/ncbi_eutils_epost/ncbi_eutils_epost/1.2"
+    },
+    {
+      "name": "NCBI ELink",
+      "id": "ncbi_eutils_elink",
+      "description": "link UIDs from one database to another",
+      "tool_shed_repository": "ncbi_eutils_elink",
+      "panel_section_name": "Get Data",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/ncbi_eutils_elink/ncbi_eutils_elink/1.2"
+    },
+    {
+      "name": "NCBI EInfo",
+      "id": "ncbi_eutils_einfo",
+      "description": "fetch NCBI database metadata",
+      "tool_shed_repository": "ncbi_eutils_einfo",
+      "panel_section_name": "Get Data",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/ncbi_eutils_einfo/ncbi_eutils_einfo/1.2"
+    },
+    {
+      "name": "NCBI ESummary",
+      "id": "ncbi_eutils_esummary",
+      "description": "fetch summary of history/ids",
+      "tool_shed_repository": "ncbi_eutils_esummary",
+      "panel_section_name": "Get Data",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/ncbi_eutils_esummary/ncbi_eutils_esummary/1.2"
+    },
+    {
+      "name": "NCBI EFetch",
+      "id": "ncbi_eutils_efetch",
+      "description": "fetch records from NCBI",
+      "tool_shed_repository": "ncbi_eutils_efetch",
+      "panel_section_name": "Get Data",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/ncbi_eutils_efetch/ncbi_eutils_efetch/1.2"
+    },
+    {
+      "name": "UniProt",
+      "id": "uniprot",
+      "description": "ID mapping and retrieval",
+      "tool_shed_repository": "uniprot_rest_interface",
+      "panel_section_name": "Get Data",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/uniprot_rest_interface/uniprot/0.2"
+    },
+    {
+      "name": "Get sequences by Ensembl ID",
+      "id": "get_sequences",
+      "description": "using REST API",
+      "tool_shed_repository": "ensembl_get_sequences",
+      "panel_section_name": "Get Data",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/earlhaminst/ensembl_get_sequences/get_sequences/0.1.2"
+    },
+    {
+      "name": "Get gene tree by Ensembl ID",
+      "id": "get_genetree",
+      "description": "using REST API",
+      "tool_shed_repository": "ensembl_get_genetree",
+      "panel_section_name": "Get Data",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/earlhaminst/ensembl_get_genetree/get_genetree/0.1.2"
+    },
+    {
+      "name": "Get features by Ensembl ID",
+      "id": "get_feature_info",
+      "description": "using REST API",
+      "tool_shed_repository": "ensembl_get_feature_info",
+      "panel_section_name": "Get Data",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/earlhaminst/ensembl_get_feature_info/get_feature_info/0.1.2"
+    },
+    {
+      "name": "Search ENA data",
+      "id": "enasearch_search_data",
+      "description": "given a query",
+      "tool_shed_repository": "enasearch_search_data",
+      "panel_section_name": "Get Data",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/enasearch_search_data/enasearch_search_data/0.1.1.0"
+    },
+    {
+      "name": "Retrieve ENA data",
+      "id": "enasearch_retrieve_data",
+      "description": "(other than taxon and project)",
+      "tool_shed_repository": "enasearch_retrieve_data",
+      "panel_section_name": "Get Data",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/enasearch_retrieve_data/enasearch_retrieve_data/0.1.1.0"
+    },
+    {
+      "name": "Retrieve ENA taxon data",
+      "id": "enasearch_retrieve_taxons",
+      "description": "",
+      "tool_shed_repository": "enasearch_retrieve_taxons",
+      "panel_section_name": "Get Data",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/enasearch_retrieve_taxons/enasearch_retrieve_taxons/0.1.1.0"
+    },
+    {
+      "name": "Retrieve an analysis report",
+      "id": "enasearch_retrieve_analysis_report",
+      "description": "",
+      "tool_shed_repository": "enasearch_retrieve_analysis_report",
+      "panel_section_name": "Get Data",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/enasearch_retrieve_analysis_report/enasearch_retrieve_analysis_report/0.1.1.0"
+    },
+    {
+      "name": "Retrieve a run report",
+      "id": "enasearch_retrieve_run_report",
+      "description": "",
+      "tool_shed_repository": "enasearch_retrieve_run_report",
+      "panel_section_name": "Get Data",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/enasearch_retrieve_run_report/enasearch_retrieve_run_report/0.1.1.0"
+    },
+    {
+      "name": "EBI Search",
+      "id": "ebi_search_rest_results",
+      "description": "to obtain search results on resources and services hosted at the EBI",
+      "tool_shed_repository": "ebi_search_rest_results",
+      "panel_section_name": "Get Data",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/ebi_search_rest_results/ebi_search_rest_results/0.1.1"
+    },
+    {
+      "name": "Download run data",
+      "id": "ebi_metagenomics_run_downloader",
+      "description": "from EBI Metagenomics database",
+      "tool_shed_repository": "ebi_metagenomics_run_downloader",
+      "panel_section_name": "Get Data",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/ebi_metagenomics_run_downloader/ebi_metagenomics_run_downloader/0.1.0"
+    },
+    {
+      "name": "EGA Download Client",
+      "id": "pyega3",
+      "description": "",
+      "tool_shed_repository": "ega_download_client",
+      "panel_section_name": "Get Data",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/ega_download_client/pyega3/3.4.0+galaxy0"
+    },
+    {
+      "name": "ENA Upload tool",
+      "id": "ena_upload",
+      "description": "",
+      "tool_shed_repository": "ena_upload",
+      "panel_section_name": "Send Data",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/ena_upload/ena_upload/0.5.3"
+    },
+    {
+      "name": "cURL",
+      "id": "curl_post",
+      "description": "send cURL POST requests",
+      "tool_shed_repository": "curl_post",
+      "panel_section_name": "Send Data",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/imgteam/curl_post/curl_post/0.0.2"
+    },
+    {
+      "name": "Collapse Collection",
+      "id": "collapse_dataset",
+      "description": "into single dataset in order of the collection",
+      "tool_shed_repository": "collapse_collections",
+      "panel_section_name": "Collection Operations",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/nml/collapse_collections/collapse_dataset/5.1.0"
+    },
+    {
+      "name": "Split file",
+      "id": "tp_split_on_column",
+      "description": "according to the values of a column",
+      "tool_shed_repository": "split_file_on_column",
+      "panel_section_name": "Collection Operations",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/split_file_on_column/tp_split_on_column/0.4"
+    },
+    {
+      "name": "Split file",
+      "id": "split_file_to_collection",
+      "description": "to dataset collection",
+      "tool_shed_repository": "split_file_to_collection",
+      "panel_section_name": "Collection Operations",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/split_file_to_collection/split_file_to_collection/0.5.0"
+    },
+    {
+      "name": "Unzip",
+      "id": "unzip",
+      "description": "Unzip file",
+      "tool_shed_repository": "unzip",
+      "panel_section_name": "Collection Operations",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/imgteam/unzip/unzip/0.2"
+    },
+    {
+      "name": "Extract element identifiers",
+      "id": "collection_element_identifiers",
+      "description": "of a list collection",
+      "tool_shed_repository": "collection_element_identifiers",
+      "panel_section_name": "Collection Operations",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/collection_element_identifiers/collection_element_identifiers/0.0.2"
+    },
+    {
+      "name": "Column join",
+      "id": "collection_column_join",
+      "description": "on multiple datasets",
+      "tool_shed_repository": "collection_column_join",
+      "panel_section_name": "Join, Subtract and Group",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/collection_column_join/collection_column_join/0.0.3"
+    },
+    {
+      "name": "Table Compute",
+      "id": "table_compute",
+      "description": "computes operations on table data",
+      "tool_shed_repository": "table_compute",
+      "panel_section_name": "Text Manipulation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/table_compute/table_compute/1.2.4+galaxy0"
+    },
+    {
+      "name": "diff",
+      "id": "diff",
+      "description": "analyzes two files and generates an unidiff text file with information about the differences and an optional Html report",
+      "tool_shed_repository": "diff",
+      "panel_section_name": "Text Manipulation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/diff/diff/3.7+galaxy0"
+    },
+    {
+      "name": "Histogram",
+      "id": "histogram_rpy",
+      "description": "of a numeric column",
+      "tool_shed_repository": "dna_filtering",
+      "panel_section_name": "Text Manipulation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/dna_filtering/histogram_rpy/1.0.3"
+    },
+    {
+      "name": "Compute",
+      "id": "Add_a_column1",
+      "description": "an expression on every row",
+      "tool_shed_repository": "column_maker",
+      "panel_section_name": "Text Manipulation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/column_maker/Add_a_column1/1.6"
+    },
+    {
+      "name": "Concatenate datasets",
+      "id": "tp_cat",
+      "description": "tail-to-head (cat)",
+      "tool_shed_repository": "text_processing",
+      "panel_section_name": "Text Manipulation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_cat/0.1.1"
+    },
+    {
+      "name": "Replace column",
+      "id": "replace_column_with_key_value_file",
+      "description": "by values which are defined in a convert file",
+      "tool_shed_repository": "replace_column_by_key_value_file",
+      "panel_section_name": "Text Manipulation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/replace_column_by_key_value_file/replace_column_with_key_value_file/0.2"
+    },
+    {
+      "name": "Add line to file",
+      "id": "add_line_to_file",
+      "description": "writes a line of text at the begining or end of a text file.",
+      "tool_shed_repository": "add_line_to_file",
+      "panel_section_name": "Text Manipulation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/add_line_to_file/add_line_to_file/0.1.0"
+    },
+    {
+      "name": "Text reformatting",
+      "id": "tp_awk_tool",
+      "description": "with awk",
+      "tool_shed_repository": "text_processing",
+      "panel_section_name": "Text Manipulation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_awk_tool/1.1.2"
+    },
+    {
+      "name": "Add input name as column",
+      "id": "addName",
+      "description": "to an existing tabular file",
+      "tool_shed_repository": "add_input_name_as_column",
+      "panel_section_name": "Text Manipulation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/mvdbeek/add_input_name_as_column/addName/0.2.0"
+    },
+    {
+      "name": "Merge Columns",
+      "id": "mergeCols1",
+      "description": "together",
+      "tool_shed_repository": "merge_cols",
+      "panel_section_name": "Text Manipulation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/merge_cols/mergeCols1/1.0.2"
+    },
+    {
+      "name": "Switch axis coordinates",
+      "id": "imagecoordinates_flipaxis",
+      "description": "Switches the axes of an image and flips the y axis.",
+      "tool_shed_repository": "imagecoordinates_flipaxis",
+      "panel_section_name": "Imaging",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/imgteam/imagecoordinates_flipaxis/imagecoordinates_flipaxis/0.1"
+    },
+    {
+      "name": "Replace",
+      "id": "tp_find_and_replace",
+      "description": "parts of text",
+      "tool_shed_repository": "text_processing",
+      "panel_section_name": "Text Manipulation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_find_and_replace/1.1.3"
+    },
+    {
+      "name": "Sort a row",
+      "id": "tp_sort_rows",
+      "description": "according to their columns",
+      "tool_shed_repository": "text_processing",
+      "panel_section_name": "Text Manipulation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_sort_rows/1.1.0+galaxy0"
+    },
+    {
+      "name": "Column Regex Find And Replace",
+      "id": "regexColumn1",
+      "description": "",
+      "tool_shed_repository": "regex_find_replace",
+      "panel_section_name": "Text Manipulation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/regex_find_replace/regexColumn1/1.0.1"
+    },
+    {
+      "name": "Regex Find And Replace",
+      "id": "regex1",
+      "description": "",
+      "tool_shed_repository": "regex_find_replace",
+      "panel_section_name": "Text Manipulation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/regex_find_replace/regex1/1.0.1"
+    },
+    {
+      "name": "Join two files",
+      "id": "join_files_on_column_fuzzy",
+      "description": "on column allowing a small difference",
+      "tool_shed_repository": "join_files_on_column_fuzzy",
+      "panel_section_name": "Text Manipulation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/join_files_on_column_fuzzy/join_files_on_column_fuzzy/1.0.1"
+    },
+    {
+      "name": "Query Tabular",
+      "id": "query_tabular",
+      "description": "using sqlite sql",
+      "tool_shed_repository": "query_tabular",
+      "panel_section_name": "Text Manipulation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/query_tabular/query_tabular/3.3.0"
+    },
+    {
+      "name": "Join",
+      "id": "tp_easyjoin_tool",
+      "description": "two files",
+      "tool_shed_repository": "text_processing",
+      "panel_section_name": "Text Manipulation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_easyjoin_tool/1.1.2"
+    },
+    {
+      "name": "Replace Text",
+      "id": "tp_replace_in_line",
+      "description": "in entire line",
+      "tool_shed_repository": "text_processing",
+      "panel_section_name": "Text Manipulation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_replace_in_line/1.1.2"
+    },
+    {
+      "name": "Replace chromosome names",
+      "id": "replace_chromosome_names",
+      "description": "in a tabular dataset using a mapping table",
+      "tool_shed_repository": "replace_chromosome_names",
+      "panel_section_name": "Text Manipulation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/earlhaminst/replace_chromosome_names/replace_chromosome_names/0.1"
+    },
+    {
+      "name": "SQLite to tabular",
+      "id": "sqlite_to_tabular",
+      "description": "for SQL query",
+      "tool_shed_repository": "sqlite_to_tabular",
+      "panel_section_name": "Text Manipulation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/sqlite_to_tabular/sqlite_to_tabular/2.0.0"
+    },
+    {
+      "name": "Unique lines",
+      "id": "tp_uniq_tool",
+      "description": "assuming sorted input file",
+      "tool_shed_repository": "text_processing",
+      "panel_section_name": "Text Manipulation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_uniq_tool/1.1.1"
+    },
+    {
+      "name": "Filter Tabular",
+      "id": "filter_tabular",
+      "description": "",
+      "tool_shed_repository": "filter_tabular",
+      "panel_section_name": "Text Manipulation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/filter_tabular/filter_tabular/2.0.0"
+    },
+    {
+      "name": "Replace Text",
+      "id": "tp_replace_in_column",
+      "description": "in a specific column",
+      "tool_shed_repository": "text_processing",
+      "panel_section_name": "Text Manipulation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_replace_in_column/1.1.3"
+    },
+    {
+      "name": "JQ",
+      "id": "jq",
+      "description": "process JSON",
+      "tool_shed_repository": "jq",
+      "panel_section_name": "Text Manipulation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/jq/jq/1.0"
+    },
+    {
+      "name": "cast",
+      "id": "cast",
+      "description": "expand combinations of variables:values to columnar format",
+      "tool_shed_repository": "reshape2_cast",
+      "panel_section_name": "Text Manipulation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/reshape2_cast/cast/1.4.2"
+    },
+    {
+      "name": "Sort",
+      "id": "tp_sort_header_tool",
+      "description": "data in ascending or descending order",
+      "tool_shed_repository": "text_processing",
+      "panel_section_name": "Text Manipulation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_sort_header_tool/1.1.1"
+    },
+    {
+      "name": "melt",
+      "id": "melt",
+      "description": "collapse combinations of variables:values to single lines",
+      "tool_shed_repository": "reshape2_melt",
+      "panel_section_name": "Text Manipulation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/reshape2_melt/melt/1.4.2"
+    },
+    {
+      "name": "Base Coverage",
+      "id": "gops_basecoverage_1",
+      "description": "of all intervals",
+      "tool_shed_repository": "basecoverage",
+      "panel_section_name": "Operate on Genomic Intervals",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/basecoverage/gops_basecoverage_1/1.0.0"
+    },
+    {
+      "name": "Search in textfiles",
+      "id": "tp_grep_tool",
+      "description": "(grep)",
+      "tool_shed_repository": "text_processing",
+      "panel_section_name": "Text Manipulation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_grep_tool/1.1.1"
+    },
+    {
+      "name": "Text transformation",
+      "id": "tp_sed_tool",
+      "description": "with sed",
+      "tool_shed_repository": "text_processing",
+      "panel_section_name": "Text Manipulation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_sed_tool/1.1.1"
+    },
+    {
+      "name": "Unfold",
+      "id": "tp_unfold_column_tool",
+      "description": "columns from a table",
+      "tool_shed_repository": "text_processing",
+      "panel_section_name": "Text Manipulation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_unfold_column_tool/1.1.1"
+    },
+    {
+      "name": "Subtract",
+      "id": "gops_subtract_1",
+      "description": "the intervals of two datasets",
+      "tool_shed_repository": "subtract",
+      "panel_section_name": "Join, Subtract and Group",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/subtract/gops_subtract_1/1.0.0"
+    },
+    {
+      "name": "Complement",
+      "id": "gops_complement_1",
+      "description": "intervals of a dataset",
+      "tool_shed_repository": "complement",
+      "panel_section_name": "Operate on Genomic Intervals",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/complement/gops_complement_1/1.0.0"
+    },
+    {
+      "name": "Cluster",
+      "id": "gops_cluster_1",
+      "description": "the intervals of a dataset",
+      "tool_shed_repository": "cluster",
+      "panel_section_name": "Operate on Genomic Intervals",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/cluster/gops_cluster_1/1.0.0"
+    },
+    {
+      "name": "Rebase GFF3 features",
+      "id": "gff3.rebase",
+      "description": "against parent features",
+      "tool_shed_repository": "gff3_rebase",
+      "panel_section_name": "Text Manipulation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/gff3_rebase/gff3.rebase/1.2"
+    },
+    {
+      "name": "Remove columns",
+      "id": "column_remove_by_header",
+      "description": "by heading",
+      "tool_shed_repository": "column_remove_by_header",
+      "panel_section_name": "Text Manipulation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/column_remove_by_header/column_remove_by_header/0.0.1"
+    },
+    {
+      "name": "Sort Column Order",
+      "id": "column_order_header_sort",
+      "description": "by heading",
+      "tool_shed_repository": "column_order_header_sort",
+      "panel_section_name": "Text Manipulation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/column_order_header_sort/column_order_header_sort/0.0.1"
+    },
+    {
+      "name": "Unique",
+      "id": "tp_sorted_uniq",
+      "description": "occurrences of each record",
+      "tool_shed_repository": "text_processing",
+      "panel_section_name": "Text Manipulation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_sorted_uniq/1.1.0"
+    },
+    {
+      "name": "Select first",
+      "id": "tp_head_tool",
+      "description": "lines from a dataset (head)",
+      "tool_shed_repository": "text_processing",
+      "panel_section_name": "Text Manipulation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_head_tool/1.1.0"
+    },
+    {
+      "name": "Multi-Join",
+      "id": "tp_multijoin_tool",
+      "description": "(combine multiple files)",
+      "tool_shed_repository": "text_processing",
+      "panel_section_name": "Text Manipulation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_multijoin_tool/1.1.1"
+    },
+    {
+      "name": "Select last",
+      "id": "tp_tail_tool",
+      "description": "lines from a dataset (tail)",
+      "tool_shed_repository": "text_processing",
+      "panel_section_name": "Text Manipulation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_tail_tool/1.1.0"
+    },
+    {
+      "name": "Advanced Cut",
+      "id": "tp_cut_tool",
+      "description": "columns from a table (cut)",
+      "tool_shed_repository": "text_processing",
+      "panel_section_name": "Text Manipulation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_cut_tool/1.1.0"
+    },
+    {
+      "name": "Create text file",
+      "id": "tp_text_file_with_recurring_lines",
+      "description": "with recurring lines",
+      "tool_shed_repository": "text_processing",
+      "panel_section_name": "Text Manipulation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_text_file_with_recurring_lines/1.1.0"
+    },
+    {
+      "name": "tac",
+      "id": "tp_tac",
+      "description": "reverse a file (reverse cat)",
+      "tool_shed_repository": "text_processing",
+      "panel_section_name": "Text Manipulation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_tac/1.1.0"
+    },
+    {
+      "name": "Coverage",
+      "id": "gops_coverage_1",
+      "description": "of a set of intervals on second set of intervals",
+      "tool_shed_repository": "coverage",
+      "panel_section_name": "Text Manipulation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/coverage/gops_coverage_1/1.0.0"
+    },
+    {
+      "name": "Regex Replace",
+      "id": "regex_replace",
+      "description": "Regular Expression replacement using the Python re module",
+      "tool_shed_repository": "regex_replace",
+      "panel_section_name": "Text Manipulation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/kellrott/regex_replace/regex_replace/1.0.0"
+    },
+    {
+      "name": "Arithmetic Operations",
+      "id": "tables_arithmetic_operations",
+      "description": "on tables",
+      "tool_shed_repository": "tables_arithmetic_operations",
+      "panel_section_name": "Text Manipulation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/tables_arithmetic_operations/tables_arithmetic_operations/1.0.0"
+    },
+    {
+      "name": "Merge",
+      "id": "gops_merge_1",
+      "description": "the overlapping intervals of a dataset",
+      "tool_shed_repository": "merge",
+      "panel_section_name": "Text Manipulation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/merge/gops_merge_1/1.0.0"
+    },
+    {
+      "name": "Intersect",
+      "id": "gops_intersect_1",
+      "description": "the intervals of two datasets",
+      "tool_shed_repository": "intersect",
+      "panel_section_name": "Text Manipulation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/intersect/gops_intersect_1/1.0.0"
+    },
+    {
+      "name": "Fetch closest non-overlapping feature",
+      "id": "flanking_features_1",
+      "description": "for every interval",
+      "tool_shed_repository": "flanking_features",
+      "panel_section_name": "Text Manipulation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/flanking_features/flanking_features_1/4.0.1"
+    },
+    {
+      "name": "Get flanks",
+      "id": "get_flanks1",
+      "description": "returns flanking region/s for every gene",
+      "tool_shed_repository": "get_flanks",
+      "panel_section_name": "Text Manipulation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/get_flanks/get_flanks1/1.0.0"
+    },
+    {
+      "name": "Subtract Whole Dataset",
+      "id": "subtract_query1",
+      "description": "from another dataset",
+      "tool_shed_repository": "subtract_query",
+      "panel_section_name": "Text Manipulation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/subtract_query/subtract_query1/0.1"
+    },
+    {
+      "name": "Unique",
+      "id": "bg_uniq",
+      "description": "occurrences of each record",
+      "tool_shed_repository": "unique",
+      "panel_section_name": "Text Manipulation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/unique/bg_uniq/0.3"
+    },
+    {
+      "name": "Add column",
+      "id": "addValue",
+      "description": "to an existing dataset",
+      "tool_shed_repository": "add_value",
+      "panel_section_name": "Text Manipulation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/add_value/addValue/1.0.0"
+    },
+    {
+      "name": "GffCompare",
+      "id": "gffcompare",
+      "description": "compare assembled transcripts to a reference annotation",
+      "tool_shed_repository": "gffcompare",
+      "panel_section_name": "BED",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/gffcompare/gffcompare/0.11.2"
+    },
+    {
+      "name": "Filter FASTA",
+      "id": "filter_by_fasta_ids",
+      "description": "on the headers and/or the sequences",
+      "tool_shed_repository": "filter_by_fasta_ids",
+      "panel_section_name": "Filter and Sort",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/filter_by_fasta_ids/filter_by_fasta_ids/2.1"
+    },
+    {
+      "name": "Column arrange",
+      "id": "bg_column_arrange_by_header",
+      "description": "by header name",
+      "tool_shed_repository": "column_arrange_by_header",
+      "panel_section_name": "Filter and Sort",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/column_arrange_by_header/bg_column_arrange_by_header/0.2"
+    },
+    {
+      "name": "XPath",
+      "id": "xpath",
+      "description": "compute xpath expressions on XML data",
+      "tool_shed_repository": "xpath",
+      "panel_section_name": "Filter and Sort",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/xpath/xpath/1.0.0"
+    },
+    {
+      "name": "Sub-sample sequences files",
+      "id": "sample_seqs",
+      "description": "e.g. to reduce coverage",
+      "tool_shed_repository": "sample_seqs",
+      "panel_section_name": "Filter and Sort",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/peterjc/sample_seqs/sample_seqs/0.2.5"
+    },
+    {
+      "name": "Filter sequences by ID",
+      "id": "seq_filter_by_id",
+      "description": "from a tabular file",
+      "tool_shed_repository": "seq_filter_by_id",
+      "panel_section_name": "Filter and Sort",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/peterjc/seq_filter_by_id/seq_filter_by_id/0.2.7"
+    },
+    {
+      "name": "find in reference",
+      "id": "find_in_reference",
+      "description": "filter peptides that are present in proteins",
+      "tool_shed_repository": "find_in_reference",
+      "panel_section_name": "Filter and Sort",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/jjohnson/find_in_reference/find_in_reference/0.0.3"
+    },
+    {
+      "name": "Column join",
+      "id": "collection_column_join",
+      "description": "on multiple datasets",
+      "tool_shed_repository": "collection_column_join",
+      "panel_section_name": "Join, Subtract and Group",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/collection_column_join/collection_column_join/0.0.3"
+    },
+    {
+      "name": "Transpose",
+      "id": "datamash_transpose",
+      "description": "rows/columns in a tabular file",
+      "tool_shed_repository": "datamash_transpose",
+      "panel_section_name": "Join, Subtract and Group",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/datamash_transpose/datamash_transpose/1.1.0"
+    },
+    {
+      "name": "Reverse",
+      "id": "datamash_reverse",
+      "description": "columns in a tabular file",
+      "tool_shed_repository": "datamash_reverse",
+      "panel_section_name": "Join, Subtract and Group",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/datamash_reverse/datamash_reverse/1.1.0"
+    },
+    {
+      "name": "Datamash",
+      "id": "datamash_ops",
+      "description": "(operations on tabular data)",
+      "tool_shed_repository": "datamash_ops",
+      "panel_section_name": "Join, Subtract and Group",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/datamash_ops/datamash_ops/1.1.0"
+    },
+    {
+      "name": "Datamash",
+      "id": "datamash_ops",
+      "description": "(operations on tabular data)",
+      "tool_shed_repository": "datamash_ops",
+      "panel_section_name": "Join, Subtract and Group",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/datamash_ops/datamash_ops/datamash_ops/1.0.6"
+    },
+    {
+      "name": "Subtract",
+      "id": "gops_subtract_1",
+      "description": "the intervals of two datasets",
+      "tool_shed_repository": "subtract",
+      "panel_section_name": "Join, Subtract and Group",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/subtract/gops_subtract_1/1.0.0"
+    },
+    {
+      "name": "CrossMap BAM",
+      "id": "crossmap_bam",
+      "description": "Convert genome coordinates or annotation files between genome assemblies",
+      "tool_shed_repository": "crossmap_bam",
+      "panel_section_name": "Convert Formats",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/crossmap_bam/crossmap_bam/0.6.1+galaxy0"
+    },
+    {
+      "name": "Stitch Gene blocks",
+      "id": "GeneBed_Maf_Fasta2",
+      "description": "given a set of coding exon intervals",
+      "tool_shed_repository": "genebed_maf_to_fasta",
+      "panel_section_name": "Convert Formats",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/genebed_maf_to_fasta/GeneBed_Maf_Fasta2/1.0.1+galaxy0"
+    },
+    {
+      "name": "ab1 to FASTQ converter",
+      "id": "ab1_fastq_converter",
+      "description": "",
+      "tool_shed_repository": "ab1_fastq_converter",
+      "panel_section_name": "Convert Formats",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/ecology/ab1_fastq_converter/ab1_fastq_converter/1.20.0"
+    },
+    {
+      "name": "mz to sqlite",
+      "id": "mz_to_sqlite",
+      "description": "Extract mzIdentML and associated proteomics datasets into a SQLite DB",
+      "tool_shed_repository": "mz_to_sqlite",
+      "panel_section_name": "Convert Formats",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/mz_to_sqlite/mz_to_sqlite/2.1.1+galaxy0"
+    },
+    {
+      "name": "Convert",
+      "id": "biom_convert",
+      "description": "between BIOM table formats",
+      "tool_shed_repository": "biom_convert",
+      "panel_section_name": "Convert Formats",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/biom_convert/biom_convert/2.1.10+galaxy0"
+    },
+    {
+      "name": "Convert BAM",
+      "id": "bioext_bam2msa",
+      "description": "to FASTA multiple sequence alignment",
+      "tool_shed_repository": "bioext_bam2msa",
+      "panel_section_name": "Convert Formats",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/bioext_bam2msa/bioext_bam2msa/0.20.4+galaxy0"
+    },
+    {
+      "name": "samtools BAM to CRAM",
+      "id": "samtools_bam_to_cram",
+      "description": "convert BAM alignments to CRAM format",
+      "tool_shed_repository": "samtools_bam_to_cram",
+      "panel_section_name": "Convert Formats",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/samtools_bam_to_cram/samtools_bam_to_cram/1.13"
+    },
+    {
+      "name": "CrossMap region",
+      "id": "crossmap_region",
+      "description": "Convert genome coordinates or annotation files between genome assemblies",
+      "tool_shed_repository": "crossmap_region",
+      "panel_section_name": "Convert Formats",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/crossmap_region/crossmap_region/0.6.1+galaxy0"
+    },
+    {
+      "name": "idpQuery",
+      "id": "idpquery",
+      "description": "Creates text reports from idpDB files.",
+      "tool_shed_repository": "idpquery",
+      "panel_section_name": "Convert Formats",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/idpquery/idpquery/3.0.21142.0"
+    },
+    {
+      "name": "Thermo",
+      "id": "thermo_raw_file_converter",
+      "description": "RAW file converter",
+      "tool_shed_repository": "thermo_raw_file_converter",
+      "panel_section_name": "Convert Formats",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/thermo_raw_file_converter/thermo_raw_file_converter/1.3.4+galaxy0"
+    },
+    {
+      "name": "Tabular-to-FASTA",
+      "id": "tab2fasta",
+      "description": "converts tabular file to FASTA format",
+      "tool_shed_repository": "tabular_to_fasta",
+      "panel_section_name": "Convert Formats",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/tabular_to_fasta/tab2fasta/1.1.0"
+    },
+    {
+      "name": "bax2bam",
+      "id": "bax2bam",
+      "description": "converts PacBio basecall format (bax.h5) into BAM",
+      "tool_shed_repository": "bax2bam",
+      "panel_section_name": "Convert Formats",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/bax2bam/bax2bam/0.0.11+galaxy0"
+    },
+    {
+      "name": "CrossMap BED",
+      "id": "crossmap_bed",
+      "description": "Convert genome coordinates or annotation files between genome assemblies",
+      "tool_shed_repository": "crossmap_bed",
+      "panel_section_name": "Convert Formats",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/crossmap_bed/crossmap_bed/0.6.1+galaxy0"
+    },
+    {
+      "name": "CrossMap GFF",
+      "id": "crossmap_gff",
+      "description": "Convert genome coordinates or annotation files between genome assemblies",
+      "tool_shed_repository": "crossmap_gff",
+      "panel_section_name": "Convert Formats",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/crossmap_gff/crossmap_gff/0.6.1+galaxy0"
+    },
+    {
+      "name": "CrossMap VCF",
+      "id": "crossmap_vcf",
+      "description": "Convert genome coordinates or annotation files between genome assemblies",
+      "tool_shed_repository": "crossmap_vcf",
+      "panel_section_name": "Convert Formats",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/crossmap_vcf/crossmap_vcf/0.6.1+galaxy0"
+    },
+    {
+      "name": "CrossMap Wig",
+      "id": "crossmap_wig",
+      "description": "Convert genome coordinates or annotation files between genome assemblies",
+      "tool_shed_repository": "crossmap_wig",
+      "panel_section_name": "Convert Formats",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/crossmap_wig/crossmap_wig/0.6.1+galaxy0"
+    },
+    {
+      "name": "Compress file(s)",
+      "id": "compress_file",
+      "description": "",
+      "tool_shed_repository": "compress_file",
+      "panel_section_name": "Convert Formats",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/compress_file/compress_file/0.1.0"
+    },
+    {
+      "name": "FASTA-to-Tabular",
+      "id": "fasta2tab",
+      "description": "converter",
+      "tool_shed_repository": "fasta_to_tabular",
+      "panel_section_name": "Convert Formats",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/fasta_to_tabular/fasta2tab/1.1.0"
+    },
+    {
+      "name": "Tabular to FASTQ",
+      "id": "tabular_to_fastq",
+      "description": "converter",
+      "tool_shed_repository": "tabular_to_fastq",
+      "panel_section_name": "Convert Formats",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/tabular_to_fastq/tabular_to_fastq/1.0.0"
+    },
+    {
+      "name": "GFA to FASTA",
+      "id": "gfa_to_fa",
+      "description": "Convert Graphical Fragment Assembly files to FASTA format",
+      "tool_shed_repository": "gfa_to_fa",
+      "panel_section_name": "Convert Formats",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/gfa_to_fa/gfa_to_fa/0.1.2"
+    },
+    {
+      "name": "msconvert",
+      "id": "msconvert",
+      "description": "Convert and/or filter mass spectrometry files",
+      "tool_shed_repository": "msconvert",
+      "panel_section_name": "Convert Formats",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/msconvert/msconvert/3.0.20287.2"
+    },
+    {
+      "name": "Extract MAF blocks",
+      "id": "Interval2Maf1",
+      "description": "given a set of genomic intervals",
+      "tool_shed_repository": "interval2maf",
+      "panel_section_name": "Convert Formats",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/interval2maf/Interval2Maf1/1.0.1+galaxy0"
+    },
+    {
+      "name": "bed to protein map",
+      "id": "bed_to_protein_map",
+      "description": "genomic location of proteins for MVP",
+      "tool_shed_repository": "bed_to_protein_map",
+      "panel_section_name": "Convert Formats",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/bed_to_protein_map/bed_to_protein_map/0.2.0"
+    },
+    {
+      "name": "Convert gffCompare annotated GTF to BED",
+      "id": "gffcompare_to_bed",
+      "description": "for StringTie results",
+      "tool_shed_repository": "gffcompare_to_bed",
+      "panel_section_name": "Convert Formats",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/gffcompare_to_bed/gffcompare_to_bed/0.2.1"
+    },
+    {
+      "name": "Map peptides to a bed file",
+      "id": "map_peptides_to_bed",
+      "description": "for viewing in a genome browser",
+      "tool_shed_repository": "map_peptides_to_bed",
+      "panel_section_name": "Convert Formats",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/map_peptides_to_bed/map_peptides_to_bed/0.2"
+    },
+    {
+      "name": "Resize coordinate window",
+      "id": "resize_coordinate_window",
+      "description": "of GFF data",
+      "tool_shed_repository": "resize_coordinate_window",
+      "panel_section_name": "Convert Formats",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/resize_coordinate_window/resize_coordinate_window/1.0.2"
+    },
+    {
+      "name": "msms_extractor",
+      "id": "msms_extractor",
+      "description": "Extract MS/MS scans from the mzML file(s) based on PSM report",
+      "tool_shed_repository": "msms_extractor",
+      "panel_section_name": "Convert Formats",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/msms_extractor/msms_extractor/1.0.0"
+    },
+    {
+      "name": "Image Montage",
+      "id": "graphicsmagick_image_montage",
+      "description": "",
+      "tool_shed_repository": "graphicsmagick_image_montage",
+      "panel_section_name": "Convert Formats",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/graphicsmagick_image_montage/graphicsmagick_image_montage/1.3.31+galaxy1"
+    },
+    {
+      "name": "Image Converter",
+      "id": "graphicsmagick_image_convert",
+      "description": "",
+      "tool_shed_repository": "graphicsmagick_image_convert",
+      "panel_section_name": "Convert Formats",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/graphicsmagick_image_convert/graphicsmagick_image_convert/1.3.31+galaxy1"
+    },
+    {
+      "name": "Create InterMine Interchange",
+      "id": "galaxy_intermine_exchange",
+      "description": "Dataset",
+      "tool_shed_repository": "intermine_galaxy_exchange",
+      "panel_section_name": "Convert Formats",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/intermine_galaxy_exchange/galaxy_intermine_exchange/0.0.1"
+    },
+    {
+      "name": "idconvert",
+      "id": "idconvert",
+      "description": "Convert mass spectrometry identification files",
+      "tool_shed_repository": "msconvert",
+      "panel_section_name": "Convert Formats",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/msconvert/idconvert/3.0.0"
+    },
+    {
+      "name": "msconvert Subset Peak List",
+      "id": "msconvert_subset",
+      "description": "against list of scan numbers or indices.",
+      "tool_shed_repository": "msconvert",
+      "panel_section_name": "Convert Formats",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/msconvert/msconvert_subset/0.3.0"
+    },
+    {
+      "name": "idconvert",
+      "id": "idconvert",
+      "description": "Convert mass spectrometry identification files",
+      "tool_shed_repository": "idconvert",
+      "panel_section_name": "Convert Formats",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/idconvert/idconvert/3.0.0"
+    },
+    {
+      "name": "Convert GTF to BED12",
+      "id": "gtftobed12",
+      "description": "",
+      "tool_shed_repository": "gtftobed12",
+      "panel_section_name": "Convert Formats",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/gtftobed12/gtftobed12/357"
+    },
+    {
+      "name": "Convert BAM to ScIdx",
+      "id": "bam_to_scidx",
+      "description": "",
+      "tool_shed_repository": "bam_to_scidx",
+      "panel_section_name": "Convert Formats",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/bam_to_scidx/bam_to_scidx/1.0.1"
+    },
+    {
+      "name": "bigWigToBedGraph",
+      "id": "bigwig_to_bedgraph",
+      "description": "Convert from bigWig to bedGraph format",
+      "tool_shed_repository": "bigwig_to_bedgraph",
+      "panel_section_name": "Convert Formats",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/bigwig_to_bedgraph/bigwig_to_bedgraph/0.1.0"
+    },
+    {
+      "name": "Filter sequences by mapping",
+      "id": "seq_filter_by_mapping",
+      "description": "from SAM/BAM file",
+      "tool_shed_repository": "seq_filter_by_mapping",
+      "panel_section_name": "FASTA/FASTQ",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/peterjc/seq_filter_by_mapping/seq_filter_by_mapping/0.0.7"
+    },
+    {
+      "name": "FASTQ splitter",
+      "id": "fastq_paired_end_splitter",
+      "description": "on joined paired end reads",
+      "tool_shed_repository": "fastq_paired_end_splitter",
+      "panel_section_name": "FASTA/FASTQ",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/fastq_paired_end_splitter/fastq_paired_end_splitter/1.1.5+galaxy1"
+    },
+    {
+      "name": "fastp",
+      "id": "fastp",
+      "description": "- fast all-in-one preprocessing for FASTQ files",
+      "tool_shed_repository": "fastp",
+      "panel_section_name": "FASTA/FASTQ",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/fastp/fastp/0.23.2+galaxy0"
+    },
+    {
+      "name": "Clip",
+      "id": "cshl_fastx_clipper",
+      "description": "adapter sequences",
+      "tool_shed_repository": "fastx_clipper",
+      "panel_section_name": "FASTA/FASTQ",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/fastx_clipper/cshl_fastx_clipper/1.0.3+galaxy0"
+    },
+    {
+      "name": "Fasta Statistics",
+      "id": "fasta-stats",
+      "description": "display summary statistics for a FASTA file",
+      "tool_shed_repository": "fasta_stats",
+      "panel_section_name": "FASTA/FASTQ",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/fasta_stats/fasta-stats/2.0"
+    },
+    {
+      "name": "RNA-seq Rcorrector",
+      "id": "rcorrector",
+      "description": "a kmer-based error correction method for RNA-seq data",
+      "tool_shed_repository": "rcorrector",
+      "panel_section_name": "FASTA/FASTQ",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/rcorrector/rcorrector/1.0.3+galaxy1"
+    },
+    {
+      "name": "FASTQE",
+      "id": "fastqe",
+      "description": "visualize fastq files with emoji's \ud83e\uddec\ud83d\ude0e",
+      "tool_shed_repository": "fastqe",
+      "panel_section_name": "FASTA/FASTQ",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/fastqe/fastqe/0.2.6+galaxy2"
+    },
+    {
+      "name": "filtlong",
+      "id": "filtlong",
+      "description": "Filtering long reads by quality",
+      "tool_shed_repository": "filtlong",
+      "panel_section_name": "FASTA/FASTQ",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/filtlong/filtlong/0.2.1+galaxy0"
+    },
+    {
+      "name": "Trimmomatic",
+      "id": "trimmomatic",
+      "description": "flexible read trimming tool for Illumina NGS data",
+      "tool_shed_repository": "trimmomatic",
+      "panel_section_name": "FASTA/FASTQ",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/pjbriggs/trimmomatic/trimmomatic/0.38.1"
+    },
+    {
+      "name": "Select high quality segments",
+      "id": "trim_reads",
+      "description": "",
+      "tool_shed_repository": "short_reads_trim_seq",
+      "panel_section_name": "FASTA/FASTQ",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/short_reads_trim_seq/trim_reads/1.0.0"
+    },
+    {
+      "name": "Build base quality distribution",
+      "id": "quality_score_distribution",
+      "description": "",
+      "tool_shed_repository": "short_reads_figure_score",
+      "panel_section_name": "FASTA/FASTQ",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/short_reads_figure_score/quality_score_distribution/1.0.2"
+    },
+    {
+      "name": "Compute sequence length",
+      "id": "fasta_compute_length",
+      "description": "",
+      "tool_shed_repository": "fasta_compute_length",
+      "panel_section_name": "FASTA/FASTQ",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/fasta_compute_length/fasta_compute_length/1.0.3"
+    },
+    {
+      "name": "Concatenate",
+      "id": "fasta_concatenate0",
+      "description": "FASTA alignment by species",
+      "tool_shed_repository": "fasta_concatenate_by_species",
+      "panel_section_name": "FASTA/FASTQ",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/fasta_concatenate_by_species/fasta_concatenate0/0.0.1"
+    },
+    {
+      "name": "FASTQ Trimmer",
+      "id": "fastq_trimmer",
+      "description": "by column",
+      "tool_shed_repository": "fastq_trimmer",
+      "panel_section_name": "FASTA/FASTQ",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/fastq_trimmer/fastq_trimmer/1.1.5"
+    },
+    {
+      "name": "FASTQ Quality Trimmer",
+      "id": "fastq_quality_trimmer",
+      "description": "by sliding window",
+      "tool_shed_repository": "fastq_trimmer_by_quality",
+      "panel_section_name": "FASTA/FASTQ",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/fastq_trimmer_by_quality/fastq_quality_trimmer/1.1.5"
+    },
+    {
+      "name": "FASTQ to FASTA",
+      "id": "fastq_to_fasta_python",
+      "description": "converter",
+      "tool_shed_repository": "fastqtofasta",
+      "panel_section_name": "FASTA/FASTQ",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/fastqtofasta/fastq_to_fasta_python/1.1.5"
+    },
+    {
+      "name": "FASTQ Summary Statistics",
+      "id": "fastq_stats",
+      "description": "by column",
+      "tool_shed_repository": "fastq_stats",
+      "panel_section_name": "FASTA/FASTQ",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/fastq_stats/fastq_stats/1.1.5"
+    },
+    {
+      "name": "FASTQ to Tabular",
+      "id": "fastq_to_tabular",
+      "description": "converter",
+      "tool_shed_repository": "fastq_to_tabular",
+      "panel_section_name": "FASTA/FASTQ",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/fastq_to_tabular/fastq_to_tabular/1.1.5"
+    },
+    {
+      "name": "Combine FASTA and QUAL",
+      "id": "fastq_combiner",
+      "description": "into FASTQ",
+      "tool_shed_repository": "fastq_combiner",
+      "panel_section_name": "FASTA/FASTQ",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/fastq_combiner/fastq_combiner/1.1.5"
+    },
+    {
+      "name": "Filter FASTQ",
+      "id": "fastq_filter",
+      "description": "reads by quality score and length",
+      "tool_shed_repository": "fastq_filter",
+      "panel_section_name": "FASTA/FASTQ",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/fastq_filter/fastq_filter/1.1.5"
+    },
+    {
+      "name": "FASTQ Groomer",
+      "id": "fastq_groomer",
+      "description": "convert between various FASTQ quality formats",
+      "tool_shed_repository": "fastq_groomer",
+      "panel_section_name": "FASTA/FASTQ",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/fastq_groomer/fastq_groomer/1.1.5"
+    },
+    {
+      "name": "Manipulate FASTQ",
+      "id": "fastq_manipulation",
+      "description": "reads on various attributes",
+      "tool_shed_repository": "fastq_manipulation",
+      "panel_section_name": "FASTA/FASTQ",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/fastq_manipulation/fastq_manipulation/1.1.5"
+    },
+    {
+      "name": "FASTQ Masker",
+      "id": "fastq_masker_by_quality",
+      "description": "by quality score",
+      "tool_shed_repository": "fastq_masker_by_quality",
+      "panel_section_name": "FASTA/FASTQ",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/fastq_masker_by_quality/fastq_masker_by_quality/1.1.5"
+    },
+    {
+      "name": "FASTQ de-interlacer",
+      "id": "fastq_paired_end_deinterlacer",
+      "description": "on paired end reads",
+      "tool_shed_repository": "fastq_paired_end_deinterlacer",
+      "panel_section_name": "FASTA/FASTQ",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/fastq_paired_end_deinterlacer/fastq_paired_end_deinterlacer/1.1.5"
+    },
+    {
+      "name": "FASTQ interlacer",
+      "id": "fastq_paired_end_interlacer",
+      "description": "on paired end reads",
+      "tool_shed_repository": "fastq_paired_end_interlacer",
+      "panel_section_name": "FASTA/FASTQ",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/fastq_paired_end_interlacer/fastq_paired_end_interlacer/1.2.0.1+galaxy0"
+    },
+    {
+      "name": "FASTQ joiner",
+      "id": "fastq_paired_end_joiner",
+      "description": "on paired end reads",
+      "tool_shed_repository": "fastq_paired_end_joiner",
+      "panel_section_name": "FASTA/FASTQ",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/fastq_paired_end_joiner/fastq_paired_end_joiner/2.0.1.1+galaxy0"
+    },
+    {
+      "name": "Rename sequences",
+      "id": "cshl_fastx_renamer",
+      "description": "",
+      "tool_shed_repository": "fastx_renamer",
+      "panel_section_name": "FASTA/FASTQ",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/fastx_renamer/cshl_fastx_renamer/0.0.14+galaxy1"
+    },
+    {
+      "name": "Reverse-Complement",
+      "id": "cshl_fastx_reverse_complement",
+      "description": "",
+      "tool_shed_repository": "fastx_reverse_complement",
+      "panel_section_name": "FASTA/FASTQ",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/fastx_reverse_complement/cshl_fastx_reverse_complement/1.0.2+galaxy0"
+    },
+    {
+      "name": "Trim sequences",
+      "id": "cshl_fastx_trimmer",
+      "description": "",
+      "tool_shed_repository": "fastx_trimmer",
+      "panel_section_name": "FASTA/FASTQ",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/fastx_trimmer/cshl_fastx_trimmer/1.0.2+galaxy0"
+    },
+    {
+      "name": "FASTQ to FASTA",
+      "id": "cshl_fastq_to_fasta",
+      "description": "converter from FASTX-toolkit",
+      "tool_shed_repository": "fastq_to_fasta",
+      "panel_section_name": "FASTA/FASTQ",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/fastq_to_fasta/cshl_fastq_to_fasta/1.0.2"
+    },
+    {
+      "name": "Compute quality statistics",
+      "id": "cshl_fastx_quality_statistics",
+      "description": "",
+      "tool_shed_repository": "fastx_quality_statistics",
+      "panel_section_name": "FASTA/FASTQ",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/fastx_quality_statistics/cshl_fastx_quality_statistics/1.0.1"
+    },
+    {
+      "name": "Draw quality score boxplot",
+      "id": "cshl_fastq_quality_boxplot",
+      "description": "",
+      "tool_shed_repository": "fastq_quality_boxplot",
+      "panel_section_name": "FASTA/FASTQ",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/fastq_quality_boxplot/cshl_fastq_quality_boxplot/1.0.1"
+    },
+    {
+      "name": "Quality format converter",
+      "id": "cshl_fastq_quality_converter",
+      "description": "(ASCII-Numeric)",
+      "tool_shed_repository": "fastq_quality_converter",
+      "panel_section_name": "FASTA/FASTQ",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/fastq_quality_converter/cshl_fastq_quality_converter/1.0.1"
+    },
+    {
+      "name": "Filter by quality",
+      "id": "cshl_fastq_quality_filter",
+      "description": "",
+      "tool_shed_repository": "fastq_quality_filter",
+      "panel_section_name": "FASTA/FASTQ",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/fastq_quality_filter/cshl_fastq_quality_filter/1.0.2+galaxy0"
+    },
+    {
+      "name": "FASTA Width",
+      "id": "cshl_fasta_formatter",
+      "description": "formatter",
+      "tool_shed_repository": "fasta_formatter",
+      "panel_section_name": "FASTA/FASTQ",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/fasta_formatter/cshl_fasta_formatter/1.0.1"
+    },
+    {
+      "name": "RNA/DNA",
+      "id": "cshl_fasta_nucleotides_changer",
+      "description": "converter",
+      "tool_shed_repository": "fasta_nucleotide_changer",
+      "panel_section_name": "FASTA/FASTQ",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/fasta_nucleotide_changer/cshl_fasta_nucleotides_changer/1.0.2"
+    },
+    {
+      "name": "Collapse",
+      "id": "cshl_fastx_collapser",
+      "description": "sequences",
+      "tool_shed_repository": "fastx_collapser",
+      "panel_section_name": "FASTA/FASTQ",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/fastx_collapser/cshl_fastx_collapser/1.0.1"
+    },
+    {
+      "name": "Filter sequences by length",
+      "id": "fasta_filter_by_length",
+      "description": "",
+      "tool_shed_repository": "fasta_filter_by_length",
+      "panel_section_name": "FASTA/FASTQ",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/fasta_filter_by_length/fasta_filter_by_length/1.2"
+    },
+    {
+      "name": "FASTA-to-Tabular",
+      "id": "fasta2tab",
+      "description": "converter",
+      "tool_shed_repository": "fasta_to_tabular",
+      "panel_section_name": "FASTA/FASTQ",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/fasta_to_tabular/fasta2tab/1.1.1"
+    },
+    {
+      "name": "Tabular to FASTQ",
+      "id": "tabular_to_fastq",
+      "description": "converter",
+      "tool_shed_repository": "tabular_to_fastq",
+      "panel_section_name": "FASTA/FASTQ",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/tabular_to_fastq/tabular_to_fastq/1.1.5"
+    },
+    {
+      "name": "Tabular-to-FASTA",
+      "id": "tab2fasta",
+      "description": "converts tabular file to FASTA format",
+      "tool_shed_repository": "tabular_to_fasta",
+      "panel_section_name": "FASTA/FASTQ",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/tabular_to_fasta/tab2fasta/1.1.1"
+    },
+    {
+      "name": "Remove sequencing artifacts",
+      "id": "cshl_fastx_artifacts_filter",
+      "description": "",
+      "tool_shed_repository": "fastx_artifacts_filter",
+      "panel_section_name": "FASTA/FASTQ",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/fastx_artifacts_filter/cshl_fastx_artifacts_filter/1.0.1+galaxy0"
+    },
+    {
+      "name": "Exonerate",
+      "id": "exonerate",
+      "description": "pairwise sequence comparison",
+      "tool_shed_repository": "exonerate",
+      "panel_section_name": "Annotation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/exonerate/exonerate/2.4.0"
+    },
+    {
+      "name": "Sickle",
+      "id": "sickle",
+      "description": "windowed adaptive trimming of FASTQ data",
+      "tool_shed_repository": "sickle",
+      "panel_section_name": "FASTA/FASTQ",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/sickle/sickle/1.33.2"
+    },
+    {
+      "name": "FLASH",
+      "id": "flash",
+      "description": "adjust length of short reads",
+      "tool_shed_repository": "flash",
+      "panel_section_name": "FASTA/FASTQ",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/flash/flash/1.2.11.4"
+    },
+    {
+      "name": "seqtk_comp",
+      "id": "seqtk_comp",
+      "description": "get the nucleotide composition of FASTA/Q",
+      "tool_shed_repository": "seqtk",
+      "panel_section_name": "FASTA/FASTQ",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/seqtk/seqtk_comp/1.3.1"
+    },
+    {
+      "name": "seqtk_mutfa",
+      "id": "seqtk_mutfa",
+      "description": "point mutate FASTA at specified positions",
+      "tool_shed_repository": "seqtk",
+      "panel_section_name": "FASTA/FASTQ",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/seqtk/seqtk_mutfa/1.3.1"
+    },
+    {
+      "name": "seqtk_hety",
+      "id": "seqtk_hety",
+      "description": "regional heterozygosity",
+      "tool_shed_repository": "seqtk",
+      "panel_section_name": "FASTA/FASTQ",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/seqtk/seqtk_hety/1.3.1"
+    },
+    {
+      "name": "seqtk_cutN",
+      "id": "seqtk_cutN",
+      "description": "cut sequence at long N",
+      "tool_shed_repository": "seqtk",
+      "panel_section_name": "FASTA/FASTQ",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/seqtk/seqtk_cutN/1.3.1"
+    },
+    {
+      "name": "seqtk_mergefa",
+      "id": "seqtk_mergefa",
+      "description": "merge two FASTA/Q files",
+      "tool_shed_repository": "seqtk",
+      "panel_section_name": "FASTA/FASTQ",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/seqtk/seqtk_mergefa/1.3.1"
+    },
+    {
+      "name": "seqtk_trimfq",
+      "id": "seqtk_trimfq",
+      "description": "trim FASTQ using the Phred algorithm",
+      "tool_shed_repository": "seqtk",
+      "panel_section_name": "FASTA/FASTQ",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/seqtk/seqtk_trimfq/1.3.1"
+    },
+    {
+      "name": "seqtk_fqchk",
+      "id": "seqtk_fqchk",
+      "description": "fastq QC (base/quality summary)",
+      "tool_shed_repository": "seqtk",
+      "panel_section_name": "FASTA/FASTQ",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/seqtk/seqtk_fqchk/1.3.1"
+    },
+    {
+      "name": "seqtk_randbase",
+      "id": "seqtk_randbase",
+      "description": "choose a random base from hets",
+      "tool_shed_repository": "seqtk",
+      "panel_section_name": "FASTA/FASTQ",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/seqtk/seqtk_randbase/1.3.1"
+    },
+    {
+      "name": "seqtk_subseq",
+      "id": "seqtk_subseq",
+      "description": "extract subsequences from FASTA/Q files",
+      "tool_shed_repository": "seqtk",
+      "panel_section_name": "FASTA/FASTQ",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/seqtk/seqtk_subseq/1.3.1"
+    },
+    {
+      "name": "seqtk_dropse",
+      "id": "seqtk_dropse",
+      "description": "drop unpaired from interleaved Paired End FASTA/Q",
+      "tool_shed_repository": "seqtk",
+      "panel_section_name": "FASTA/FASTQ",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/seqtk/seqtk_dropse/1.3.1"
+    },
+    {
+      "name": "seqtk_mergepe",
+      "id": "seqtk_mergepe",
+      "description": "interleave two unpaired FASTA/Q files for a paired-end file",
+      "tool_shed_repository": "seqtk",
+      "panel_section_name": "FASTA/FASTQ",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/seqtk/seqtk_mergepe/1.3.1"
+    },
+    {
+      "name": "seqtk_seq",
+      "id": "seqtk_seq",
+      "description": "common transformation of FASTA/Q",
+      "tool_shed_repository": "seqtk",
+      "panel_section_name": "FASTA/FASTQ",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/seqtk/seqtk_seq/1.3.3"
+    },
+    {
+      "name": "seqtk_listhet",
+      "id": "seqtk_listhet",
+      "description": "extract the position of each het",
+      "tool_shed_repository": "seqtk",
+      "panel_section_name": "FASTA/FASTQ",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/seqtk/seqtk_listhet/1.3.1"
+    },
+    {
+      "name": "mQC",
+      "id": "mqc",
+      "description": "quality control of ribosome profiling mapping results",
+      "tool_shed_repository": "mqc",
+      "panel_section_name": "FASTA/FASTQ",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/rnateam/mqc/mqc/1.9"
+    },
+    {
+      "name": "Draw nucleotides distribution chart",
+      "id": "cshl_fastx_nucleotides_distribution",
+      "description": "",
+      "tool_shed_repository": "fastx_nucleotides_distribution",
+      "panel_section_name": "FASTA/FASTQ",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/fastx_nucleotides_distribution/cshl_fastx_nucleotides_distribution/1.0.1"
+    },
+    {
+      "name": "Barcode Splitter",
+      "id": "cshl_fastx_barcode_splitter",
+      "description": "",
+      "tool_shed_repository": "fastx_barcode_splitter",
+      "panel_section_name": "FASTA/FASTQ",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/fastx_barcode_splitter/cshl_fastx_barcode_splitter/1.0.1"
+    },
+    {
+      "name": "Get crosslinked nucleotides",
+      "id": "bctools_extract_crosslinked_nucleotides",
+      "description": "from full alignments",
+      "tool_shed_repository": "bctools_extract_crosslinked_nucleotides",
+      "panel_section_name": "FASTA/FASTQ",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/bctools_extract_crosslinked_nucleotides/bctools_extract_crosslinked_nucleotides/0.2.1"
+    },
+    {
+      "name": "Trim putative adapter sequence",
+      "id": "atactk_trim_adapters",
+      "description": "",
+      "tool_shed_repository": "atactk_trim_adapters",
+      "panel_section_name": "FASTA/FASTQ",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/rnateam/atactk_trim_adapters/atactk_trim_adapters/0.1.6"
+    },
+    {
+      "name": "Create binary barcodes",
+      "id": "bctools_convert_to_binary_barcode",
+      "description": "from regular barcodes.",
+      "tool_shed_repository": "bctools_convert_to_binary_barcode",
+      "panel_section_name": "FASTA/FASTQ",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/bctools_convert_to_binary_barcode/bctools_convert_to_binary_barcode/0.2.2"
+    },
+    {
+      "name": "Extract barcodes",
+      "id": "bctools_extract_barcodes",
+      "description": "according to pattern",
+      "tool_shed_repository": "bctools_extract_barcodes",
+      "panel_section_name": "FASTA/FASTQ",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/bctools_extract_barcodes/bctools_extract_barcodes/0.2.2"
+    },
+    {
+      "name": "Extract alignment ends",
+      "id": "bctools_extract_alignment_ends",
+      "description": "from SAM or BAM",
+      "tool_shed_repository": "bctools_extract_alignment_ends",
+      "panel_section_name": "FASTA/FASTQ",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/bctools_extract_alignment_ends/bctools_extract_alignment_ends/0.2.2"
+    },
+    {
+      "name": "Merge PCR duplicates",
+      "id": "bctools_merge_pcr_duplicates",
+      "description": "according to UMIs",
+      "tool_shed_repository": "bctools_merge_pcr_duplicates",
+      "panel_section_name": "FASTA/FASTQ",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/bctools_merge_pcr_duplicates/bctools_merge_pcr_duplicates/0.2.2"
+    },
+    {
+      "name": "Remove spurious",
+      "id": "bctools_remove_spurious_events",
+      "description": "crosslinking events",
+      "tool_shed_repository": "bctools_remove_spurious_events",
+      "panel_section_name": "FASTA/FASTQ",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/bctools_remove_spurious_events/bctools_remove_spurious_events/0.2.2"
+    },
+    {
+      "name": "Remove 3'-end nts",
+      "id": "bctools_remove_tail",
+      "description": "from FASTQ",
+      "tool_shed_repository": "bctools_remove_tail",
+      "panel_section_name": "FASTA/FASTQ",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/bctools_remove_tail/bctools_remove_tail/0.2.2"
+    },
+    {
+      "name": "Je-Clip",
+      "id": "je_clip",
+      "description": "clips Unique Molecular Identifiers (UMIs) from fastq files",
+      "tool_shed_repository": "je_clip",
+      "panel_section_name": "FASTA/FASTQ",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/gbcs-embl-heidelberg/je_clip/je_clip/1.2.1"
+    },
+    {
+      "name": "Je-Demultiplex",
+      "id": "je_demultiplex",
+      "description": "demultiplexes fastq files",
+      "tool_shed_repository": "je_demultiplex",
+      "panel_section_name": "FASTA/FASTQ",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/gbcs-embl-heidelberg/je_demultiplex/je_demultiplex/1.2.1"
+    },
+    {
+      "name": "Je-MarkDuplicates",
+      "id": "je_markdupes",
+      "description": "to filter BAM files for read duplicates taking UMIs into account",
+      "tool_shed_repository": "je_markdupes",
+      "panel_section_name": "FASTA/FASTQ",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/gbcs-embl-heidelberg/je_markdupes/je_markdupes/1.2.1"
+    },
+    {
+      "name": "Je-Demultiplex-Illu",
+      "id": "je_demultiplex_illu",
+      "description": "demultiplexes fastq files using Illumina Index file",
+      "tool_shed_repository": "je_demultiplex_illu",
+      "panel_section_name": "FASTA/FASTQ",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/gbcs-embl-heidelberg/je_demultiplex_illu/je_demultiplex_illu/1.2.1"
+    },
+    {
+      "name": "FASTA Merge Files and Filter Unique Sequences",
+      "id": "fasta_merge_files_and_filter_unique_sequences",
+      "description": "Concatenate FASTA database files together",
+      "tool_shed_repository": "fasta_merge_files_and_filter_unique_sequences",
+      "panel_section_name": "FASTA/FASTQ",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/fasta_merge_files_and_filter_unique_sequences/fasta_merge_files_and_filter_unique_sequences/1.2.0"
+    },
+    {
+      "name": "Thread nucleotides onto a protein alignment (back-translation)",
+      "id": "align_back_trans",
+      "description": "Gives a codon aware alignment",
+      "tool_shed_repository": "align_back_trans",
+      "panel_section_name": "FASTA/FASTQ",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/peterjc/align_back_trans/align_back_trans/0.0.10"
+    },
+    {
+      "name": "lighter",
+      "id": "lighter",
+      "description": "can correct the reads containing sequence errors",
+      "tool_shed_repository": "lighter",
+      "panel_section_name": "FASTA/FASTQ",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/lighter/lighter/1.0"
+    },
+    {
+      "name": "fastq-join",
+      "id": "fastq_join",
+      "description": "- Joins two paired-end reads on the overlapping ends",
+      "tool_shed_repository": "fastq_join",
+      "panel_section_name": "FASTA/FASTQ",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/lparsons/fastq_join/fastq_join/1.1.2-806"
+    },
+    {
+      "name": "Split Fasta",
+      "id": "rbc_splitfasta",
+      "description": "files into a collection",
+      "tool_shed_repository": "splitfasta",
+      "panel_section_name": "FASTA/FASTQ",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/rnateam/splitfasta/rbc_splitfasta/0.2.0"
+    },
+    {
+      "name": "FASTQ info",
+      "id": "fastq_info",
+      "description": "validates single or paired fastq files",
+      "tool_shed_repository": "fastq_info",
+      "panel_section_name": "Quality Control",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/fastq_info/fastq_info/0.25.1+Galaxy0"
+    },
+    {
+      "name": "QualiMap Counts QC",
+      "id": "qualimap_counts",
+      "description": "",
+      "tool_shed_repository": "qualimap_counts",
+      "panel_section_name": "RNA Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/qualimap_counts/qualimap_counts/2.2.2c"
+    },
+    {
+      "name": "Samtools coverage",
+      "id": "samtools_coverage",
+      "description": "computes the depth at each position or region",
+      "tool_shed_repository": "samtools_coverage",
+      "panel_section_name": "SAM/BAM",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/samtools_coverage/samtools_coverage/1.13"
+    },
+    {
+      "name": "Convert, Merge, Randomize",
+      "id": "bamtools",
+      "description": "BAM datasets and perform other transformations",
+      "tool_shed_repository": "bamtools",
+      "panel_section_name": "SAM/BAM",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/bamtools/bamtools/2.5.1+galaxy0"
+    },
+    {
+      "name": "Filter",
+      "id": "bamFilter",
+      "description": "BAM datasets on a variety of attributes",
+      "tool_shed_repository": "bamtools_filter",
+      "panel_section_name": "SAM/BAM",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/bamtools_filter/bamFilter/2.5.1+galaxy0"
+    },
+    {
+      "name": "Split BAM by Paired/Single End",
+      "id": "bamtools_split_paired",
+      "description": "",
+      "tool_shed_repository": "bamtools_split_paired",
+      "panel_section_name": "SAM/BAM",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/bamtools_split_paired/bamtools_split_paired/2.5.1+galaxy0"
+    },
+    {
+      "name": "Split BAM by Reference",
+      "id": "bamtools_split_ref",
+      "description": "into dataset list collection",
+      "tool_shed_repository": "bamtools_split_ref",
+      "panel_section_name": "SAM/BAM",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/bamtools_split_ref/bamtools_split_ref/2.5.1+galaxy0"
+    },
+    {
+      "name": "Split BAM by Mapped",
+      "id": "bamtools_split_mapped",
+      "description": "",
+      "tool_shed_repository": "bamtools_split_mapped",
+      "panel_section_name": "SAM/BAM",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/bamtools_split_mapped/bamtools_split_mapped/2.5.1+galaxy0"
+    },
+    {
+      "name": "Split BAM by Tag",
+      "id": "bamtools_split_tag",
+      "description": "into dataset list collection",
+      "tool_shed_repository": "bamtools_split_tag",
+      "panel_section_name": "SAM/BAM",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/bamtools_split_tag/bamtools_split_tag/2.5.1+galaxy0"
+    },
+    {
+      "name": "Samtools phase",
+      "id": "samtools_phase",
+      "description": "call and phase heterozygous SNPs",
+      "tool_shed_repository": "samtools_phase",
+      "panel_section_name": "SAM/BAM",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/samtools_phase/samtools_phase/2.0.2"
+    },
+    {
+      "name": "Samtools fastx",
+      "id": "samtools_fastx",
+      "description": "extract FASTA or FASTQ from alignment files",
+      "tool_shed_repository": "samtools_fastx",
+      "panel_section_name": "SAM/BAM",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/samtools_fastx/samtools_fastx/1.13"
+    },
+    {
+      "name": "Samtools view",
+      "id": "samtools_view",
+      "description": "- reformat, filter, or subsample SAM, BAM or CRAM",
+      "tool_shed_repository": "samtools_view",
+      "panel_section_name": "SAM/BAM",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/samtools_view/samtools_view/1.13+galaxy2"
+    },
+    {
+      "name": "Samtools stats",
+      "id": "samtools_stats",
+      "description": "generate statistics for BAM dataset",
+      "tool_shed_repository": "samtools_stats",
+      "panel_section_name": "SAM/BAM",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/samtools_stats/samtools_stats/2.0.3"
+    },
+    {
+      "name": "Samtools split",
+      "id": "samtools_split",
+      "description": "BAM dataset on readgroups",
+      "tool_shed_repository": "samtools_split",
+      "panel_section_name": "SAM/BAM",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/samtools_split/samtools_split/1.13"
+    },
+    {
+      "name": "Samtools flagstat",
+      "id": "samtools_flagstat",
+      "description": "tabulate descriptive stats for BAM datset",
+      "tool_shed_repository": "samtools_flagstat",
+      "panel_section_name": "SAM/BAM",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/samtools_flagstat/samtools_flagstat/2.0.4"
+    },
+    {
+      "name": "Samtools markdup",
+      "id": "samtools_markdup",
+      "description": "marks duplicate alignments",
+      "tool_shed_repository": "samtools_markdup",
+      "panel_section_name": "SAM/BAM",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/samtools_markdup/samtools_markdup/1.13"
+    },
+    {
+      "name": "Slice",
+      "id": "samtools_slice_bam",
+      "description": "BAM by genomic regions",
+      "tool_shed_repository": "samtools_slice_bam",
+      "panel_section_name": "SAM/BAM",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/samtools_slice_bam/samtools_slice_bam/2.0.2"
+    },
+    {
+      "name": "Samtools idxstats",
+      "id": "samtools_idxstats",
+      "description": "reports stats of the BAM index file",
+      "tool_shed_repository": "samtools_idxstats",
+      "panel_section_name": "SAM/BAM",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/samtools_idxstats/samtools_idxstats/2.0.4"
+    },
+    {
+      "name": "Samtools sort",
+      "id": "samtools_sort",
+      "description": "order of storing aligned sequences",
+      "tool_shed_repository": "samtools_sort",
+      "panel_section_name": "SAM/BAM",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/samtools_sort/samtools_sort/2.0.4"
+    },
+    {
+      "name": "Samtools bedcov",
+      "id": "samtools_bedcov",
+      "description": "calculate read depth for a set of genomic intervals",
+      "tool_shed_repository": "samtools_bedcov",
+      "panel_section_name": "SAM/BAM",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/samtools_bedcov/samtools_bedcov/2.0.3"
+    },
+    {
+      "name": "BamUtil diff",
+      "id": "bamutil_diff",
+      "description": "two coordinate sorted SAM/BAM files",
+      "tool_shed_repository": "bamutil_diff",
+      "panel_section_name": "SAM/BAM",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/bamutil_diff/bamutil_diff/1.0.15+galaxy1"
+    },
+    {
+      "name": "Pileup-to-Interval",
+      "id": "pileup_interval",
+      "description": "condenses pileup format into ranges of bases",
+      "tool_shed_repository": "pileup_interval",
+      "panel_section_name": "SAM/BAM",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/pileup_interval/pileup_interval/1.0.3"
+    },
+    {
+      "name": "Samtools reheader",
+      "id": "samtools_reheader",
+      "description": "copy SAM/BAM header between datasets",
+      "tool_shed_repository": "samtools_reheader",
+      "panel_section_name": "SAM/BAM",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/samtools_reheader/samtools_reheader/2.0.2"
+    },
+    {
+      "name": "QualiMap BamQC",
+      "id": "qualimap_bamqc",
+      "description": "",
+      "tool_shed_repository": "qualimap_bamqc",
+      "panel_section_name": "SAM/BAM",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/qualimap_bamqc/qualimap_bamqc/2.2.2c+galaxy1"
+    },
+    {
+      "name": "Convert SAM",
+      "id": "sam2interval",
+      "description": "to interval",
+      "tool_shed_repository": "sam2interval",
+      "panel_section_name": "SAM/BAM",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/sam2interval/sam2interval/1.0.2"
+    },
+    {
+      "name": "Generate pileup",
+      "id": "sam_pileup",
+      "description": "from BAM dataset",
+      "tool_shed_repository": "sam_pileup",
+      "panel_section_name": "SAM/BAM",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/sam_pileup/sam_pileup/1.1.3"
+    },
+    {
+      "name": "QualiMap Multi-Sample BamQC",
+      "id": "qualimap_multi_bamqc",
+      "description": "",
+      "tool_shed_repository": "qualimap_multi_bamqc",
+      "panel_section_name": "SAM/BAM",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/qualimap_multi_bamqc/qualimap_multi_bamqc/2.2.2c"
+    },
+    {
+      "name": "Split",
+      "id": "bamtools_split",
+      "description": "BAM datasets on variety of attributes",
+      "tool_shed_repository": "bamtools_split",
+      "panel_section_name": "SAM/BAM",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/bamtools_split/bamtools_split/2.5.1+galaxy0"
+    },
+    {
+      "name": "Tag pileup frequency",
+      "id": "tag_pileup_frequency",
+      "description": "",
+      "tool_shed_repository": "tag_pileup_frequency",
+      "panel_section_name": "SAM/BAM",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/tag_pileup_frequency/tag_pileup_frequency/1.0.2"
+    },
+    {
+      "name": "Samtools mpileup",
+      "id": "samtools_mpileup",
+      "description": "multi-way pileup of variants",
+      "tool_shed_repository": "samtools_mpileup",
+      "panel_section_name": "SAM/BAM",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/samtools_mpileup/samtools_mpileup/2.1.6"
+    },
+    {
+      "name": "Samtools calmd",
+      "id": "samtools_calmd",
+      "description": "recalculate MD/NM tags",
+      "tool_shed_repository": "samtools_calmd",
+      "panel_section_name": "SAM/BAM",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/samtools_calmd/samtools_calmd/2.0.3"
+    },
+    {
+      "name": "Samtools merge",
+      "id": "samtools_merge",
+      "description": "merge multiple sorted alignment files",
+      "tool_shed_repository": "samtools_merge",
+      "panel_section_name": "SAM/BAM",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/samtools_merge/samtools_merge/1.13"
+    },
+    {
+      "name": "Samtools depth",
+      "id": "samtools_depth",
+      "description": "compute the depth at each position or region",
+      "tool_shed_repository": "samtools_depth",
+      "panel_section_name": "SAM/BAM",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/samtools_depth/samtools_depth/1.13"
+    },
+    {
+      "name": "Samtools fixmate",
+      "id": "samtools_fixmate",
+      "description": "fill mate coordinates, ISIZE and mate related flags",
+      "tool_shed_repository": "samtools_fixmate",
+      "panel_section_name": "SAM/BAM",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/samtools_fixmate/samtools_fixmate/1.13"
+    },
+    {
+      "name": "Filter SAM or BAM, output SAM or BAM",
+      "id": "samtool_filter2",
+      "description": "files on FLAG MAPQ RG LN or by region",
+      "tool_shed_repository": "samtool_filter2",
+      "panel_section_name": "SAM/BAM",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/samtool_filter2/samtool_filter2/1.8+galaxy1"
+    },
+    {
+      "name": "BAM filter",
+      "id": "ngsutils_bam_filter",
+      "description": "Removes reads from a BAM file based on criteria",
+      "tool_shed_repository": "ngsutils_bam_filter",
+      "panel_section_name": "SAM/BAM",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/ngsutils_bam_filter/ngsutils_bam_filter/0.5.9"
+    },
+    {
+      "name": "RmDup",
+      "id": "samtools_rmdup",
+      "description": "remove PCR duplicates",
+      "tool_shed_repository": "samtools_rmdup",
+      "panel_section_name": "SAM/BAM",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/samtools_rmdup/samtools_rmdup/2.0.1"
+    },
+    {
+      "name": "Merge BAM Files",
+      "id": "sam_merge2",
+      "description": "merges BAM files together",
+      "tool_shed_repository": "sam_merge",
+      "panel_section_name": "SAM/BAM",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/sam_merge/sam_merge2/1.2.0"
+    },
+    {
+      "name": "BamHash",
+      "id": "bamhash",
+      "description": "Hash BAM and FASTQ files to verify data integrity",
+      "tool_shed_repository": "bamhash",
+      "panel_section_name": "SAM/BAM",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/bamhash/bamhash/1.1"
+    },
+    {
+      "name": "bedtools AnnotateBed",
+      "id": "bedtools_annotatebed",
+      "description": "annotate coverage of features from multiple files",
+      "tool_shed_repository": "bedtools",
+      "panel_section_name": "BED",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/bedtools/bedtools_annotatebed/2.30.0"
+    },
+    {
+      "name": "bedtools BED12 to BED6",
+      "id": "bedtools_bed12tobed6",
+      "description": "converter",
+      "tool_shed_repository": "bedtools",
+      "panel_section_name": "BED",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/bedtools/bedtools_bed12tobed6/2.30.0"
+    },
+    {
+      "name": "bedtools BED to BAM",
+      "id": "bedtools_bedtobam",
+      "description": "converter",
+      "tool_shed_repository": "bedtools",
+      "panel_section_name": "BED",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/bedtools/bedtools_bedtobam/2.30.0"
+    },
+    {
+      "name": "bedtools BED to IGV",
+      "id": "bedtools_bedtoigv",
+      "description": "create batch script for taking IGV screenshots",
+      "tool_shed_repository": "bedtools",
+      "panel_section_name": "BED",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/bedtools/bedtools_bedtoigv/2.30.0"
+    },
+    {
+      "name": "bedtools BEDPE to BAM",
+      "id": "bedtools_bedpetobam",
+      "description": "converter",
+      "tool_shed_repository": "bedtools",
+      "panel_section_name": "BED",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/bedtools/bedtools_bedpetobam/2.30.0"
+    },
+    {
+      "name": "bedtools ClosestBed",
+      "id": "bedtools_closestbed",
+      "description": "find the closest, potentially non-overlapping interval",
+      "tool_shed_repository": "bedtools",
+      "panel_section_name": "BED",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/bedtools/bedtools_closestbed/2.30.0"
+    },
+    {
+      "name": "bedtools ClusterBed",
+      "id": "bedtools_clusterbed",
+      "description": "cluster overlapping/nearby intervals",
+      "tool_shed_repository": "bedtools",
+      "panel_section_name": "BED",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/bedtools/bedtools_clusterbed/2.30.0"
+    },
+    {
+      "name": "bedtools ComplementBed",
+      "id": "bedtools_complementbed",
+      "description": "Extract intervals not represented by an interval file",
+      "tool_shed_repository": "bedtools",
+      "panel_section_name": "BED",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/bedtools/bedtools_complementbed/2.30.0"
+    },
+    {
+      "name": "bedtools Compute both the depth and breadth of coverage",
+      "id": "bedtools_coveragebed",
+      "description": "of features in file B on the features in file A (bedtools coverage)",
+      "tool_shed_repository": "bedtools",
+      "panel_section_name": "BED",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/bedtools/bedtools_coveragebed/2.30.0"
+    },
+    {
+      "name": "bedtools ExpandBed",
+      "id": "bedtools_expandbed",
+      "description": "replicate lines based on lists of values in columns",
+      "tool_shed_repository": "bedtools",
+      "panel_section_name": "BED",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/bedtools/bedtools_expandbed/2.30.0"
+    },
+    {
+      "name": "bedtools FisherBed",
+      "id": "bedtools_fisher",
+      "description": "calculate Fisher statistic between two feature files",
+      "tool_shed_repository": "bedtools",
+      "panel_section_name": "BED",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/bedtools/bedtools_fisher/2.30.0"
+    },
+    {
+      "name": "bedtools FlankBed",
+      "id": "bedtools_flankbed",
+      "description": "create new intervals from the flanks of existing intervals",
+      "tool_shed_repository": "bedtools",
+      "panel_section_name": "BED",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/bedtools/bedtools_flankbed/2.30.0"
+    },
+    {
+      "name": "bedtools Genome Coverage",
+      "id": "bedtools_genomecoveragebed",
+      "description": "compute the coverage over an entire genome",
+      "tool_shed_repository": "bedtools",
+      "panel_section_name": "BED",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/bedtools/bedtools_genomecoveragebed/2.30.0"
+    },
+    {
+      "name": "bedtools GetFastaBed",
+      "id": "bedtools_getfastabed",
+      "description": "use intervals to extract sequences from a FASTA file",
+      "tool_shed_repository": "bedtools",
+      "panel_section_name": "BED",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/bedtools/bedtools_getfastabed/2.30.0"
+    },
+    {
+      "name": "bedtools GroupByBed",
+      "id": "bedtools_groupbybed",
+      "description": "group by common cols and summarize other cols",
+      "tool_shed_repository": "bedtools",
+      "panel_section_name": "BED",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/bedtools/bedtools_groupbybed/2.30.0"
+    },
+    {
+      "name": "bedtools Intersect intervals",
+      "id": "bedtools_intersectbed",
+      "description": "find overlapping intervals in various ways",
+      "tool_shed_repository": "bedtools",
+      "panel_section_name": "BED",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/bedtools/bedtools_intersectbed/2.30.0"
+    },
+    {
+      "name": "bedtools JaccardBed",
+      "id": "bedtools_jaccard",
+      "description": "calculate the distribution of relative distances between two files",
+      "tool_shed_repository": "bedtools",
+      "panel_section_name": "BED",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/bedtools/bedtools_jaccard/2.30.0"
+    },
+    {
+      "name": "bedtools LinksBed",
+      "id": "bedtools_links",
+      "description": "create a HTML page of links to UCSC locations",
+      "tool_shed_repository": "bedtools",
+      "panel_section_name": "BED",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/bedtools/bedtools_links/2.30.0"
+    },
+    {
+      "name": "bedtools MakeWindowsBed",
+      "id": "bedtools_makewindowsbed",
+      "description": "make interval windows across a genome",
+      "tool_shed_repository": "bedtools",
+      "panel_section_name": "BED",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/bedtools/bedtools_makewindowsbed/2.30.0"
+    },
+    {
+      "name": "bedtools MapBed",
+      "id": "bedtools_map",
+      "description": "apply a function to a column for each overlapping interval",
+      "tool_shed_repository": "bedtools",
+      "panel_section_name": "BED",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/bedtools/bedtools_map/2.30.0.2"
+    },
+    {
+      "name": "bedtools MaskFastaBed",
+      "id": "bedtools_maskfastabed",
+      "description": "use intervals to mask sequences from a FASTA file",
+      "tool_shed_repository": "bedtools",
+      "panel_section_name": "BED",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/bedtools/bedtools_maskfastabed/2.30.0"
+    },
+    {
+      "name": "bedtools MergeBED",
+      "id": "bedtools_mergebed",
+      "description": "combine overlapping/nearby intervals into a single interval",
+      "tool_shed_repository": "bedtools",
+      "panel_section_name": "BED",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/bedtools/bedtools_mergebed/2.30.0"
+    },
+    {
+      "name": "bedtools MultiCovBed",
+      "id": "bedtools_multicovtbed",
+      "description": "counts coverage from multiple BAMs at specific intervals",
+      "tool_shed_repository": "bedtools",
+      "panel_section_name": "BED",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/bedtools/bedtools_multicovtbed/2.30.0"
+    },
+    {
+      "name": "bedtools Multiple Intersect",
+      "id": "bedtools_multiintersectbed",
+      "description": "identifies common intervals among multiple interval files",
+      "tool_shed_repository": "bedtools",
+      "panel_section_name": "BED",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/bedtools/bedtools_multiintersectbed/2.30.0"
+    },
+    {
+      "name": "bedtools NucBed",
+      "id": "bedtools_nucbed",
+      "description": "profile the nucleotide content of intervals in a FASTA file",
+      "tool_shed_repository": "bedtools",
+      "panel_section_name": "BED",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/bedtools/bedtools_nucbed/2.30.0"
+    },
+    {
+      "name": "bedtools OverlapBed",
+      "id": "bedtools_overlapbed",
+      "description": "computes the amount of overlap from two intervals",
+      "tool_shed_repository": "bedtools",
+      "panel_section_name": "BED",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/bedtools/bedtools_overlapbed/2.30.0"
+    },
+    {
+      "name": "bedtools RandomBed",
+      "id": "bedtools_randombed",
+      "description": "generate random intervals in a genome",
+      "tool_shed_repository": "bedtools",
+      "panel_section_name": "BED",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/bedtools/bedtools_randombed/2.30.0"
+    },
+    {
+      "name": "bedtools ReldistBed",
+      "id": "bedtools_reldistbed",
+      "description": "calculate the distribution of relative distances",
+      "tool_shed_repository": "bedtools",
+      "panel_section_name": "BED",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/bedtools/bedtools_reldistbed/2.30.0"
+    },
+    {
+      "name": "bedtools ShuffleBed",
+      "id": "bedtools_shufflebed",
+      "description": "randomly redistrubute intervals in a genome",
+      "tool_shed_repository": "bedtools",
+      "panel_section_name": "BED",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/bedtools/bedtools_shufflebed/2.30.0"
+    },
+    {
+      "name": "bedtools SlopBed",
+      "id": "bedtools_slopbed",
+      "description": "adjust the size of intervals",
+      "tool_shed_repository": "bedtools",
+      "panel_section_name": "BED",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/bedtools/bedtools_slopbed/2.30.0"
+    },
+    {
+      "name": "bedtools SortBED",
+      "id": "bedtools_sortbed",
+      "description": "order the intervals",
+      "tool_shed_repository": "bedtools",
+      "panel_section_name": "BED",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/bedtools/bedtools_sortbed/2.30.0"
+    },
+    {
+      "name": "bedtools SpacingBed",
+      "id": "bedtools_spacingbed",
+      "description": "reports the distances between features",
+      "tool_shed_repository": "bedtools",
+      "panel_section_name": "BED",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/bedtools/bedtools_spacingbed/2.30.0"
+    },
+    {
+      "name": "bedtools SubtractBed",
+      "id": "bedtools_subtractbed",
+      "description": "remove intervals based on overlaps",
+      "tool_shed_repository": "bedtools",
+      "panel_section_name": "BED",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/bedtools/bedtools_subtractbed/2.30.0"
+    },
+    {
+      "name": "bedtools TagBed",
+      "id": "bedtools_tagbed",
+      "description": "tag BAM alignments based on overlaps with interval files",
+      "tool_shed_repository": "bedtools",
+      "panel_section_name": "BED",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/bedtools/bedtools_tagbed/2.30.0"
+    },
+    {
+      "name": "bedtools Merge BedGraph files",
+      "id": "bedtools_unionbedgraph",
+      "description": "combines coverage intervals from multiple BEDGRAPH files",
+      "tool_shed_repository": "bedtools",
+      "panel_section_name": "BED",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/bedtools/bedtools_unionbedgraph/2.30.0"
+    },
+    {
+      "name": "bedtools WindowBed",
+      "id": "bedtools_windowbed",
+      "description": "find overlapping intervals within a window around an interval",
+      "tool_shed_repository": "bedtools",
+      "panel_section_name": "BED",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/bedtools/bedtools_windowbed/2.30.0"
+    },
+    {
+      "name": "GffCompare",
+      "id": "gffcompare",
+      "description": "compare assembled transcripts to a reference annotation",
+      "tool_shed_repository": "gffcompare",
+      "panel_section_name": "BED",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/gffcompare/gffcompare/0.11.2"
+    },
+    {
+      "name": "bedtools Convert from BAM to FastQ",
+      "id": "bedtools_bamtofastq",
+      "description": "",
+      "tool_shed_repository": "bedtools",
+      "panel_section_name": "BED",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/bedtools/bedtools_bamtofastq/2.27.1"
+    },
+    {
+      "name": "Create a BedGraph of genome coverage",
+      "id": "bedtools_genomecoveragebed_bedgraph",
+      "description": "",
+      "tool_shed_repository": "bedtools",
+      "panel_section_name": "BED",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/bedtools/bedtools_genomecoveragebed_bedgraph/2.19.0"
+    },
+    {
+      "name": "Merge BedGraph files",
+      "id": "bedtools_mergebedgraph",
+      "description": "",
+      "tool_shed_repository": "bedtools",
+      "panel_section_name": "BED",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/bedtools/bedtools_mergebedgraph/2.19.0"
+    },
+    {
+      "name": "Create a histogram of genome coverage",
+      "id": "bedtools_genomecoveragebed_histogram",
+      "description": "",
+      "tool_shed_repository": "bedtools",
+      "panel_section_name": "BED",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/bedtools/bedtools_genomecoveragebed_histogram/2.19.0"
+    },
+    {
+      "name": "VarScan somatic",
+      "id": "varscan_somatic",
+      "description": "Call germline/somatic and LOH variants from tumor-normal sample pairs",
+      "tool_shed_repository": "varscan_somatic",
+      "panel_section_name": "Variant Calling",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/varscan_somatic/varscan_somatic/2.4.3.6"
+    },
+    {
+      "name": "VarScan copynumber",
+      "id": "varscan_copynumber",
+      "description": "Determine relative tumor copy number from tumor-normal pileups",
+      "tool_shed_repository": "varscan_copynumber",
+      "panel_section_name": "Variant Calling",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/varscan_copynumber/varscan_copynumber/2.4.3.2"
+    },
+    {
+      "name": "bcftools csq",
+      "id": "bcftools_csq",
+      "description": "Haplotype aware consequence predictor",
+      "tool_shed_repository": "bcftools_csq",
+      "panel_section_name": "Variant Calling",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/bcftools_csq/bcftools_csq/1.9+galaxy1"
+    },
+    {
+      "name": "bcftools cnv",
+      "id": "bcftools_cnv",
+      "description": "Call copy number variation from VCF B-allele frequency (BAF) and Log R Ratio intensity (LRR) values",
+      "tool_shed_repository": "bcftools_cnv",
+      "panel_section_name": "Variant Calling",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/bcftools_cnv/bcftools_cnv/1.9+galaxy1"
+    },
+    {
+      "name": "bcftools consensus",
+      "id": "bcftools_consensus",
+      "description": "Create consensus sequence by applying VCF variants to a reference fasta file",
+      "tool_shed_repository": "bcftools_consensus",
+      "panel_section_name": "Variant Calling",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/bcftools_consensus/bcftools_consensus/1.9+galaxy1"
+    },
+    {
+      "name": "bcftools norm",
+      "id": "bcftools_norm",
+      "description": "Left-align and normalize indels; check if REF alleles match the reference; split multiallelic sites into multiple rows; recover multiallelics from multiple rows",
+      "tool_shed_repository": "bcftools_norm",
+      "panel_section_name": "VCF/BCF",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/bcftools_norm/bcftools_norm/1.9+galaxy1"
+    },
+    {
+      "name": "bcftools call",
+      "id": "bcftools_call",
+      "description": "SNP/indel variant calling from VCF/BCF",
+      "tool_shed_repository": "bcftools_call",
+      "panel_section_name": "Variant Calling",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/bcftools_call/bcftools_call/1.9+galaxy1"
+    },
+    {
+      "name": "VCFcheck:",
+      "id": "vcfcheck",
+      "description": "Verify that the reference allele matches the reference genome",
+      "tool_shed_repository": "vcfcheck",
+      "panel_section_name": "Variant Calling",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/vcfcheck/vcfcheck/1.0.0_rc3+galaxy0"
+    },
+    {
+      "name": "VCFfilter:",
+      "id": "vcffilter2",
+      "description": "filter VCF data in a variety of attributes",
+      "tool_shed_repository": "vcffilter",
+      "panel_section_name": "VCF/BCF",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/vcffilter/vcffilter2/1.0.0_rc1+galaxy2"
+    },
+    {
+      "name": "VCFselectsamples:",
+      "id": "vcfselectsamples",
+      "description": "Select samples from a VCF dataset",
+      "tool_shed_repository": "vcfselectsamples",
+      "panel_section_name": "VCF/BCF",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/vcfselectsamples/vcfselectsamples/1.0.0_rc1+galaxy0"
+    },
+    {
+      "name": "VCFannotateGenotypes:",
+      "id": "vcfannotategenotypes",
+      "description": "Annotate genotypes in a VCF dataset using genotypes from another VCF dataset",
+      "tool_shed_repository": "vcfannotategenotypes",
+      "panel_section_name": "VCF/BCF",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/vcfannotategenotypes/vcfannotategenotypes/1.0.0_rc1+galaxy0"
+    },
+    {
+      "name": "VCFflatten:",
+      "id": "vcfflatten2",
+      "description": "Removes multi-allelic sites by picking the most common alternate",
+      "tool_shed_repository": "vcfflatten",
+      "panel_section_name": "VCF/BCF",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/vcfflatten/vcfflatten2/1.0.0_rc1+galaxy0"
+    },
+    {
+      "name": "VCFcommonSamples:",
+      "id": "vcfcommonsamples",
+      "description": "Output records belonging to samples common between two datasets",
+      "tool_shed_repository": "vcfcommonsamples",
+      "panel_section_name": "VCF/BCF",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/vcfcommonsamples/vcfcommonsamples/1.0.0_rc1+galaxy0"
+    },
+    {
+      "name": "VCFannotate:",
+      "id": "vcfannotate",
+      "description": "Intersect VCF records with BED annotations",
+      "tool_shed_repository": "vcfannotate",
+      "panel_section_name": "VCF/BCF",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/vcfannotate/vcfannotate/1.0.0_rc1+galaxy0"
+    },
+    {
+      "name": "VCF-VCFintersect:",
+      "id": "vcfvcfintersect",
+      "description": "Intersect two VCF datasets",
+      "tool_shed_repository": "vcfvcfintersect",
+      "panel_section_name": "VCF/BCF",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/vcfvcfintersect/vcfvcfintersect/1.0.0_rc1+galaxy0"
+    },
+    {
+      "name": "VCFbreakCreateMulti:",
+      "id": "vcfbreakcreatemulti",
+      "description": "Break multiple alleles into multiple records, or combine overallpoing alleles into a single record",
+      "tool_shed_repository": "vcfbreakcreatemulti",
+      "panel_section_name": "VCF/BCF",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/vcfbreakcreatemulti/vcfbreakcreatemulti/1.0.0_rc1+galaxy0"
+    },
+    {
+      "name": "VcfAllelicPrimitives:",
+      "id": "vcfallelicprimitives",
+      "description": "Split alleleic primitives (gaps or mismatches) into multiple VCF lines",
+      "tool_shed_repository": "vcfallelicprimitives",
+      "panel_section_name": "VCF/BCF",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/vcfallelicprimitives/vcfallelicprimitives/1.0.0_rc1+galaxy0"
+    },
+    {
+      "name": "VCFgenotype-to-haplotype:",
+      "id": "vcfgeno2haplo",
+      "description": "Convert genotype-based phased alleles into haplotype alleles",
+      "tool_shed_repository": "vcfgeno2haplo",
+      "panel_section_name": "VCF/BCF",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/vcfgeno2haplo/vcfgeno2haplo/1.0.0_rc1+galaxy0"
+    },
+    {
+      "name": "VCFfixup:",
+      "id": "vcffixup",
+      "description": "Count the allele frequencies across alleles present in each record in the VCF file",
+      "tool_shed_repository": "vcffixup",
+      "panel_section_name": "VCF/BCF",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/vcffixup/vcffixup/1.0.0_rc1+galaxy0"
+    },
+    {
+      "name": "VCFgenotypes:",
+      "id": "vcfgenotypes",
+      "description": "Convert numerical representation of genotypes to allelic",
+      "tool_shed_repository": "vcfgenotypes",
+      "panel_section_name": "VCF/BCF",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/vcfgenotypes/vcfgenotypes/1.0.0_rc1+galaxy0"
+    },
+    {
+      "name": "VCF-BEDintersect:",
+      "id": "vcfbedintersect",
+      "description": "Intersect VCF and BED datasets",
+      "tool_shed_repository": "vcfbedintersect",
+      "panel_section_name": "VCF/BCF",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/vcfbedintersect/vcfbedintersect/1.0.0_rc1+galaxy0"
+    },
+    {
+      "name": "VCFrandomSample:",
+      "id": "vcfrandomsample",
+      "description": "Randomly sample sites from VCF dataset",
+      "tool_shed_repository": "vcfrandomsample",
+      "panel_section_name": "VCF/BCF",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/vcfrandomsample/vcfrandomsample/1.0.0_rc1+galaxy0"
+    },
+    {
+      "name": "VCFhetHomAlleles:",
+      "id": "vcfhethom",
+      "description": "Count the number of heterozygotes and alleles, compute het/hom ratio",
+      "tool_shed_repository": "vcfhethom",
+      "panel_section_name": "VCF/BCF",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/vcfhethom/vcfhethom/1.0.0_rc1+galaxy0"
+    },
+    {
+      "name": "VCFsort:",
+      "id": "vcfsort",
+      "description": "Sort VCF dataset by coordinate",
+      "tool_shed_repository": "vcfsort",
+      "panel_section_name": "VCF/BCF",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/vcfsort/vcfsort/1.0.0_rc1+galaxy0"
+    },
+    {
+      "name": "VCFprimers:",
+      "id": "vcfprimers",
+      "description": "Extract flanking sequences for each VCF record",
+      "tool_shed_repository": "vcfprimers",
+      "panel_section_name": "VCF/BCF",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/vcfprimers/vcfprimers/1.0.0_rc1+galaxy0"
+    },
+    {
+      "name": "VCFcombine:",
+      "id": "vcfcombine",
+      "description": "Combine multiple VCF datasets",
+      "tool_shed_repository": "vcfcombine",
+      "panel_section_name": "VCF/BCF",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/vcfcombine/vcfcombine/1.0.0_rc1+galaxy0"
+    },
+    {
+      "name": "VCFleftAlign:",
+      "id": "vcfleftalign",
+      "description": "Left-align indels and complex variants in VCF dataset",
+      "tool_shed_repository": "vcfleftalign",
+      "panel_section_name": "VCF/BCF",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/vcfleftalign/vcfleftalign/1.0.0_rc1+galaxy0"
+    },
+    {
+      "name": "VCFtoTab-delimited:",
+      "id": "vcf2tsv",
+      "description": "Convert VCF data into TAB-delimited format",
+      "tool_shed_repository": "vcf2tsv",
+      "panel_section_name": "VCF/BCF",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/vcf2tsv/vcf2tsv/1.0.0_rc1+galaxy0"
+    },
+    {
+      "name": "VCFaddinfo:",
+      "id": "vcfaddinfo",
+      "description": "Adds info fields from the second dataset which are not present in the first dataset",
+      "tool_shed_repository": "vcfaddinfo",
+      "panel_section_name": "VCF/BCF",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/vcfaddinfo/vcfaddinfo/1.0.0_rc1+galaxy0"
+    },
+    {
+      "name": "VarScan",
+      "id": "varscan",
+      "description": "for variant detection",
+      "tool_shed_repository": "varscan_version_2",
+      "panel_section_name": "VCF/BCF",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/varscan_version_2/varscan/2.4.2"
+    },
+    {
+      "name": "VarScan mpileup",
+      "id": "varscan_mpileup",
+      "description": "for variant detection",
+      "tool_shed_repository": "varscan_mpileup",
+      "panel_section_name": "VCF/BCF",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/varscan_mpileup/varscan_mpileup/2.4.3.0"
+    },
+    {
+      "name": "bcftoolsView",
+      "id": "bcfview",
+      "description": "Convert, filter, subset VCF/BCF files",
+      "tool_shed_repository": "bcftools",
+      "panel_section_name": "VCF/BCF",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/bcftools/bcfview/0.1.19"
+    },
+    {
+      "name": "FreeBayes",
+      "id": "freebayes",
+      "description": "bayesian genetic variant detector",
+      "tool_shed_repository": "freebayes",
+      "panel_section_name": "VCF/BCF",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/freebayes/freebayes/1.1.0.46-0"
+    },
+    {
+      "name": "VCFdistance:",
+      "id": "vcfdistance",
+      "description": "Calculate distance to the nearest variant",
+      "tool_shed_repository": "vcfdistance",
+      "panel_section_name": "VCF/BCF",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/vcfdistance/vcfdistance/1.0.0_rc1+galaxy0"
+    },
+    {
+      "name": "Naive Variant Caller (NVC)",
+      "id": "naive_variant_caller",
+      "description": "- tabulate variable sites from BAM datasets",
+      "tool_shed_repository": "naive_variant_caller",
+      "panel_section_name": "VCF/BCF",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/blankenberg/naive_variant_caller/naive_variant_caller/0.0.3"
+    },
+    {
+      "name": "snippy",
+      "id": "snippy",
+      "description": "Snippy finds SNPs between a haploid reference genome and your NGS sequence reads.",
+      "tool_shed_repository": "snippy",
+      "panel_section_name": "VCF/BCF",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/snippy/snippy/3.2"
+    },
+    {
+      "name": "snippy-core",
+      "id": "snippy_core",
+      "description": "Combine multiple Snippy outputs into a core SNP alignment",
+      "tool_shed_repository": "snippy",
+      "panel_section_name": "Variant Calling",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/snippy/snippy_core/3.2"
+    },
+    {
+      "name": "ococo",
+      "id": "ococo",
+      "description": "consensus caller on SAM/BAM",
+      "tool_shed_repository": "ococo",
+      "panel_section_name": "VCF/BCF",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/ococo/ococo/0.1.2.6"
+    },
+    {
+      "name": "BamLeftAlign",
+      "id": "bamleftalign",
+      "description": "indels in BAM datasets",
+      "tool_shed_repository": "freebayes",
+      "panel_section_name": "VCF/BCF",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/freebayes/bamleftalign/1.1.0.46-0"
+    },
+    {
+      "name": "VCFdistance:",
+      "id": "vcfdistance",
+      "description": "Calculate distance to the nearest variant",
+      "tool_shed_repository": "vcfdistance",
+      "panel_section_name": "VCF/BCF",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/vcfdistance/vcfdistance/0.0.3"
+    },
+    {
+      "name": "Variant Annotator",
+      "id": "allele_counts_1",
+      "description": "process variant counts",
+      "tool_shed_repository": "allele_counts",
+      "panel_section_name": "VCF/BCF",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/nick/allele_counts/allele_counts_1/1.2"
+    },
+    {
+      "name": "Merge",
+      "id": "vcftools_merge",
+      "description": "multiple VCF datasets",
+      "tool_shed_repository": "vcftools_merge",
+      "panel_section_name": "VCF/BCF",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/vcftools_merge/vcftools_merge/0.1.1"
+    },
+    {
+      "name": "Intersect",
+      "id": "vcftools_isec",
+      "description": "multiple VCF datasets",
+      "tool_shed_repository": "vcftools_isec",
+      "panel_section_name": "VCF/BCF",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/vcftools_isec/vcftools_isec/0.1.1"
+    },
+    {
+      "name": "VT normalize",
+      "id": "vt_normalize",
+      "description": "normalizes variants in a VCF file",
+      "tool_shed_repository": "vt_variant_tools",
+      "panel_section_name": "VCF/BCF",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/vt_variant_tools/vt_normalize/0.1.0"
+    },
+    {
+      "name": "Compare",
+      "id": "vcftools_compare",
+      "description": "multiple VCF datasets",
+      "tool_shed_repository": "vcftools_compare",
+      "panel_section_name": "VCF/BCF",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/vcftools_compare/vcftools_compare/0.1"
+    },
+    {
+      "name": "Annotate",
+      "id": "vcftools_annotate",
+      "description": "a VCF dataset with custom filters",
+      "tool_shed_repository": "vcftools_annotate",
+      "panel_section_name": "VCF/BCF",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/vcftools_annotate/vcftools_annotate/0.1"
+    },
+    {
+      "name": "Slice VCF",
+      "id": "vcftools_slice",
+      "description": "to get data from selected regions",
+      "tool_shed_repository": "vcftools_slice",
+      "panel_section_name": "VCF/BCF",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/vcftools_slice/vcftools_slice/0.1"
+    },
+    {
+      "name": "Subset",
+      "id": "vcftools_subset",
+      "description": "columns from a VCF dataset",
+      "tool_shed_repository": "vcftools_subset",
+      "panel_section_name": "VCF/BCF",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/vcftools_subset/vcftools_subset/0.1"
+    },
+    {
+      "name": "Porechop",
+      "id": "porechop",
+      "description": "adapter trimmer for Oxford Nanopore reads",
+      "tool_shed_repository": "porechop",
+      "panel_section_name": "Nanopore",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/porechop/porechop/0.2.4+galaxy0"
+    },
+    {
+      "name": "medaka variant pipeline",
+      "id": "medaka_variant_pipeline",
+      "description": "via neural networks",
+      "tool_shed_repository": "medaka_variant_pipeline",
+      "panel_section_name": "Nanopore",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/medaka_variant_pipeline/medaka_variant_pipeline/1.4.4+galaxy0"
+    },
+    {
+      "name": "ont_fast5_api: Multi to single",
+      "id": "ont_fast5_api_multi_to_single_fast5",
+      "description": "read file(s)",
+      "tool_shed_repository": "ont_fast5_api_multi_to_single_fast5",
+      "panel_section_name": "Nanopore",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/ont_fast5_api_multi_to_single_fast5/ont_fast5_api_multi_to_single_fast5/3.1.3+galaxy1"
+    },
+    {
+      "name": "ont_fast5_api: Compress",
+      "id": "ont_fast5_api_compress_fast5",
+      "description": "multi read file(s)",
+      "tool_shed_repository": "ont_fast5_api_compress_fast5",
+      "panel_section_name": "Nanopore",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/ont_fast5_api_compress_fast5/ont_fast5_api_compress_fast5/3.1.3+galaxy1"
+    },
+    {
+      "name": "medaka variant tool",
+      "id": "medaka_variant",
+      "description": "decodes variant calls from medaka consensus output",
+      "tool_shed_repository": "medaka_variant",
+      "panel_section_name": "Nanopore",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/medaka_variant/medaka_variant/1.4.4+galaxy0"
+    },
+    {
+      "name": "medaka consensus tool",
+      "id": "medaka_consensus",
+      "description": "Assembly polishing via neural networks",
+      "tool_shed_repository": "medaka_consensus",
+      "panel_section_name": "Nanopore",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/medaka_consensus/medaka_consensus/1.4.4+galaxy0"
+    },
+    {
+      "name": "FLAIR correct",
+      "id": "flair_correct",
+      "description": "corrects misaligned splice sites using genome annotations",
+      "tool_shed_repository": "flair_correct",
+      "panel_section_name": "Nanopore",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/flair_correct/flair_correct/1.5+galaxy0"
+    },
+    {
+      "name": "Pycoqc",
+      "id": "pycoqc",
+      "description": "",
+      "tool_shed_repository": "pycoqc",
+      "panel_section_name": "Nanopore",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/pycoqc/pycoqc/2.5.2+galaxy0"
+    },
+    {
+      "name": "FLAIR collapse",
+      "id": "flair_collapse",
+      "description": "defines high-confidence isoforms from flair-corrected reads",
+      "tool_shed_repository": "flair_collapse",
+      "panel_section_name": "Nanopore",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/flair_collapse/flair_collapse/1.5+galaxy1"
+    },
+    {
+      "name": "CoNvex",
+      "id": "ngmlr",
+      "description": "Gap-cost alignMents for Long Reads",
+      "tool_shed_repository": "ngmlr",
+      "panel_section_name": "Nanopore",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/ngmlr/ngmlr/0.2.7"
+    },
+    {
+      "name": "medaka consensus pipeline",
+      "id": "medaka_consensus_pipeline",
+      "description": "Assembly polishing via neural networks",
+      "tool_shed_repository": "medaka_consensus_pipeline",
+      "panel_section_name": "Nanopore",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/medaka_consensus_pipeline/medaka_consensus_pipeline/1.4.4+galaxy0"
+    },
+    {
+      "name": "NanoComporeDB",
+      "id": "nanocompore_db",
+      "description": "Process SampComp results database",
+      "tool_shed_repository": "nanocompore_db",
+      "panel_section_name": "Nanopore",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/nanocompore_db/nanocompore_db/1.0.0rc3.post2+galaxy2"
+    },
+    {
+      "name": "ont_fast5_api: Subset",
+      "id": "ont_fast5_api_fast5_subset",
+      "description": "of multi read file(s)",
+      "tool_shed_repository": "ont_fast5_api_fast5_subset",
+      "panel_section_name": "Nanopore",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/ont_fast5_api_fast5_subset/ont_fast5_api_fast5_subset/3.1.3+galaxy2"
+    },
+    {
+      "name": "ont_fast5_api: Single to multi",
+      "id": "ont_fast5_api_single_to_multi_fast5",
+      "description": "read file(s)",
+      "tool_shed_repository": "ont_fast5_api_single_to_multi_fast5",
+      "panel_section_name": "Nanopore",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/ont_fast5_api_single_to_multi_fast5/ont_fast5_api_single_to_multi_fast5/3.1.3+galaxy1"
+    },
+    {
+      "name": "NanoPlot",
+      "id": "nanoplot",
+      "description": "Plotting suite for Oxford Nanopore sequencing data and alignments",
+      "tool_shed_repository": "nanoplot",
+      "panel_section_name": "Nanopore",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/nanoplot/nanoplot/1.28.2+galaxy1"
+    },
+    {
+      "name": "Nanopolish polyA",
+      "id": "nanopolish_polya",
+      "description": "- Estimate the length of the poly-A tail on direct RNA reads.",
+      "tool_shed_repository": "nanopolish_polya",
+      "panel_section_name": "Nanopore",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/nanopolish_polya/nanopolish_polya/0.13.2+galaxy0"
+    },
+    {
+      "name": "Nanopolish eventalign",
+      "id": "nanopolish_eventalign",
+      "description": "- Align nanopore events to reference k-mers",
+      "tool_shed_repository": "nanopolish_eventalign",
+      "panel_section_name": "Nanopore",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/nanopolish_eventalign/nanopolish_eventalign/0.13.2+galaxy0"
+    },
+    {
+      "name": "Nanopolish methylation",
+      "id": "nanopolish_methylation",
+      "description": "- Classify nucleotides as methylated or not.",
+      "tool_shed_repository": "nanopolish_methylation",
+      "panel_section_name": "Nanopore",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/nanopolish_methylation/nanopolish_methylation/0.13.2+galaxy0"
+    },
+    {
+      "name": "Nanopolish variants",
+      "id": "nanopolish_variants",
+      "description": "- Find SNPs of basecalled merged Nanopore reads and polishes the consensus sequences",
+      "tool_shed_repository": "nanopolish_variants",
+      "panel_section_name": "Nanopore",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/nanopolish_variants/nanopolish_variants/0.13.2+galaxy0"
+    },
+    {
+      "name": "SampComp",
+      "id": "nanocompore_sampcomp",
+      "description": "to compare Nanopolished datasets",
+      "tool_shed_repository": "nanocompore_sampcomp",
+      "panel_section_name": "Nanopore",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/nanocompore_sampcomp/nanocompore_sampcomp/1.0.0rc3.post2+galaxy0"
+    },
+    {
+      "name": "NanopolishComp: FreqMethCalculate",
+      "id": "nanopolishcomp_freqmethcalculate",
+      "description": "calculates methylation frequency at genomic CpG sites",
+      "tool_shed_repository": "nanopolishcomp_freqmethcalculate",
+      "panel_section_name": "Nanopore",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/nanopolishcomp_freqmethcalculate/nanopolishcomp_freqmethcalculate/0.6.11+galaxy1"
+    },
+    {
+      "name": "NanopolishComp: EventalignCollapse",
+      "id": "nanopolishcomp_eventaligncollapse",
+      "description": "by kmers rather than by event",
+      "tool_shed_repository": "nanopolishcomp_eventaligncollapse",
+      "panel_section_name": "Nanopore",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/nanopolishcomp_eventaligncollapse/nanopolishcomp_eventaligncollapse/0.6.11+galaxy1"
+    },
+    {
+      "name": "Extract time",
+      "id": "poretools_times",
+      "description": "and channel information from a set of FAST5 files",
+      "tool_shed_repository": "poretools_times",
+      "panel_section_name": "Nanopore",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/poretools_times/poretools_times/0.6.1a1.0"
+    },
+    {
+      "name": "Show nucleotide",
+      "id": "poretools_nucdist",
+      "description": "distribution in nanopore sequencing reads",
+      "tool_shed_repository": "poretools_nucdist",
+      "panel_section_name": "Nanopore",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/poretools_nucdist/poretools_nucdist/0.6.1a1.0"
+    },
+    {
+      "name": "Show quality",
+      "id": "poretools_qualdist",
+      "description": "score distribution in nanopore sequencing reads",
+      "tool_shed_repository": "poretools_qualdist",
+      "panel_section_name": "Nanopore",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/poretools_qualdist/poretools_qualdist/0.6.1a1.0"
+    },
+    {
+      "name": "Extract reads",
+      "id": "poretools_extract",
+      "description": "in FASTA or FASTQ format from nanopore files",
+      "tool_shed_repository": "poretools_extract",
+      "panel_section_name": "Nanopore",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/poretools_extract/poretools_extract/0.6.1a1.0"
+    },
+    {
+      "name": "Extract FASTQ",
+      "id": "poretools_tabular",
+      "description": "in tabular format from a set of FAST5 files",
+      "tool_shed_repository": "poretools_tabular",
+      "panel_section_name": "Nanopore",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/poretools_tabular/poretools_tabular/0.6.1a1.0"
+    },
+    {
+      "name": "Read length statistics",
+      "id": "poretools_stats",
+      "description": "from a set of FAST5 files",
+      "tool_shed_repository": "poretools_stats",
+      "panel_section_name": "Nanopore",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/poretools_stats/poretools_stats/0.6.1a1.0"
+    },
+    {
+      "name": "Plot signals",
+      "id": "poretools_squiggle",
+      "description": "for nanopore reads",
+      "tool_shed_repository": "poretools_squiggle",
+      "panel_section_name": "Nanopore",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/poretools_squiggle/poretools_squiggle/0.6.1a1.0"
+    },
+    {
+      "name": "Plot performance",
+      "id": "poretools_occupancy",
+      "description": "per cell in nanopore reads",
+      "tool_shed_repository": "poretools_occupancy",
+      "panel_section_name": "Nanopore",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/poretools_occupancy/poretools_occupancy/0.6.1a1.0"
+    },
+    {
+      "name": "Generate histogram",
+      "id": "poretools_hist",
+      "description": "of nanopore read lengths",
+      "tool_shed_repository": "poretools_hist",
+      "panel_section_name": "Nanopore",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/poretools_hist/poretools_hist/0.6.1a1.0"
+    },
+    {
+      "name": "Collector\u2019s curve",
+      "id": "poretools_yield_plot",
+      "description": "of sequencing yield over time",
+      "tool_shed_repository": "poretools_yield_plot",
+      "panel_section_name": "Nanopore",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/poretools_yield_plot/poretools_yield_plot/0.6.1a1.0"
+    },
+    {
+      "name": "Generate box-whisker",
+      "id": "poretools_qualpos",
+      "description": "plot of quality score distribution over positions in nanopore reads",
+      "tool_shed_repository": "poretools_qualpos",
+      "panel_section_name": "Nanopore",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/poretools_qualpos/poretools_qualpos/0.6.1a1.0"
+    },
+    {
+      "name": "Get longest read",
+      "id": "poretools_winner",
+      "description": "from a set of FAST5 files.",
+      "tool_shed_repository": "poretools_winner",
+      "panel_section_name": "Nanopore",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/poretools_winner/poretools_winner/0.6.1a1.0"
+    },
+    {
+      "name": "Extract nanopore events",
+      "id": "poretools_events",
+      "description": "from a set of sequencing reads",
+      "tool_shed_repository": "poretools_events",
+      "panel_section_name": "Nanopore",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/poretools_events/poretools_events/0.6.1a1.0"
+    },
+    {
+      "name": "Complement",
+      "id": "gops_complement_1",
+      "description": "intervals of a dataset",
+      "tool_shed_repository": "complement",
+      "panel_section_name": "Operate on Genomic Intervals",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/complement/gops_complement_1/1.0.0"
+    },
+    {
+      "name": "Cluster",
+      "id": "gops_cluster_1",
+      "description": "the intervals of a dataset",
+      "tool_shed_repository": "cluster",
+      "panel_section_name": "Operate on Genomic Intervals",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/cluster/gops_cluster_1/1.0.0"
+    },
+    {
+      "name": "Base Coverage",
+      "id": "gops_basecoverage_1",
+      "description": "of all intervals",
+      "tool_shed_repository": "basecoverage",
+      "panel_section_name": "Operate on Genomic Intervals",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/basecoverage/gops_basecoverage_1/1.0.0"
+    },
+    {
+      "name": "Profile Annotations",
+      "id": "Annotation_Profiler_0",
+      "description": "for a set of genomic intervals",
+      "tool_shed_repository": "annotation_profiler",
+      "panel_section_name": "Operate on Genomic Intervals",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/annotation_profiler/Annotation_Profiler_0/1.0.0"
+    },
+    {
+      "name": "Table to GFF3",
+      "id": "tbl2gff3",
+      "description": "",
+      "tool_shed_repository": "tbl2gff3",
+      "panel_section_name": "Operate on Genomic Intervals",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/tbl2gff3/tbl2gff3/1.1"
+    },
+    {
+      "name": "Translate BED transcripts",
+      "id": "translate_bed",
+      "description": "cDNA in 3frames or CDS",
+      "tool_shed_repository": "translate_bed",
+      "panel_section_name": "Operate on Genomic Intervals",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/translate_bed/translate_bed/0.1.0"
+    },
+    {
+      "name": "Concatenate",
+      "id": "gops_concat_1",
+      "description": "two BED files",
+      "tool_shed_repository": "concat",
+      "panel_section_name": "Operate on Genomic Intervals",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/concat/gops_concat_1/1.0.1"
+    },
+    {
+      "name": "Join",
+      "id": "gops_join_1",
+      "description": "the intervals of two datasets side-by-side",
+      "tool_shed_repository": "join",
+      "panel_section_name": "Operate on Genomic Intervals",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/join/gops_join_1/1.0.0"
+    },
+    {
+      "name": "Translate BED Sequences",
+      "id": "translate_bed_sequences",
+      "description": "3 frame translation of BED augmented with a sequence column",
+      "tool_shed_repository": "translate_bed_sequences",
+      "panel_section_name": "Operate on Genomic Intervals",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/jjohnson/translate_bed_sequences/translate_bed_sequences/0.0.1"
+    },
+    {
+      "name": "Filter BED on splice junctions",
+      "id": "filter_bed_on_splice_junctions",
+      "description": "that are not in a reference bed file",
+      "tool_shed_repository": "filter_bed_on_splice_junctions",
+      "panel_section_name": "Operate on Genomic Intervals",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/jjohnson/filter_bed_on_splice_junctions/filter_bed_on_splice_junctions/0.0.1"
+    },
+    {
+      "name": "Extract Genomic DNA",
+      "id": "Extract genomic DNA 1",
+      "description": "using coordinates from assembled/unassembled genomes",
+      "tool_shed_repository": "extract_genomic_dna",
+      "panel_section_name": "Fetch Sequences / Alignments",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/extract_genomic_dna/Extract genomic DNA 1/3.0.3+galaxy2"
+    },
+    {
+      "name": "Gene length and GC content",
+      "id": "length_and_gc_content",
+      "description": "from GTF and FASTA file",
+      "tool_shed_repository": "length_and_gc_content",
+      "panel_section_name": "Fetch Sequences / Alignments",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/length_and_gc_content/length_and_gc_content/0.1.1"
+    },
+    {
+      "name": "FragGeneScan",
+      "id": "fraggenescan",
+      "description": "for finding (fragmented) genes in short reads",
+      "tool_shed_repository": "fraggenescan",
+      "panel_section_name": "Fetch Sequences / Alignments",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/fraggenescan/fraggenescan/1.30.0"
+    },
+    {
+      "name": "RepeatModeler",
+      "id": "repeatmodeler",
+      "description": "Model repetitive DNA",
+      "tool_shed_repository": "repeatmodeler",
+      "panel_section_name": "Annotation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/csbl/repeatmodeler/repeatmodeler/2.0.3+galaxy0"
+    },
+    {
+      "name": "Promoter 2.0",
+      "id": "promoter2",
+      "description": "Find eukaryotic PolII promoters in DNA sequences",
+      "tool_shed_repository": "tmhmm_and_signalp",
+      "panel_section_name": "Annotation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/peterjc/tmhmm_and_signalp/promoter2/0.0.13"
+    },
+    {
+      "name": "psortb",
+      "id": "Psortb",
+      "description": "Determines sub-cellular localisation of bacterial/archaeal protein sequences",
+      "tool_shed_repository": "tmhmm_and_signalp",
+      "panel_section_name": "Annotation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/peterjc/tmhmm_and_signalp/Psortb/0.0.10"
+    },
+    {
+      "name": "RXLR Motifs",
+      "id": "rxlr_motifs",
+      "description": "Find RXLR Effectors of Plant Pathogenic Oomycetes",
+      "tool_shed_repository": "tmhmm_and_signalp",
+      "panel_section_name": "Annotation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/peterjc/tmhmm_and_signalp/rxlr_motifs/0.0.17"
+    },
+    {
+      "name": "SignalP 3.0",
+      "id": "signalp3",
+      "description": "Find signal peptides in protein sequences",
+      "tool_shed_repository": "tmhmm_and_signalp",
+      "panel_section_name": "Annotation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/peterjc/tmhmm_and_signalp/signalp3/0.0.20"
+    },
+    {
+      "name": "TMHMM 2.0",
+      "id": "tmhmm2",
+      "description": "Find transmembrane domains in protein sequences",
+      "tool_shed_repository": "tmhmm_and_signalp",
+      "panel_section_name": "Annotation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/peterjc/tmhmm_and_signalp/tmhmm2/0.0.17"
+    },
+    {
+      "name": "WoLF PSORT",
+      "id": "wolf_psort",
+      "description": "Eukaryote protein subcellular localization prediction",
+      "tool_shed_repository": "tmhmm_and_signalp",
+      "panel_section_name": "Annotation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/peterjc/tmhmm_and_signalp/wolf_psort/0.0.12"
+    },
+    {
+      "name": "TB Variant Report",
+      "id": "tbvcfreport",
+      "description": "- generate HTML report from SnpEff annotated M.tb VCF(s)",
+      "tool_shed_repository": "tbvcfreport",
+      "panel_section_name": "Annotation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/tbvcfreport/tbvcfreport/0.1.10+galaxy0"
+    },
+    {
+      "name": "TB-Profiler Profile",
+      "id": "tb_profiler_profile",
+      "description": "Infer strain types and drug resistance markers from sequences",
+      "tool_shed_repository": "tbprofiler",
+      "panel_section_name": "Annotation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/tbprofiler/tb_profiler_profile/4.1.1+galaxy0"
+    },
+    {
+      "name": "legsta",
+      "id": "legsta",
+      "description": "Legionella pneumophila sequence based typing",
+      "tool_shed_repository": "legsta",
+      "panel_section_name": "Annotation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/legsta/legsta/0.5.1+galaxy1"
+    },
+    {
+      "name": "KofamScan",
+      "id": "kofamscan",
+      "description": "gene function annotation based on KEGG orthology and HMM",
+      "tool_shed_repository": "kofamscan",
+      "panel_section_name": "Annotation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/kofamscan/kofamscan/1.3.0+galaxy1"
+    },
+    {
+      "name": "progressiveMauve",
+      "id": "progressivemauve",
+      "description": "constructs multiple genome alignments",
+      "tool_shed_repository": "progressivemauve",
+      "panel_section_name": "Annotation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/progressivemauve/progressivemauve/2015_02_13.1"
+    },
+    {
+      "name": "GECCO",
+      "id": "gecco",
+      "description": "is a fast and scalable method for identifying putative novel Biosynthetic Gene Clusters (BGCs) in genomic and metagenomic data using Conditional Random Fields (CRFs).",
+      "tool_shed_repository": "gecco",
+      "panel_section_name": "Annotation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/althonos/gecco/gecco/0.8.5"
+    },
+    {
+      "name": "List spaln parameter tables",
+      "id": "list_spaln_tables",
+      "description": "Given a query species, list the spaln settings tables that exist, from closest related species to most different",
+      "tool_shed_repository": "spaln",
+      "panel_section_name": "Annotation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/spaln/list_spaln_tables/2.4.7+galaxy0"
+    },
+    {
+      "name": "Spaln: align cDNA or Protein to genome",
+      "id": "spaln",
+      "description": "Maps and aligns a set of cDNA or protein sequences onto a whole genomic sequence.",
+      "tool_shed_repository": "spaln",
+      "panel_section_name": "Annotation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/spaln/spaln/2.4.7+galaxy0"
+    },
+    {
+      "name": "summarize",
+      "id": "hamronize_summarize",
+      "description": "harmorization reports",
+      "tool_shed_repository": "hamronize_summarize",
+      "panel_section_name": "Annotation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/hamronize_summarize/hamronize_summarize/1.0.3+galaxy1"
+    },
+    {
+      "name": "hamronize",
+      "id": "hamronize_tool",
+      "description": "parse multiple Antimicrobial Resistance Analysis Reports into a common data structure",
+      "tool_shed_repository": "hamronize_tool",
+      "panel_section_name": "Annotation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/hamronize_tool/hamronize_tool/1.0.3+galaxy1"
+    },
+    {
+      "name": "annotatePeaks",
+      "id": "homer_annotatePeaks",
+      "description": "",
+      "tool_shed_repository": "homer_annotatepeaks",
+      "panel_section_name": "Annotation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/homer_annotatepeaks/homer_annotatePeaks/4.11+galaxy2"
+    },
+    {
+      "name": "Funannotate functional",
+      "id": "funannotate_annotate",
+      "description": "annotation",
+      "tool_shed_repository": "funannotate_annotate",
+      "panel_section_name": "Annotation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/funannotate_annotate/funannotate_annotate/1.8.9+galaxy2"
+    },
+    {
+      "name": "Funannotate predict annotation",
+      "id": "funannotate_predict",
+      "description": "",
+      "tool_shed_repository": "funannotate_predict",
+      "panel_section_name": "Annotation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/funannotate_predict/funannotate_predict/1.8.9+galaxy2"
+    },
+    {
+      "name": "TB Variant Filter",
+      "id": "tb_variant_filter",
+      "description": "M. tuberculosis H37Rv VCF filter",
+      "tool_shed_repository": "tb_variant_filter",
+      "panel_section_name": "Annotation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/tb_variant_filter/tb_variant_filter/0.3.5+galaxy2"
+    },
+    {
+      "name": "Train Augustus",
+      "id": "augustus_training",
+      "description": "ab-initio gene predictor",
+      "tool_shed_repository": "augustus_training",
+      "panel_section_name": "Annotation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/augustus_training/augustus_training/3.4.0+galaxy1"
+    },
+    {
+      "name": "Augustus",
+      "id": "augustus",
+      "description": "gene prediction for prokaryotic and eukaryotic genomes",
+      "tool_shed_repository": "augustus",
+      "panel_section_name": "Annotation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/augustus/augustus/3.4.0+galaxy1"
+    },
+    {
+      "name": "ChIPseeker",
+      "id": "chipseeker",
+      "description": "for ChIP peak annotation and visualization",
+      "tool_shed_repository": "chipseeker",
+      "panel_section_name": "Annotation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/rnateam/chipseeker/chipseeker/1.28.3+galaxy0"
+    },
+    {
+      "name": "SpoTyping",
+      "id": "spotyping",
+      "description": "fast and accurate in silico Mycobacterium spoligotyping from sequence reads",
+      "tool_shed_repository": "spotyping",
+      "panel_section_name": "Annotation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/spotyping/spotyping/2.1+galaxy2"
+    },
+    {
+      "name": "lorikeet spoligotyping",
+      "id": "lorikeet_spoligotype",
+      "description": "M. tuberculosis DNA fingerprinting",
+      "tool_shed_repository": "lorikeet_spoligotype",
+      "panel_section_name": "Annotation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/lorikeet_spoligotype/lorikeet_spoligotype/20+galaxy0"
+    },
+    {
+      "name": "hmmbuild",
+      "id": "hmmer_hmmbuild",
+      "description": "Build a profile HMM from an input multiple alignment",
+      "tool_shed_repository": "hmmer_hmmbuild",
+      "panel_section_name": "Annotation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/hmmer_hmmbuild/hmmer_hmmbuild/3.3.2+galaxy0"
+    },
+    {
+      "name": "hmmscan",
+      "id": "hmmer_hmmscan",
+      "description": "search protein sequence(s) against a protein profile database",
+      "tool_shed_repository": "hmmer_hmmscan",
+      "panel_section_name": "Annotation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/hmmer_hmmscan/hmmer_hmmscan/3.3.2+galaxy0"
+    },
+    {
+      "name": "annotateMyIDs",
+      "id": "annotatemyids",
+      "description": "annotate a generic set of identifiers",
+      "tool_shed_repository": "annotatemyids",
+      "panel_section_name": "Annotation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/annotatemyids/annotatemyids/3.12.0+galaxy1"
+    },
+    {
+      "name": "MITOS2",
+      "id": "mitos2",
+      "description": "de-novo annotation of metazoan mitochondrial genomes",
+      "tool_shed_repository": "mitos2",
+      "panel_section_name": "Annotation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/mitos2/mitos2/2.0.6+galaxy1"
+    },
+    {
+      "name": "sistr_cmd",
+      "id": "sistr_cmd",
+      "description": "Salmonella In Silico Typing Resource commandline tool for serovar prediction",
+      "tool_shed_repository": "sistr_cmd",
+      "panel_section_name": "Annotation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/nml/sistr_cmd/sistr_cmd/1.1.1+galaxy1"
+    },
+    {
+      "name": "HHsearch",
+      "id": "hhsearch",
+      "description": "detecting remote homologues of proteins",
+      "tool_shed_repository": "hhsearch",
+      "panel_section_name": "Annotation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/guerler/hhsearch/hhsearch/3.2.0+galaxy0"
+    },
+    {
+      "name": "OptiType",
+      "id": "optitype",
+      "description": "HLA genotyping predictions from NGS data",
+      "tool_shed_repository": "optitype",
+      "panel_section_name": "Annotation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/optitype/optitype/1.3.5+galaxy0"
+    },
+    {
+      "name": "nhmmer",
+      "id": "hmmer_nhmmer",
+      "description": "search a DNA model or alignment against a DNA database (BLASTN-like)",
+      "tool_shed_repository": "hmmer_nhmmer",
+      "panel_section_name": "Annotation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/hmmer_nhmmer/hmmer_nhmmer/3.3.2+galaxy0"
+    },
+    {
+      "name": "phmmer",
+      "id": "hmmer_phmmer",
+      "description": "search a protein sequence against a protein database (BLASTP-like)",
+      "tool_shed_repository": "hmmer_phmmer",
+      "panel_section_name": "Annotation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/hmmer_phmmer/hmmer_phmmer/3.3.2+galaxy0"
+    },
+    {
+      "name": "jackhmmer",
+      "id": "hmmer_jackhmmer",
+      "description": "iteratively search a protein sequence against a protein database (PSIBLAST-like)",
+      "tool_shed_repository": "hmmer_jackhmmer",
+      "panel_section_name": "Annotation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/hmmer_jackhmmer/hmmer_jackhmmer/3.3.2+galaxy0"
+    },
+    {
+      "name": "nhmmscan",
+      "id": "hmmer_nhmmscan",
+      "description": "search DNA sequence(s) against a DNA profile database",
+      "tool_shed_repository": "hmmer_nhmmscan",
+      "panel_section_name": "Annotation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/hmmer_nhmmscan/hmmer_nhmmscan/3.3.2+galaxy0"
+    },
+    {
+      "name": "hmmsearch",
+      "id": "hmmer_hmmsearch",
+      "description": "search profile(s) against a sequence database",
+      "tool_shed_repository": "hmmer_hmmsearch",
+      "panel_section_name": "Annotation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/hmmer_hmmsearch/hmmer_hmmsearch/3.3.2+galaxy0"
+    },
+    {
+      "name": "Table to GFF3",
+      "id": "tbl2gff3",
+      "description": "",
+      "tool_shed_repository": "tbl2gff3",
+      "panel_section_name": "Annotation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/tbl2gff3/tbl2gff3/1.2"
+    },
+    {
+      "name": "hmmemit",
+      "id": "hmmer_hmmemit",
+      "description": "sample sequence(s) from a profile HMM",
+      "tool_shed_repository": "hmmer_hmmemit",
+      "panel_section_name": "Annotation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/hmmer_hmmemit/hmmer_hmmemit/3.3.2"
+    },
+    {
+      "name": "hmmalign",
+      "id": "hmmer_hmmalign",
+      "description": "align sequences to a profile HMM",
+      "tool_shed_repository": "hmmer_hmmalign",
+      "panel_section_name": "Annotation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/hmmer_hmmalign/hmmer_hmmalign/3.3.2"
+    },
+    {
+      "name": "Converts GTF to Annotations file for Homer",
+      "id": "homer_gtf_to_annotations",
+      "description": "",
+      "tool_shed_repository": "homer_gtf_to_annotations",
+      "panel_section_name": "Annotation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/homer_gtf_to_annotations/homer_gtf_to_annotations/4.11+galaxy0"
+    },
+    {
+      "name": "Funannotate assembly clean",
+      "id": "funannotate_clean",
+      "description": "",
+      "tool_shed_repository": "funannotate_clean",
+      "panel_section_name": "Annotation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/funannotate_clean/funannotate_clean/1.8.9+galaxy2"
+    },
+    {
+      "name": "Sort assembly",
+      "id": "funannotate_sort",
+      "description": "",
+      "tool_shed_repository": "funannotate_sort",
+      "panel_section_name": "Annotation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/funannotate_sort/funannotate_sort/1.8.9+galaxy2"
+    },
+    {
+      "name": "Funannotate compare",
+      "id": "funannotate_compare",
+      "description": "annotations",
+      "tool_shed_repository": "funannotate_compare",
+      "panel_section_name": "Annotation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/funannotate_compare/funannotate_compare/1.8.9+galaxy2"
+    },
+    {
+      "name": "hmmfetch",
+      "id": "hmmer_hmmfetch",
+      "description": "retrieve profile HMM(s) from a file",
+      "tool_shed_repository": "hmmer_hmmfetch",
+      "panel_section_name": "Annotation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/hmmer_hmmfetch/hmmer_hmmfetch/3.3.2"
+    },
+    {
+      "name": "alimask",
+      "id": "hmmer_alimask",
+      "description": "append modelmask line to a multiple sequence alignments",
+      "tool_shed_repository": "hmmer_alimask",
+      "panel_section_name": "Annotation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/hmmer_alimask/hmmer_alimask/3.3.2"
+    },
+    {
+      "name": "hmmconvert",
+      "id": "hmmer_hmmconvert",
+      "description": "convert profile file to a HMMER format",
+      "tool_shed_repository": "hmmer_hmmconvert",
+      "panel_section_name": "Annotation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/hmmer_hmmconvert/hmmer_hmmconvert/3.3.2"
+    },
+    {
+      "name": "MOB-Recon",
+      "id": "mob_recon",
+      "description": "Type contigs and extract plasmid sequences",
+      "tool_shed_repository": "mob_suite",
+      "panel_section_name": "Annotation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/nml/mob_suite/mob_recon/3.0.3+galaxy0"
+    },
+    {
+      "name": "MOB-Typer",
+      "id": "mob_typer",
+      "description": "Get the plasmid type and mobility given its sequence",
+      "tool_shed_repository": "mob_suite",
+      "panel_section_name": "Annotation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/nml/mob_suite/mob_typer/3.0.3+galaxy0"
+    },
+    {
+      "name": "seq2HLA",
+      "id": "seq2hla",
+      "description": "HLA genotype and expression from RNA-seq",
+      "tool_shed_repository": "seq2hla",
+      "panel_section_name": "Annotation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/seq2hla/seq2hla/2.2.0+galaxy1"
+    },
+    {
+      "name": "MITOS",
+      "id": "mitos",
+      "description": "de-novo annotation of metazoan mitochondrial genomes",
+      "tool_shed_repository": "mitos",
+      "panel_section_name": "Annotation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/mitos/mitos/1.0.5+galaxy1"
+    },
+    {
+      "name": "ectyper",
+      "id": "ectyper",
+      "description": "ectyper is a standalone serotyping module for Escherichia coli. It supports fasta and fastq file formats.",
+      "tool_shed_repository": "ectyper",
+      "panel_section_name": "Annotation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/nml/ectyper/ectyper/1.0.0"
+    },
+    {
+      "name": "Antismash",
+      "id": "antismash",
+      "description": "allows the genome-wide identification, annotation and analysis of secondary metabolite biosynthesis gene clusters",
+      "tool_shed_repository": "antismash",
+      "panel_section_name": "Annotation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/antismash/antismash/5.1.2"
+    },
+    {
+      "name": "Convert XMFA to gapped GFF3",
+      "id": "xmfa2gff3",
+      "description": "",
+      "tool_shed_repository": "progressivemauve",
+      "panel_section_name": "Annotation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/progressivemauve/xmfa2gff3/2015_02_13.1"
+    },
+    {
+      "name": "MLST List",
+      "id": "mlst_list",
+      "description": "Lists available schemes for the MLST tool.",
+      "tool_shed_repository": "mlst",
+      "panel_section_name": "Annotation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/mlst/mlst_list/2.19.0"
+    },
+    {
+      "name": "MLST",
+      "id": "mlst",
+      "description": "Scans genomes against PubMLST schemes.",
+      "tool_shed_repository": "mlst",
+      "panel_section_name": "Annotation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/mlst/mlst/2.19.0"
+    },
+    {
+      "name": "Genbank to GFF3",
+      "id": "bp_genbank2gff3",
+      "description": "converter",
+      "tool_shed_repository": "bp_genbank2gff3",
+      "panel_section_name": "Annotation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/bp_genbank2gff3/bp_genbank2gff3/1.1"
+    },
+    {
+      "name": "Exonerate",
+      "id": "exonerate",
+      "description": "pairwise sequence comparison",
+      "tool_shed_repository": "exonerate",
+      "panel_section_name": "Annotation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/exonerate/exonerate/2.4.0+galaxy2"
+    },
+    {
+      "name": "FastANI",
+      "id": "fastani",
+      "description": "fast alignment-free computation of whole-genome Average Nucleotide Identity",
+      "tool_shed_repository": "fastani",
+      "panel_section_name": "Annotation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/fastani/fastani/1.3"
+    },
+    {
+      "name": "TETyper",
+      "id": "tetyper",
+      "description": "Transposable Element Typer",
+      "tool_shed_repository": "tetyper",
+      "panel_section_name": "Annotation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/tetyper/tetyper/1.1+galaxy1"
+    },
+    {
+      "name": "fargene",
+      "id": "fargene",
+      "description": "Fragmented antibiotic resistance gene identifier",
+      "tool_shed_repository": "fargene",
+      "panel_section_name": "Annotation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/fargene/fargene/0.1+galaxy1"
+    },
+    {
+      "name": "KOBAS Annotate",
+      "id": "kobas_annotate",
+      "description": "KEGG Orthology Based Annotation System",
+      "tool_shed_repository": "kobas",
+      "panel_section_name": "Annotation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/kobas/kobas_annotate/2.1.1"
+    },
+    {
+      "name": "KOBAS Identify",
+      "id": "kobas_identify",
+      "description": "KEGG Orthology Based Annotation System",
+      "tool_shed_repository": "kobas",
+      "panel_section_name": "Annotation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/kobas/kobas_identify/2.1.1"
+    },
+    {
+      "name": "gProfiler SNPense",
+      "id": "gprofiler_snpense",
+      "description": "maps SNP rs-codes to gene names, chromosomal coordinates and variant effects",
+      "tool_shed_repository": "gprofiler_snpense",
+      "panel_section_name": "Annotation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/gprofiler_snpense/gprofiler_snpense/0.1.7+galaxy11"
+    },
+    {
+      "name": "gProfiler Random",
+      "id": "gprofiler_random",
+      "description": "generates a gene list",
+      "tool_shed_repository": "gprofiler_random",
+      "panel_section_name": "Annotation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/gprofiler_random/gprofiler_random/0.1.7+galaxy11"
+    },
+    {
+      "name": "gProfiler GOSt",
+      "id": "gprofiler_gost",
+      "description": "performs functional enrichment analysis of gene lists",
+      "tool_shed_repository": "gprofiler_gost",
+      "panel_section_name": "Annotation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/gprofiler_gost/gprofiler_gost/0.1.7+galaxy11"
+    },
+    {
+      "name": "gProfiler Orth",
+      "id": "gprofiler_orth",
+      "description": "translates gene identifiers between organisms",
+      "tool_shed_repository": "gprofiler_orth",
+      "panel_section_name": "Annotation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/gprofiler_orth/gprofiler_orth/0.1.7+galaxy11"
+    },
+    {
+      "name": "gProfiler Convert",
+      "id": "gprofiler_convert",
+      "description": "converts between various types of namespaces",
+      "tool_shed_repository": "gprofiler_convert",
+      "panel_section_name": "Annotation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/gprofiler_convert/gprofiler_convert/0.1.7+galaxy11"
+    },
+    {
+      "name": "BlastXML to gapped GFF3",
+      "id": "blastxml_to_gapped_gff3",
+      "description": "",
+      "tool_shed_repository": "blastxml_to_gapped_gff3",
+      "panel_section_name": "Annotation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/blastxml_to_gapped_gff3/blastxml_to_gapped_gff3/1.1"
+    },
+    {
+      "name": "Compute",
+      "id": "Add_a_column1",
+      "description": "an expression on every row",
+      "tool_shed_repository": "column_maker",
+      "panel_section_name": "Annotation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/column_maker/Add_a_column1/1.4"
+    },
+    {
+      "name": "socru",
+      "id": "socru",
+      "description": "Calculate the order and orientation of complete bacterial genomes",
+      "tool_shed_repository": "socru",
+      "panel_section_name": "Annotation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/socru/socru/2.1.7"
+    },
+    {
+      "name": "Train SNAP",
+      "id": "snap_training",
+      "description": "ab-initio gene predictor",
+      "tool_shed_repository": "snap_training",
+      "panel_section_name": "Annotation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/snap_training/snap_training/2013_11_29+galaxy1"
+    },
+    {
+      "name": "fgsea",
+      "id": "fgsea",
+      "description": "- fast preranked gene set enrichment analysis",
+      "tool_shed_repository": "fgsea",
+      "panel_section_name": "Annotation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/fgsea/fgsea/1.8.0+galaxy1"
+    },
+    {
+      "name": "Filter with SortMeRNA",
+      "id": "bg_sortmerna",
+      "description": "of ribosomal RNAs in metatranscriptomic data",
+      "tool_shed_repository": "sortmerna",
+      "panel_section_name": "Annotation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/rnateam/sortmerna/bg_sortmerna/2.1b.6"
+    },
+    {
+      "name": "GOSlimmer",
+      "id": "goslimmer",
+      "description": "converts a set of annotation from GO to a given GOSlim version",
+      "tool_shed_repository": "goslimmer",
+      "panel_section_name": "Annotation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/goslimmer/goslimmer/1.0.1"
+    },
+    {
+      "name": "GOEnrichment",
+      "id": "goenrichment",
+      "description": "performs GO enrichment analysis of a set of gene products",
+      "tool_shed_repository": "goenrichment",
+      "panel_section_name": "Annotation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/goenrichment/goenrichment/2.0.1"
+    },
+    {
+      "name": "Genome annotation statistics",
+      "id": "jcvi_gff_stats",
+      "description": "",
+      "tool_shed_repository": "jcvi_gff_stats",
+      "panel_section_name": "Annotation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/jcvi_gff_stats/jcvi_gff_stats/0.8.4"
+    },
+    {
+      "name": "Hammock - cluster peptides",
+      "id": "hammock_1.0",
+      "description": "Clusters short peptide sequences",
+      "tool_shed_repository": "hammock",
+      "panel_section_name": "Annotation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/hammock/hammock/hammock_1.0/1.0.4"
+    },
+    {
+      "name": "Metagenome Contributions",
+      "id": "picrust_metagenome_contributions",
+      "description": "of OTUs to user-specified functions",
+      "tool_shed_repository": "picrust_metagenome_contributions",
+      "panel_section_name": "Annotation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/picrust_metagenome_contributions/picrust_metagenome_contributions/1.1.1.0"
+    },
+    {
+      "name": "Format",
+      "id": "picrust_format_tree_and_trait_table",
+      "description": "tree and trait tables",
+      "tool_shed_repository": "picrust_format_tree_and_trait_table",
+      "panel_section_name": "Annotation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/picrust_format_tree_and_trait_table/picrust_format_tree_and_trait_table/1.1.1.0"
+    },
+    {
+      "name": "Compare BIOM tables",
+      "id": "picrust_compare_biom",
+      "description": "Compare the accuracy of biom files (expected and observed) either by observations (default) or by samples.",
+      "tool_shed_repository": "picrust_compare_biom",
+      "panel_section_name": "Annotation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/picrust_compare_biom/picrust_compare_biom/1.1.1.0"
+    },
+    {
+      "name": "Predict Metagenome",
+      "id": "picrust_predict_metagenomes",
+      "description": "based on the abundance of OTUs and a functional database",
+      "tool_shed_repository": "picrust_predict_metagenomes",
+      "panel_section_name": "Annotation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/picrust_predict_metagenomes/picrust_predict_metagenomes/1.1.1.0"
+    },
+    {
+      "name": "Categorize",
+      "id": "picrust_categorize",
+      "description": "by collapsing hierarchical data to a specified functional level",
+      "tool_shed_repository": "picrust_categorize",
+      "panel_section_name": "Annotation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/picrust_categorize/picrust_categorize/1.1.1.0"
+    },
+    {
+      "name": "tRNA prediction",
+      "id": "trnascan",
+      "description": "(tRNAscan)",
+      "tool_shed_repository": "trna_prediction",
+      "panel_section_name": "Annotation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/trna_prediction/trnascan/0.4"
+    },
+    {
+      "name": "tRNA and tmRNA",
+      "id": "aragorn_trna",
+      "description": "prediction (Aragorn)",
+      "tool_shed_repository": "trna_prediction",
+      "panel_section_name": "Annotation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/trna_prediction/aragorn_trna/0.6"
+    },
+    {
+      "name": "TransTermHP",
+      "id": "transtermhp",
+      "description": "finds rho-independent transcription terminators in bacterial genomes",
+      "tool_shed_repository": "transtermhp",
+      "panel_section_name": "Annotation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/transtermhp/transtermhp/2.09.1"
+    },
+    {
+      "name": "estimate-energy",
+      "id": "smf_utils_estimate-energy",
+      "description": "Estimates whether a certain Segment(Loop) is present and for which delta-G this transistion takes place",
+      "tool_shed_repository": "segmentation_fold",
+      "panel_section_name": "Annotation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/yhoogstrate/segmentation_fold/smf_utils_estimate-energy/smf-v1.7-0_utils-v2.1.1-2"
+    },
+    {
+      "name": "fix-fasta-headers",
+      "id": "smf_utils_fix-fasta-headers",
+      "description": "Replaces all spaces with underscores in the \">..\"-sequence headers of a FASTA file",
+      "tool_shed_repository": "segmentation_fold",
+      "panel_section_name": "Annotation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/yhoogstrate/segmentation_fold/smf_utils_fix-fasta-headers/smf-v1.7-0_utils-v2.1.1-1"
+    },
+    {
+      "name": "filter-annotated-entries",
+      "id": "smf_utils_filter-annotated-entries",
+      "description": "Split entries into two files based on whether they overlap annotations in a bed file",
+      "tool_shed_repository": "segmentation_fold",
+      "panel_section_name": "Annotation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/yhoogstrate/segmentation_fold/smf_utils_filter-annotated-entries/smf-v1.7-0_utils-v2.1.1-1"
+    },
+    {
+      "name": "add-read-counts",
+      "id": "smf_utils_add-read-counts",
+      "description": "Annotate sequences by adding the read counts from a bam file, within a region contained in the fasta header of the dbn file",
+      "tool_shed_repository": "segmentation_fold",
+      "panel_section_name": "Annotation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/yhoogstrate/segmentation_fold/smf_utils_add-read-counts/smf-v1.7-0_utils-v2.1.1-3"
+    },
+    {
+      "name": "find-boxes",
+      "id": "smf_utils_find-boxes",
+      "description": "Finds all occurances of two given boxes (sequence motifs) within a FASTA file",
+      "tool_shed_repository": "segmentation_fold",
+      "panel_section_name": "Annotation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/yhoogstrate/segmentation_fold/smf_utils_find-boxes/smf-v1.7-0_utils-v2.1.1-1"
+    },
+    {
+      "name": "filter-by-energy",
+      "id": "smf_utils_filter-by-energy",
+      "description": "Split entries over two files based on the estimated energy",
+      "tool_shed_repository": "segmentation_fold",
+      "panel_section_name": "Annotation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/yhoogstrate/segmentation_fold/smf_utils_filter-by-energy/smf-v1.7-0_utils-v2.1.1-1"
+    },
+    {
+      "name": "extract-boxed-sequences",
+      "id": "smf_utils_extract-boxed-sequences",
+      "description": "Extracts boxed sequences from bed_input_file which has to be created with 'find-box', part of this utility",
+      "tool_shed_repository": "segmentation_fold",
+      "panel_section_name": "Annotation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/yhoogstrate/segmentation_fold/smf_utils_extract-boxed-sequences/smf-v1.7-0_utils-v2.1.1-1"
+    },
+    {
+      "name": "segmentation-fold",
+      "id": "segmentation_fold",
+      "description": "RNA-Folding including predefined segments including K-turns",
+      "tool_shed_repository": "segmentation_fold",
+      "panel_section_name": "Annotation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/yhoogstrate/segmentation_fold/segmentation_fold/0.2.0"
+    },
+    {
+      "name": "Gubbins",
+      "id": "gubbins",
+      "description": "Recombination detection in Bacteria",
+      "tool_shed_repository": "gubbins",
+      "panel_section_name": "Annotation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/gubbins/gubbins/0.1.0"
+    },
+    {
+      "name": "ProbMetab Tool",
+      "id": "Probmetab",
+      "description": "Wrapper function for ProbMetab R package.",
+      "tool_shed_repository": "probmetab",
+      "panel_section_name": "Annotation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/mmonsoor/probmetab/Probmetab/1.0.1"
+    },
+    {
+      "name": "LC/MS matching",
+      "id": "lcmsmatching",
+      "description": "Annotation of MS peaks using matching on a spectra database.",
+      "tool_shed_repository": "lcmsmatching",
+      "panel_section_name": "Annotation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/prog/lcmsmatching/lcmsmatching/3.0"
+    },
+    {
+      "name": "Nucleosome Predictions",
+      "id": "Nucleosome",
+      "description": "",
+      "tool_shed_repository": "nucleosome_prediction",
+      "panel_section_name": "Annotation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/nucleosome_prediction/Nucleosome/3.0"
+    },
+    {
+      "name": "miRanda",
+      "id": "miranda",
+      "description": "finds potential target sites for miRNAs in genomic sequences",
+      "tool_shed_repository": "miranda",
+      "panel_section_name": "Annotation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/tgac/miranda/miranda/3.3a"
+    },
+    {
+      "name": "DotKnot",
+      "id": "dotknot",
+      "description": "pseudoknot prediction in a given RNA sequence",
+      "tool_shed_repository": "dotknot",
+      "panel_section_name": "Annotation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/dotknot/dotknot/1.3.1"
+    },
+    {
+      "name": "Blast2GO",
+      "id": "blast2go",
+      "description": "Maps BLAST results to GO annotation terms",
+      "tool_shed_repository": "blast2go",
+      "panel_section_name": "Annotation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/peterjc/blast2go/blast2go/0.0.9"
+    },
+    {
+      "name": "nhmmer",
+      "id": "hmmer_nhmmer",
+      "description": "search a DNA model or alignment against a DNA database (BLASTN-like)",
+      "tool_shed_repository": "hmmer3",
+      "panel_section_name": "Annotation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/hmmer3/hmmer_nhmmer/0.1.0"
+    },
+    {
+      "name": "hmmsearch",
+      "id": "hmmer_hmmsearch",
+      "description": "search profile(s) against a sequence database",
+      "tool_shed_repository": "hmmer3",
+      "panel_section_name": "Annotation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/hmmer3/hmmer_hmmsearch/0.1.0"
+    },
+    {
+      "name": "hmmconvert",
+      "id": "hmmer_hmmconvert",
+      "description": "convert profile file to a HMMER format",
+      "tool_shed_repository": "hmmer3",
+      "panel_section_name": "Annotation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/hmmer3/hmmer_hmmconvert/0.1.0"
+    },
+    {
+      "name": "hmmfetch",
+      "id": "hmmer_hmmfetch",
+      "description": "retrieve profile HMM(s) from a file",
+      "tool_shed_repository": "hmmer3",
+      "panel_section_name": "Annotation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/hmmer3/hmmer_hmmfetch/0.1.0"
+    },
+    {
+      "name": "jackhmmer",
+      "id": "hmmer_jackhmmer",
+      "description": "iteratively search a protein sequence against a protein database (PSIBLAST-like)",
+      "tool_shed_repository": "hmmer3",
+      "panel_section_name": "Annotation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/hmmer3/hmmer_jackhmmer/0.1.0"
+    },
+    {
+      "name": "alimask",
+      "id": "hmmer_alimask",
+      "description": "append modelmask line to a multiple sequence alignments",
+      "tool_shed_repository": "hmmer3",
+      "panel_section_name": "Annotation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/hmmer3/hmmer_alimask/0.1.0"
+    },
+    {
+      "name": "hmmscan",
+      "id": "hmmer_hmmscan",
+      "description": "search sequence(s) against a profile database",
+      "tool_shed_repository": "hmmer3",
+      "panel_section_name": "Annotation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/hmmer3/hmmer_hmmscan/0.1.0"
+    },
+    {
+      "name": "nhmmscan",
+      "id": "hmmer_nhmmscan",
+      "description": "search DNA sequence(s) against a DNA profile database",
+      "tool_shed_repository": "hmmer3",
+      "panel_section_name": "Annotation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/hmmer3/hmmer_nhmmscan/0.1.0"
+    },
+    {
+      "name": "hmmemit",
+      "id": "hmmer_hmmemit",
+      "description": "sample sequence(s) from a profile HMM",
+      "tool_shed_repository": "hmmer3",
+      "panel_section_name": "Annotation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/hmmer3/hmmer_hmmemit/0.1.0"
+    },
+    {
+      "name": "phmmer",
+      "id": "hmmer_phmmer",
+      "description": "search a protein sequence against a protein database (BLASTP-like)",
+      "tool_shed_repository": "hmmer3",
+      "panel_section_name": "Annotation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/hmmer3/hmmer_phmmer/0.1.0"
+    },
+    {
+      "name": "hmmalign",
+      "id": "hmmer_hmmalign",
+      "description": "align sequences to a profile HMM",
+      "tool_shed_repository": "hmmer3",
+      "panel_section_name": "Annotation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/hmmer3/hmmer_hmmalign/0.1.0"
+    },
+    {
+      "name": "hmmbuild",
+      "id": "hmmer_hmmbuild",
+      "description": "Build a profile HMM from an input multiple alignment",
+      "tool_shed_repository": "hmmer3",
+      "panel_section_name": "Annotation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/hmmer3/hmmer_hmmbuild/0.1.0"
+    },
+    {
+      "name": "Nucleotide subsequence search",
+      "id": "bg_find_subsequences",
+      "description": "providing regions in BED format",
+      "tool_shed_repository": "find_subsequences",
+      "panel_section_name": "Annotation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/find_subsequences/bg_find_subsequences/0.2"
+    },
+    {
+      "name": "GotohScan",
+      "id": "rbc_gotohscan",
+      "description": "Find subsequences in db",
+      "tool_shed_repository": "gotohscan",
+      "panel_section_name": "Annotation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/rnateam/gotohscan/rbc_gotohscan/1.3.0"
+    },
+    {
+      "name": "CryptoGenotyper",
+      "id": "CryptoGenotyper",
+      "description": "classifies Cryptosporidium species subtypes based on SSU rRNA and gp60 gene markers from Sanger sequencing data.",
+      "tool_shed_repository": "cryptogenotyper",
+      "panel_section_name": "Annotation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/nml/cryptogenotyper/CryptoGenotyper/1.0+galaxy0"
+    },
+    {
+      "name": "Interproscan functional predictions of ORFs",
+      "id": "interproscan",
+      "description": "Interproscan functional predictions of ORFs",
+      "tool_shed_repository": "interproscan5",
+      "panel_section_name": "Annotation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/interproscan5/interproscan/5.0.0"
+    },
+    {
+      "name": "Annotate with DGI",
+      "id": "dgidb_annotator",
+      "description": "database info",
+      "tool_shed_repository": "dgidb_annotator",
+      "panel_section_name": "Annotation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/dgidb_annotator/dgidb_annotator/0.1"
+    },
+    {
+      "name": "Annotate with DGI",
+      "id": "dgidb_annotate",
+      "description": "database info",
+      "tool_shed_repository": "dgidb_annotator",
+      "panel_section_name": "Annotation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/dgidb_annotator/dgidb_annotate/0.1"
+    },
+    {
+      "name": "MAFFT add",
+      "id": "rbc_mafft_add",
+      "description": "Align a sequence,alignment or fragments to an existing alignment.",
+      "tool_shed_repository": "mafft",
+      "panel_section_name": "Multiple Alignments",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/rnateam/mafft/rbc_mafft_add/7.489+galaxy0"
+    },
+    {
+      "name": "MAFFT",
+      "id": "rbc_mafft",
+      "description": "Multiple alignment program for amino acid or nucleotide sequences",
+      "tool_shed_repository": "mafft",
+      "panel_section_name": "Multiple Alignments",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/rnateam/mafft/rbc_mafft/7.489+galaxy0"
+    },
+    {
+      "name": "Chromeister",
+      "id": "chromeister",
+      "description": "ultra-fast pairwise genome comparisons",
+      "tool_shed_repository": "chromeister",
+      "panel_section_name": "Multiple Alignments",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/chromeister/chromeister/1.5.a"
+    },
+    {
+      "name": "ClustalW",
+      "id": "clustalw",
+      "description": "multiple sequence alignment program for DNA or proteins",
+      "tool_shed_repository": "clustalw",
+      "panel_section_name": "Multiple Alignments",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/clustalw/clustalw/2.1"
+    },
+    {
+      "name": "SINA",
+      "id": "sina",
+      "description": "reference based multiple sequence alignment",
+      "tool_shed_repository": "sina",
+      "panel_section_name": "Multiple Alignments",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/sina/sina/1.7.2+galaxy0"
+    },
+    {
+      "name": "Gecko",
+      "id": "gecko",
+      "description": "Ungapped genome comparison",
+      "tool_shed_repository": "gecko",
+      "panel_section_name": "Multiple Alignments",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/gecko/gecko/1.2"
+    },
+    {
+      "name": "MAF Coverage Stats",
+      "id": "maf_stats1",
+      "description": "Alignment coverage information",
+      "tool_shed_repository": "maf_stats",
+      "panel_section_name": "Multiple Alignments",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/maf_stats/maf_stats1/1.0.1+galaxy0"
+    },
+    {
+      "name": "Kc-Align",
+      "id": "kc-align",
+      "description": "",
+      "tool_shed_repository": "kc_align",
+      "panel_section_name": "Multiple Alignments",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/kc_align/kc-align/1.0.2"
+    },
+    {
+      "name": "Automated multiple sequence",
+      "id": "pipelign",
+      "description": "alignment with pipelign",
+      "tool_shed_repository": "pipelign",
+      "panel_section_name": "Multiple Alignments",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/pipelign/pipelign/0.2+galaxy0"
+    },
+    {
+      "name": "Select Sequences",
+      "id": "selectsequencesfrommsa",
+      "description": "Tool to select representative sequences from a multiple sequence alignment.",
+      "tool_shed_repository": "selectsequencesfrommsa",
+      "panel_section_name": "Multiple Alignments",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/rnateam/selectsequencesfrommsa/selectsequencesfrommsa/1.0.2"
+    },
+    {
+      "name": "MSABOOT",
+      "id": "msaboot",
+      "description": "Output PHYLIP file with bootstrapped multiple sequence alignment data",
+      "tool_shed_repository": "msaboot",
+      "panel_section_name": "Multiple Alignments",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/msaboot/msaboot/0.1.2"
+    },
+    {
+      "name": "Hammock - cluster peptides",
+      "id": "hammock_1.0",
+      "description": "Clusters short peptide sequences",
+      "tool_shed_repository": "hammock",
+      "panel_section_name": "Multiple Alignments",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/hammock/hammock/hammock_1.0/1.1.1"
+    },
+    {
+      "name": "Format cd-hit outputs",
+      "id": "format_cd_hit_output",
+      "description": "to rename representative sequences with cluster name and/or extract distribution inside clusters given a mapping file",
+      "tool_shed_repository": "format_cd_hit_output",
+      "panel_section_name": "Multiple Alignments",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bebatut/format_cd_hit_output/format_cd_hit_output/1.0.0"
+    },
+    {
+      "name": "MUSCLE",
+      "id": "muscle",
+      "description": "multiple aligner",
+      "tool_shed_repository": "muscle",
+      "panel_section_name": "Multiple Alignments",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/crs4/muscle/muscle/0.0.11"
+    },
+    {
+      "name": "Compalignp",
+      "id": "compalignp",
+      "description": "Fractional identities between alignments",
+      "tool_shed_repository": "compalignp",
+      "panel_section_name": "Multiple Alignments",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/rnateam/compalignp/compalignp/1.0"
+    },
+    {
+      "name": "Raven",
+      "id": "raven",
+      "description": "De novo assembly of Oxford Nanopore Technologies data",
+      "tool_shed_repository": "raven",
+      "panel_section_name": "Assembly",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/raven/raven/1.8.0+galaxy0"
+    },
+    {
+      "name": "coronaSPAdes",
+      "id": "spades_coronaspades",
+      "description": "SARS-CoV-2 de novo genome assembler",
+      "tool_shed_repository": "spades_coronaspades",
+      "panel_section_name": "Assembly",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/spades_coronaspades/spades_coronaspades/3.15.4+galaxy0"
+    },
+    {
+      "name": "metaviralSPAdes",
+      "id": "spades_metaviralspades",
+      "description": "extract and assembly viral genomes from metagenomic data",
+      "tool_shed_repository": "spades_metaviralspades",
+      "panel_section_name": "Assembly",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/spades_metaviralspades/spades_metaviralspades/3.15.4+galaxy0"
+    },
+    {
+      "name": "plasmidSPAdes",
+      "id": "spades_plasmidspades",
+      "description": "extract and assembly plasmids from WGS data",
+      "tool_shed_repository": "spades_plasmidspades",
+      "panel_section_name": "Assembly",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/spades_plasmidspades/spades_plasmidspades/3.15.4+galaxy0"
+    },
+    {
+      "name": "rnaviralSPAdes",
+      "id": "spades_rnaviralspades",
+      "description": "de novo assembler for transcriptomes, metatranscriptomes and metaviromes",
+      "tool_shed_repository": "spades_rnaviralspades",
+      "panel_section_name": "Assembly",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/spades_rnaviralspades/spades_rnaviralspades/3.15.4+galaxy0"
+    },
+    {
+      "name": "SPAdes",
+      "id": "spades",
+      "description": "genome assembler for genomes of regular and single-cell projects",
+      "tool_shed_repository": "spades",
+      "panel_section_name": "Assembly",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/nml/spades/spades/3.15.4+galaxy0"
+    },
+    {
+      "name": "metaSPAdes",
+      "id": "metaspades",
+      "description": "metagenome assembler",
+      "tool_shed_repository": "metaspades",
+      "panel_section_name": "Assembly",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/nml/metaspades/metaspades/3.15.4+galaxy0"
+    },
+    {
+      "name": "biosyntheticSPAdes",
+      "id": "spades_biosyntheticspades",
+      "description": "biosynthetic gene cluster assembly",
+      "tool_shed_repository": "spades_biosyntheticspades",
+      "panel_section_name": "Assembly",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/spades_biosyntheticspades/spades_biosyntheticspades/3.15.4+galaxy0"
+    },
+    {
+      "name": "metaplasmidSPAdes",
+      "id": "spades_metaplasmidspades",
+      "description": "extract and assembly plasmids from metagenomic data",
+      "tool_shed_repository": "spades_metaplasmidspades",
+      "panel_section_name": "Assembly",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/spades_metaplasmidspades/spades_metaplasmidspades/3.15.4+galaxy0"
+    },
+    {
+      "name": "Bionano Hybrid Scaffold",
+      "id": "bionano_scaffold",
+      "description": "automates the scaffolding process",
+      "tool_shed_repository": "bionano_scaffold",
+      "panel_section_name": "Assembly",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/bionano_scaffold/bionano_scaffold/3.7.0+galaxy0"
+    },
+    {
+      "name": "rnaSPAdes",
+      "id": "rnaspades",
+      "description": "de novo transcriptome assembler",
+      "tool_shed_repository": "rnaspades",
+      "panel_section_name": "Assembly",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/rnaspades/rnaspades/3.15.4+galaxy0"
+    },
+    {
+      "name": "Trycycler cluster",
+      "id": "trycycler_cluster",
+      "description": "cluster the contigs of your input assemblies into per-replicon groups",
+      "tool_shed_repository": "trycycler_cluster",
+      "panel_section_name": "Assembly",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/trycycler_cluster/trycycler_cluster/0.5.3"
+    },
+    {
+      "name": "Trycycler consensus",
+      "id": "trycycler_consensus",
+      "description": "generate a consensus contig sequence for each cluster",
+      "tool_shed_repository": "trycycler_consensus",
+      "panel_section_name": "Assembly",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/trycycler_consensus/trycycler_consensus/0.5.3"
+    },
+    {
+      "name": "Trycycler partition",
+      "id": "trycycler_partition",
+      "description": "assign the reads to the clusters",
+      "tool_shed_repository": "trycycler_partition",
+      "panel_section_name": "Assembly",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/trycycler_partition/trycycler_partition/0.5.3"
+    },
+    {
+      "name": "Trycycler reconcile/msa",
+      "id": "trycycler_reconcile_msa",
+      "description": "reconcile the contigs within each cluster and perform a multiple sequence alignment",
+      "tool_shed_repository": "trycycler_reconcile_msa",
+      "panel_section_name": "Assembly",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/trycycler_reconcile_msa/trycycler_reconcile_msa/0.5.3"
+    },
+    {
+      "name": "Trycycler subsample",
+      "id": "trycycler_subsample",
+      "description": "make a maximally-independent read subsets of an appropiate depth for your genome",
+      "tool_shed_repository": "trycycler_subsample",
+      "panel_section_name": "Assembly",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/trycycler_subsample/trycycler_subsample/0.5.3"
+    },
+    {
+      "name": "NOVOplasty",
+      "id": "novoplasty",
+      "description": "de novo assembler for short circular genomes",
+      "tool_shed_repository": "novoplasty",
+      "panel_section_name": "Assembly",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/novoplasty/novoplasty/4.3.1+galaxy0"
+    },
+    {
+      "name": "Flye",
+      "id": "flye",
+      "description": "de novo assembler for single molecule sequencing reads",
+      "tool_shed_repository": "flye",
+      "panel_section_name": "Assembly",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/flye/flye/2.9+galaxy0"
+    },
+    {
+      "name": "PretextMap",
+      "id": "pretext_map",
+      "description": "converts SAM or BAM files into genome contact maps",
+      "tool_shed_repository": "pretext_map",
+      "panel_section_name": "Assembly",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/pretext_map/pretext_map/0.1.9+galaxy0"
+    },
+    {
+      "name": "Hifiasm",
+      "id": "hifiasm",
+      "description": "haplotype-resolved de novo assembler for PacBio Hifi reads",
+      "tool_shed_repository": "hifiasm",
+      "panel_section_name": "Assembly",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/hifiasm/hifiasm/0.16.1+galaxy2"
+    },
+    {
+      "name": "Meryl",
+      "id": "meryl",
+      "description": "a genomic k-mer counter and sequence utility",
+      "tool_shed_repository": "meryl",
+      "panel_section_name": "Assembly",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/meryl/meryl/1.3+galaxy4"
+    },
+    {
+      "name": "GenomeScope",
+      "id": "genomescope",
+      "description": "reference-free genome profiling",
+      "tool_shed_repository": "genomescope",
+      "panel_section_name": "Assembly",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/genomescope/genomescope/2.0+galaxy1"
+    },
+    {
+      "name": "MitoHiFi",
+      "id": "mitohifi",
+      "description": "assembly mitogenomes from Pacbio HiFi reads",
+      "tool_shed_repository": "mitohifi",
+      "panel_section_name": "Assembly",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/mitohifi/mitohifi/2+galaxy0"
+    },
+    {
+      "name": "Filter and merge",
+      "id": "bellerophon",
+      "description": "chimeric reads from Arima Genomics",
+      "tool_shed_repository": "bellerophon",
+      "panel_section_name": "Assembly",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/bellerophon/bellerophon/1.0+galaxy0"
+    },
+    {
+      "name": "DISCO",
+      "id": "disco",
+      "description": "to assemble metagenomics data using an overlap-layout-consensus (OLC) approach",
+      "tool_shed_repository": "disco",
+      "panel_section_name": "Assembly",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/disco/disco/1.2.1"
+    },
+    {
+      "name": "miniasm",
+      "id": "miniasm",
+      "description": "Ultrafast de novo assembly for long noisy reads",
+      "tool_shed_repository": "miniasm",
+      "panel_section_name": "Assembly",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/miniasm/miniasm/0.3_r179+galaxy1"
+    },
+    {
+      "name": "Racon",
+      "id": "racon",
+      "description": "Consensus module for raw de novo DNA assembly of long uncorrected reads.",
+      "tool_shed_repository": "racon",
+      "panel_section_name": "Assembly",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/racon/racon/1.4.20+galaxy0"
+    },
+    {
+      "name": "Lordec",
+      "id": "lordec",
+      "description": "is a set a programs for correcting sequencing errors in PacBio reads",
+      "tool_shed_repository": "colibread_lordec",
+      "panel_section_name": "Assembly",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/colibread_lordec/lordec/0.9+galaxy2"
+    },
+    {
+      "name": "MITObim",
+      "id": "mitobim",
+      "description": "mitochondrial baiting and iterative mapping",
+      "tool_shed_repository": "mitobim",
+      "panel_section_name": "Assembly",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/mitobim/mitobim/1.9.1"
+    },
+    {
+      "name": "TrimN",
+      "id": "trimns",
+      "description": "",
+      "tool_shed_repository": "trimns",
+      "panel_section_name": "Assembly",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/trimns/trimns/0.1.0"
+    },
+    {
+      "name": "Shasta",
+      "id": "shasta",
+      "description": "De novo assembly of long read sequencing data",
+      "tool_shed_repository": "shasta",
+      "panel_section_name": "Assembly",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/shasta/shasta/0.6.0+galaxy0"
+    },
+    {
+      "name": "IDBA-TRAN",
+      "id": "idba_tran",
+      "description": "Iterative de Bruijn Graph Assembler for transcriptome data",
+      "tool_shed_repository": "idba_tran",
+      "panel_section_name": "Assembly",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/idba_tran/idba_tran/1.1.3+galaxy0"
+    },
+    {
+      "name": "Create assemblies with Unicycler",
+      "id": "unicycler",
+      "description": "",
+      "tool_shed_repository": "unicycler",
+      "panel_section_name": "Assembly",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/unicycler/unicycler/0.4.8.0"
+    },
+    {
+      "name": "IDBA-UD",
+      "id": "idba_ud",
+      "description": "Iterative de Bruijn Graph Assembler for data with highly uneven depth",
+      "tool_shed_repository": "idba_ud",
+      "panel_section_name": "Assembly",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/idba_ud/idba_ud/1.1.3+galaxy1"
+    },
+    {
+      "name": "IDBA-HYBRID",
+      "id": "idba_hybrid",
+      "description": "Iterative de Bruijn Graph Assembler for hybrid sequencing data",
+      "tool_shed_repository": "idba_hybrid",
+      "panel_section_name": "Assembly",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/idba_hybrid/idba_hybrid/1.1.3"
+    },
+    {
+      "name": "VelvetOptimiser",
+      "id": "velvetoptimiser",
+      "description": "Automatically optimize Velvet assemblies",
+      "tool_shed_repository": "velvetoptimiser",
+      "panel_section_name": "Assembly",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/simon-gladman/velvetoptimiser/velvetoptimiser/2.2.6"
+    },
+    {
+      "name": "pilon",
+      "id": "pilon",
+      "description": "An automated genome assembly improvement and variant detection tool",
+      "tool_shed_repository": "pilon",
+      "panel_section_name": "Assembly",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/pilon/pilon/1.20.1"
+    },
+    {
+      "name": "WTDBG",
+      "id": "wtdbg",
+      "description": "De novo assembler AND consensuser for long noisy sequences",
+      "tool_shed_repository": "wtdbg",
+      "panel_section_name": "Assembly",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/wtdbg/wtdbg/1.2.8.1"
+    },
+    {
+      "name": "Assemble with MIRA v3.4",
+      "id": "mira_assembler",
+      "description": "Takes Sanger, Roche, Illumina, and Ion Torrent data",
+      "tool_shed_repository": "mira_assembler",
+      "panel_section_name": "Assembly",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/peterjc/mira_assembler/mira_assembler/0.0.11"
+    },
+    {
+      "name": "Edena (assembling)",
+      "id": "edena_ass_wrapper",
+      "description": "",
+      "tool_shed_repository": "edena",
+      "panel_section_name": "Assembly",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/crs4/edena/edena_ass_wrapper/0.3"
+    },
+    {
+      "name": "Edena (overlapping)",
+      "id": "edena_ovl_wrapper",
+      "description": "",
+      "tool_shed_repository": "edena",
+      "panel_section_name": "Assembly",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/crs4/edena/edena_ovl_wrapper/0.3"
+    },
+    {
+      "name": "SOPRA with prebuilt contigs",
+      "id": "sopra_wpc",
+      "description": "for Illumina libraries",
+      "tool_shed_repository": "sopra",
+      "panel_section_name": "Assembly",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/crs4/sopra/sopra_wpc/0.1"
+    },
+    {
+      "name": "SSAKE",
+      "id": "ssake",
+      "description": "short DNA sequences assembler",
+      "tool_shed_repository": "ssake",
+      "panel_section_name": "Assembly",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/crs4/ssake/ssake/0.0.10"
+    },
+    {
+      "name": "CRISPR Recognition Tool",
+      "id": "crispr_recognition_tool",
+      "description": "(CRT)",
+      "tool_shed_repository": "crispr_recognition_tool",
+      "panel_section_name": "Assembly",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/crispr_recognition_tool/crispr_recognition_tool/1.2.0"
+    },
+    {
+      "name": "detect CRISPR sequences",
+      "id": "minced",
+      "description": "(minced)",
+      "tool_shed_repository": "minced",
+      "panel_section_name": "Assembly",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/minced/minced/0.1.5"
+    },
+    {
+      "name": "BBTools: BBMap",
+      "id": "bbtools_bbmap",
+      "description": "short-read aligner",
+      "tool_shed_repository": "bbtools_bbmap",
+      "panel_section_name": "Mapping",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/bbtools_bbmap/bbtools_bbmap/1.0.0+galaxy4"
+    },
+    {
+      "name": "Map with KMA",
+      "id": "kma_map",
+      "description": "",
+      "tool_shed_repository": "kma",
+      "panel_section_name": "Mapping",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/kma/kma_map/1.2.21+galaxy1"
+    },
+    {
+      "name": "Align sequences",
+      "id": "bioext_bealign",
+      "description": "to a reference using a codon alignment algorithm",
+      "tool_shed_repository": "bioext_bealign",
+      "panel_section_name": "Mapping",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/bioext_bealign/bioext_bealign/0.20.4+galaxy0"
+    },
+    {
+      "name": "HISAT2",
+      "id": "hisat2",
+      "description": "A fast and sensitive alignment program",
+      "tool_shed_repository": "hisat2",
+      "panel_section_name": "Mapping",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/hisat2/hisat2/2.2.1+galaxy0"
+    },
+    {
+      "name": "Winnowmap",
+      "id": "winnowmap",
+      "description": "a mapping tool optimized for repetitive sequences",
+      "tool_shed_repository": "winnowmap",
+      "panel_section_name": "Mapping",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/winnowmap/winnowmap/2.03+galaxy1"
+    },
+    {
+      "name": "Map with BWA-MEM",
+      "id": "bwa_mem",
+      "description": "- map medium and long reads (> 100 bp) against reference genome",
+      "tool_shed_repository": "bwa",
+      "panel_section_name": "Mapping",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/bwa/bwa_mem/0.7.17.2"
+    },
+    {
+      "name": "Parse blast XML output",
+      "id": "megablast_xml_parser",
+      "description": "",
+      "tool_shed_repository": "megablast_xml_parser",
+      "panel_section_name": "Mapping",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/megablast_xml_parser/megablast_xml_parser/1.0.1"
+    },
+    {
+      "name": "Megablast",
+      "id": "megablast_wrapper",
+      "description": "compare short reads against htgs, nt, and wgs databases",
+      "tool_shed_repository": "megablast_wrapper",
+      "panel_section_name": "Mapping",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/megablast_wrapper/megablast_wrapper/1.2.0"
+    },
+    {
+      "name": "Lastz paired reads",
+      "id": "lastz_paired_reads_wrapper",
+      "description": "map short paired reads against reference sequence",
+      "tool_shed_repository": "lastz_paired_reads",
+      "panel_section_name": "Mapping",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/lastz_paired_reads/lastz_paired_reads_wrapper/1.1.1"
+    },
+    {
+      "name": "Map with Bowtie for Illumina",
+      "id": "bowtie_wrapper",
+      "description": "",
+      "tool_shed_repository": "bowtie_wrappers",
+      "panel_section_name": "Mapping",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/bowtie_wrappers/bowtie_wrapper/1.2.0"
+    },
+    {
+      "name": "Bismark Mapper",
+      "id": "bismark_bowtie2",
+      "description": "Bisulfite reads mapper",
+      "tool_shed_repository": "bismark",
+      "panel_section_name": "Mapping",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/bismark/bismark_bowtie2/0.22.1+galaxy4"
+    },
+    {
+      "name": "STAR-Fusion",
+      "id": "star_fusion",
+      "description": "detect fusion genes in RNA-Seq data",
+      "tool_shed_repository": "star_fusion",
+      "panel_section_name": "Mapping",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/star_fusion/star_fusion/0.5.4-3+galaxy1"
+    },
+    {
+      "name": "Bismark Deduplicate",
+      "id": "bismark_deduplicate",
+      "description": "Deduplicates reads mapped by Bismark",
+      "tool_shed_repository": "bismark",
+      "panel_section_name": "Mapping",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/bismark/bismark_deduplicate/0.22.1"
+    },
+    {
+      "name": "Bismark Pretty Report",
+      "id": "bismark_pretty_report",
+      "description": "Generates a graphical HTML report page from report outputs of Bismark",
+      "tool_shed_repository": "bismark",
+      "panel_section_name": "Mapping",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/bismark/bismark_pretty_report/0.22.1"
+    },
+    {
+      "name": "Bismark Meth. Extractor",
+      "id": "bismark_methylation_extractor",
+      "description": "Reports on methylation status of reads mapped by Bismark",
+      "tool_shed_repository": "bismark",
+      "panel_section_name": "Mapping",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/bismark/bismark_methylation_extractor/0.22.1"
+    },
+    {
+      "name": "segemehl",
+      "id": "segemehl",
+      "description": "short read mapping with gaps",
+      "tool_shed_repository": "segemehl",
+      "panel_section_name": "Mapping",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/rnateam/segemehl/segemehl/0.2.0.4"
+    },
+    {
+      "name": "Owler",
+      "id": "graphmap_overlap",
+      "description": "fast, trimmed overlap pipeline without aligning",
+      "tool_shed_repository": "graphmap_overlap",
+      "panel_section_name": "Mapping",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/graphmap_overlap/graphmap_overlap/0.5.2"
+    },
+    {
+      "name": "Mapper",
+      "id": "graphmap_align",
+      "description": "for long, error-prone reads, like Nanopore ONT and PacBio",
+      "tool_shed_repository": "graphmap_align",
+      "panel_section_name": "Mapping",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/graphmap_align/graphmap_align/0.5.2"
+    },
+    {
+      "name": "Bismark",
+      "id": "bismark_bowtie",
+      "description": "bisulfite mapper (bowtie)",
+      "tool_shed_repository": "bismark",
+      "panel_section_name": "Mapping",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/bismark/bismark_bowtie/0.7.12"
+    },
+    {
+      "name": "Map with BWA",
+      "id": "bwa",
+      "description": "- map short reads (< 100 bp) against reference genome",
+      "tool_shed_repository": "bwa",
+      "panel_section_name": "Mapping",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/bwa/bwa/0.7.17.4"
+    },
+    {
+      "name": "TopHat",
+      "id": "tophat2",
+      "description": "Gapped-read mapper for RNA-seq data",
+      "tool_shed_repository": "tophat2",
+      "panel_section_name": "Mapping",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/tophat2/tophat2/2.1.1"
+    },
+    {
+      "name": "Map with Bowtie for SOLiD",
+      "id": "bowtie_color_wrapper",
+      "description": "",
+      "tool_shed_repository": "bowtie_color_wrappers",
+      "panel_section_name": "Mapping",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/bowtie_color_wrappers/bowtie_color_wrapper/1.1.2"
+    },
+    {
+      "name": "BBTools: call variants",
+      "id": "bbtools_callvariants",
+      "description": "in aligned Bam files",
+      "tool_shed_repository": "bbtools_callvariants",
+      "panel_section_name": "Variant Calling",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/bbtools_callvariants/bbtools_callvariants/1.0.0+galaxy3"
+    },
+    {
+      "name": "pharmCAT",
+      "id": "pharmcat",
+      "description": "Pharmacogenomics Clinical Annotation Tool",
+      "tool_shed_repository": "pharmcat",
+      "panel_section_name": "Variant Calling",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/pharmcat/pharmcat/1.3.1+galaxy0"
+    },
+    {
+      "name": "seqwish",
+      "id": "seqwish",
+      "description": "Alignment to variation graph inducer",
+      "tool_shed_repository": "seqwish",
+      "panel_section_name": "Variant Calling",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/seqwish/seqwish/0.7.4"
+    },
+    {
+      "name": "VCFcheck:",
+      "id": "vcfcheck",
+      "description": "Verify that the reference allele matches the reference genome",
+      "tool_shed_repository": "vcfcheck",
+      "panel_section_name": "Variant Calling",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/vcfcheck/vcfcheck/1.0.0_rc3+galaxy0"
+    },
+    {
+      "name": "VarScan somatic",
+      "id": "varscan_somatic",
+      "description": "Call germline/somatic and LOH variants from tumor-normal sample pairs",
+      "tool_shed_repository": "varscan_somatic",
+      "panel_section_name": "Variant Calling",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/varscan_somatic/varscan_somatic/2.4.3.6"
+    },
+    {
+      "name": "VarScan copynumber",
+      "id": "varscan_copynumber",
+      "description": "Determine relative tumor copy number from tumor-normal pileups",
+      "tool_shed_repository": "varscan_copynumber",
+      "panel_section_name": "Variant Calling",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/varscan_copynumber/varscan_copynumber/2.4.3.2"
+    },
+    {
+      "name": "VarScan mpileup",
+      "id": "varscan_mpileup",
+      "description": "for variant detection",
+      "tool_shed_repository": "varscan_mpileup",
+      "panel_section_name": "Variant Calling",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/varscan_mpileup/varscan_mpileup/2.4.3.1"
+    },
+    {
+      "name": "Delly classify",
+      "id": "delly_classify",
+      "description": "somatic or germline copy-number variants",
+      "tool_shed_repository": "delly_classify",
+      "panel_section_name": "Variant Calling",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/delly_classify/delly_classify/0.9.1+galaxy0"
+    },
+    {
+      "name": "GATK4 Mutect2",
+      "id": "gatk4_mutect2",
+      "description": "- Call somatic SNVs and indels via local assembly of haplotypes",
+      "tool_shed_repository": "gatk4_mutect2",
+      "panel_section_name": "Variant Calling",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/gatk4_mutect2/gatk4_mutect2/4.1.7.0+galaxy1"
+    },
+    {
+      "name": "DeepVariant",
+      "id": "deepvariant",
+      "description": "deep learning-based variant caller",
+      "tool_shed_repository": "deepvariant",
+      "panel_section_name": "Variant Calling",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/deepvariant/deepvariant/1.2.0+galaxy1"
+    },
+    {
+      "name": "snippy-core",
+      "id": "snippy_core",
+      "description": "Combine multiple Snippy outputs into a core SNP alignment",
+      "tool_shed_repository": "snippy",
+      "panel_section_name": "Variant Calling",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/snippy/snippy_core/4.6.0+galaxy0"
+    },
+    {
+      "name": "snippy",
+      "id": "snippy",
+      "description": "Snippy finds SNPs between a haploid reference genome and your NGS sequence reads.",
+      "tool_shed_repository": "snippy",
+      "panel_section_name": "Variant Calling",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/snippy/snippy/4.6.0+galaxy0"
+    },
+    {
+      "name": "snippy-clean_full_aln",
+      "id": "snippy_clean_full_aln",
+      "description": "Replace any non-standard sequence characters in snippy 'core.full.aln' file.",
+      "tool_shed_repository": "snippy",
+      "panel_section_name": "Variant Calling",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/snippy/snippy_clean_full_aln/4.6.0+galaxy0"
+    },
+    {
+      "name": "LUMPY",
+      "id": "lumpy_sv",
+      "description": "is a probabilistic framework for structural variant discovery",
+      "tool_shed_repository": "lumpy_sv",
+      "panel_section_name": "Variant Calling",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/lumpy_sv/lumpy_sv/0.3.1+galaxy1"
+    },
+    {
+      "name": "Beagle",
+      "id": "beagle",
+      "description": "phasing genotypes and imputing ungenotyped markers",
+      "tool_shed_repository": "beagle",
+      "panel_section_name": "Variant Calling",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/beagle/beagle/5.2_21Apr21.304+galaxy0"
+    },
+    {
+      "name": "Iris",
+      "id": "irissv",
+      "description": "Refine insertion sequences",
+      "tool_shed_repository": "irissv",
+      "panel_section_name": "Variant Calling",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/irissv/irissv/1.0.4+galaxy1"
+    },
+    {
+      "name": "JasmineSV",
+      "id": "jasminesv",
+      "description": "Merge structural variants across samples",
+      "tool_shed_repository": "jasminesv",
+      "panel_section_name": "Variant Calling",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/jasminesv/jasminesv/1.0.11+galaxy1"
+    },
+    {
+      "name": "sansa annotate",
+      "id": "sansa_annotate",
+      "description": "structural variants",
+      "tool_shed_repository": "sansa_annotate",
+      "panel_section_name": "Variant Calling",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/sansa_annotate/sansa_annotate/0.0.8+galaxy0"
+    },
+    {
+      "name": "Strelka Germline",
+      "id": "strelka_germline",
+      "description": "small variant caller for germline variation in small cohorts",
+      "tool_shed_repository": "strelka_germline",
+      "panel_section_name": "Variant Calling",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/strelka_germline/strelka_germline/2.9.10+galaxy0"
+    },
+    {
+      "name": "Get homopolymer run length",
+      "id": "get_hrun",
+      "description": "Annotate indel variants with homopolymer context",
+      "tool_shed_repository": "get_hrun",
+      "panel_section_name": "Variant Calling",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/get_hrun/get_hrun/1.0+galaxy0"
+    },
+    {
+      "name": "Strelka Somatic",
+      "id": "strelka_somatic",
+      "description": "small variant caller for somatic variation in tumor/normal sample pairs",
+      "tool_shed_repository": "strelka_somatic",
+      "panel_section_name": "Variant Calling",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/strelka_somatic/strelka_somatic/2.9.10+galaxy0"
+    },
+    {
+      "name": "LUMPY preprocessing",
+      "id": "lumpy_prep",
+      "description": "extracts discordant read pairs and split-read alignments from a BAM dataset",
+      "tool_shed_repository": "lumpy_prep",
+      "panel_section_name": "Variant Calling",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/lumpy_prep/lumpy_prep/0.3.1+galaxy1"
+    },
+    {
+      "name": "KING",
+      "id": "king",
+      "description": "Kinship-based INference for GWAS",
+      "tool_shed_repository": "king",
+      "panel_section_name": "Variant Calling",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/king/king/2.2.4+galaxy0"
+    },
+    {
+      "name": "VarDict",
+      "id": "vardict_java",
+      "description": "calls SNVs and indels for tumor-normal pairs",
+      "tool_shed_repository": "vardict_java",
+      "panel_section_name": "Variant Calling",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/vardict_java/vardict_java/1.8.3+galaxy1"
+    },
+    {
+      "name": "ARTIC guppyplex",
+      "id": "artic_guppyplex",
+      "description": "Filter Nanopore reads by read length and (optionally) quality",
+      "tool_shed_repository": "artic_guppyplex",
+      "panel_section_name": "Variant Calling",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/artic_guppyplex/artic_guppyplex/1.2.1+galaxy2"
+    },
+    {
+      "name": "Variant Frequency Plot",
+      "id": "snpfreqplot",
+      "description": "Generates a heatmap of allele frequencies grouped by variant type for SnpEff-annotated SARS-CoV-2 data",
+      "tool_shed_repository": "snpfreqplot",
+      "panel_section_name": "Variant Calling",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/snpfreqplot/snpfreqplot/1.0+galaxy3"
+    },
+    {
+      "name": "DCS mutations to tags/reads:",
+      "id": "mut2read",
+      "description": "Extracts all tags that carry a mutation in the duplex consensus sequence (DCS)",
+      "tool_shed_repository": "variant_analyzer",
+      "panel_section_name": "Variant Calling",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/variant_analyzer/mut2read/2.0.0"
+    },
+    {
+      "name": "SnpSift Filter",
+      "id": "snpSift_filter",
+      "description": "Filter variants using arbitrary expressions",
+      "tool_shed_repository": "snpsift",
+      "panel_section_name": "Variant Calling",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/snpsift/snpSift_filter/4.3+t.galaxy1"
+    },
+    {
+      "name": "DCS mutations to SSCS stats:",
+      "id": "mut2sscs",
+      "description": "Extracts all tags from the single stranded consensus sequence (SSCS) bam file that carry a mutation at the same position a mutation is called in the duplex consensus sequence (DCS) and calculates their frequencies",
+      "tool_shed_repository": "variant_analyzer",
+      "panel_section_name": "Variant Calling",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/variant_analyzer/mut2sscs/2.0.0"
+    },
+    {
+      "name": "Call specific mutations in reads:",
+      "id": "read2mut",
+      "description": "Looks for reads with mutation at known positions and calculates frequencies and stats.",
+      "tool_shed_repository": "variant_analyzer",
+      "panel_section_name": "Variant Calling",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/variant_analyzer/read2mut/2.0.0"
+    },
+    {
+      "name": "Lofreq filter",
+      "id": "lofreq_filter",
+      "description": "called variants posteriorly",
+      "tool_shed_repository": "lofreq_filter",
+      "panel_section_name": "Variant Calling",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/lofreq_filter/lofreq_filter/2.1.5+galaxy0"
+    },
+    {
+      "name": "Call variants",
+      "id": "lofreq_call",
+      "description": "with LoFreq",
+      "tool_shed_repository": "lofreq_call",
+      "panel_section_name": "Variant Calling",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/lofreq_call/lofreq_call/2.1.5+galaxy1"
+    },
+    {
+      "name": "cuteSV",
+      "id": "cutesv",
+      "description": "detects long-read-based SVs",
+      "tool_shed_repository": "cutesv",
+      "panel_section_name": "Variant Calling",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/cutesv/cutesv/1.0.8+galaxy0"
+    },
+    {
+      "name": "sniffles",
+      "id": "sniffles",
+      "description": "Structural variation caller using third generation sequencing",
+      "tool_shed_repository": "sniffles",
+      "panel_section_name": "Variant Calling",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/sniffles/sniffles/1.0.12+galaxy0"
+    },
+    {
+      "name": "SnpEff eff:",
+      "id": "snpeff_sars_cov_2",
+      "description": "annotate variants for SARS-CoV-2",
+      "tool_shed_repository": "snpeff_sars_cov_2",
+      "panel_section_name": "Variant Calling",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/snpeff_sars_cov_2/snpeff_sars_cov_2/4.5covid19"
+    },
+    {
+      "name": "Realign reads",
+      "id": "lofreq_viterbi",
+      "description": "with LoFreq viterbi",
+      "tool_shed_repository": "lofreq_viterbi",
+      "panel_section_name": "Variant Calling",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/lofreq_viterbi/lofreq_viterbi/2.1.5+galaxy0"
+    },
+    {
+      "name": "Add LoFreq alignment quality scores",
+      "id": "lofreq_alnqual",
+      "description": "to aligned read SAM/BAM records",
+      "tool_shed_repository": "lofreq_alnqual",
+      "panel_section_name": "Variant Calling",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/lofreq_alnqual/lofreq_alnqual/2.1.5+galaxy0"
+    },
+    {
+      "name": "Insert indel qualities",
+      "id": "lofreq_indelqual",
+      "description": "into a BAM file",
+      "tool_shed_repository": "lofreq_indelqual",
+      "panel_section_name": "Variant Calling",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/lofreq_indelqual/lofreq_indelqual/2.1.5+galaxy0"
+    },
+    {
+      "name": "odgi viz",
+      "id": "odgi_viz",
+      "description": "variation graph visualizations",
+      "tool_shed_repository": "odgi_viz",
+      "panel_section_name": "Variant Calling",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/odgi_viz/odgi_viz/0.3"
+    },
+    {
+      "name": "odgi build",
+      "id": "odgi_build",
+      "description": "construct a dynamic succinct variation graph",
+      "tool_shed_repository": "odgi_build",
+      "panel_section_name": "Variant Calling",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/odgi_build/odgi_build/0.3"
+    },
+    {
+      "name": "vg view",
+      "id": "vg_view",
+      "description": "",
+      "tool_shed_repository": "vg_view",
+      "panel_section_name": "Variant Calling",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/vg_view/vg_view/1.23.0"
+    },
+    {
+      "name": "vg deconstruct",
+      "id": "vg_deconstruct",
+      "description": "construct a dynamic succinct variation graph",
+      "tool_shed_repository": "vg_deconstruct",
+      "panel_section_name": "Variant Calling",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/vg_deconstruct/vg_deconstruct/1.23.0"
+    },
+    {
+      "name": "vg convert",
+      "id": "vg_convert",
+      "description": "",
+      "tool_shed_repository": "vg_convert",
+      "panel_section_name": "Variant Calling",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/vg_convert/vg_convert/1.23.0"
+    },
+    {
+      "name": "VCFselectsamples:",
+      "id": "vcfselectsamples",
+      "description": "Select samples from a VCF dataset",
+      "tool_shed_repository": "vcfselectsamples",
+      "panel_section_name": "Variant Calling",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/vcfselectsamples/vcfselectsamples/1.0.0_rc3+galaxy0"
+    },
+    {
+      "name": "VCFannotateGenotypes:",
+      "id": "vcfannotategenotypes",
+      "description": "Annotate genotypes in a VCF dataset using genotypes from another VCF dataset",
+      "tool_shed_repository": "vcfannotategenotypes",
+      "panel_section_name": "Variant Calling",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/vcfannotategenotypes/vcfannotategenotypes/1.0.0_rc3+galaxy0"
+    },
+    {
+      "name": "VCFdistance:",
+      "id": "vcfdistance",
+      "description": "Calculate distance to the nearest variant",
+      "tool_shed_repository": "vcfdistance",
+      "panel_section_name": "Variant Calling",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/vcfdistance/vcfdistance/1.0.0_rc3+galaxy0"
+    },
+    {
+      "name": "VCFflatten:",
+      "id": "vcfflatten2",
+      "description": "Removes multi-allelic sites by picking the most common alternate",
+      "tool_shed_repository": "vcfflatten",
+      "panel_section_name": "Variant Calling",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/vcfflatten/vcfflatten2/1.0.0_rc3+galaxy0"
+    },
+    {
+      "name": "VCFcommonSamples:",
+      "id": "vcfcommonsamples",
+      "description": "Output records belonging to samples common between two datasets",
+      "tool_shed_repository": "vcfcommonsamples",
+      "panel_section_name": "Variant Calling",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/vcfcommonsamples/vcfcommonsamples/1.0.0_rc3+galaxy0"
+    },
+    {
+      "name": "VCFannotate:",
+      "id": "vcfannotate",
+      "description": "Intersect VCF records with BED annotations",
+      "tool_shed_repository": "vcfannotate",
+      "panel_section_name": "Variant Calling",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/vcfannotate/vcfannotate/1.0.0_rc3+galaxy0"
+    },
+    {
+      "name": "VCF-VCFintersect:",
+      "id": "vcfvcfintersect",
+      "description": "Intersect two VCF datasets",
+      "tool_shed_repository": "vcfvcfintersect",
+      "panel_section_name": "Variant Calling",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/vcfvcfintersect/vcfvcfintersect/1.0.0_rc3+galaxy0"
+    },
+    {
+      "name": "VCFbreakCreateMulti:",
+      "id": "vcfbreakcreatemulti",
+      "description": "Break multiple alleles into multiple records, or combine overallpoing alleles into a single record",
+      "tool_shed_repository": "vcfbreakcreatemulti",
+      "panel_section_name": "Variant Calling",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/vcfbreakcreatemulti/vcfbreakcreatemulti/1.0.0_rc3+galaxy0"
+    },
+    {
+      "name": "VcfAllelicPrimitives:",
+      "id": "vcfallelicprimitives",
+      "description": "Split alleleic primitives (gaps or mismatches) into multiple VCF lines",
+      "tool_shed_repository": "vcfallelicprimitives",
+      "panel_section_name": "Variant Calling",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/vcfallelicprimitives/vcfallelicprimitives/1.0.0_rc3+galaxy0"
+    },
+    {
+      "name": "VCFgenotype-to-haplotype:",
+      "id": "vcfgeno2haplo",
+      "description": "Convert genotype-based phased alleles into haplotype alleles",
+      "tool_shed_repository": "vcfgeno2haplo",
+      "panel_section_name": "Variant Calling",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/vcfgeno2haplo/vcfgeno2haplo/1.0.0_rc3+galaxy0"
+    },
+    {
+      "name": "VCFfilter:",
+      "id": "vcffilter2",
+      "description": "filter VCF data in a variety of attributes",
+      "tool_shed_repository": "vcffilter",
+      "panel_section_name": "Variant Calling",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/vcffilter/vcffilter2/1.0.0_rc3+galaxy3"
+    },
+    {
+      "name": "VCFfixup:",
+      "id": "vcffixup",
+      "description": "Count the allele frequencies across alleles present in each record in the VCF file",
+      "tool_shed_repository": "vcffixup",
+      "panel_section_name": "Variant Calling",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/vcffixup/vcffixup/1.0.0_rc3+galaxy0"
+    },
+    {
+      "name": "VCFgenotypes:",
+      "id": "vcfgenotypes",
+      "description": "Convert numerical representation of genotypes to allelic",
+      "tool_shed_repository": "vcfgenotypes",
+      "panel_section_name": "Variant Calling",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/vcfgenotypes/vcfgenotypes/1.0.0_rc3+galaxy0"
+    },
+    {
+      "name": "VCF-BEDintersect:",
+      "id": "vcfbedintersect",
+      "description": "Intersect VCF and BED datasets",
+      "tool_shed_repository": "vcfbedintersect",
+      "panel_section_name": "Variant Calling",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/vcfbedintersect/vcfbedintersect/1.0.0_rc3+galaxy0"
+    },
+    {
+      "name": "VCFrandomSample:",
+      "id": "vcfrandomsample",
+      "description": "Randomly sample sites from VCF dataset",
+      "tool_shed_repository": "vcfrandomsample",
+      "panel_section_name": "Variant Calling",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/vcfrandomsample/vcfrandomsample/1.0.0_rc3+galaxy0"
+    },
+    {
+      "name": "VCFhetHomAlleles:",
+      "id": "vcfhethom",
+      "description": "Count the number of heterozygotes and alleles, compute het/hom ratio",
+      "tool_shed_repository": "vcfhethom",
+      "panel_section_name": "Variant Calling",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/vcfhethom/vcfhethom/1.0.0_rc3+galaxy0"
+    },
+    {
+      "name": "VCFsort:",
+      "id": "vcfsort",
+      "description": "Sort VCF dataset by coordinate",
+      "tool_shed_repository": "vcfsort",
+      "panel_section_name": "Variant Calling",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/vcfsort/vcfsort/1.0.0_rc3+galaxy0"
+    },
+    {
+      "name": "VCFprimers:",
+      "id": "vcfprimers",
+      "description": "Extract flanking sequences for each VCF record",
+      "tool_shed_repository": "vcfprimers",
+      "panel_section_name": "Variant Calling",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/vcfprimers/vcfprimers/1.0.0_rc3+galaxy0"
+    },
+    {
+      "name": "VCFcombine:",
+      "id": "vcfcombine",
+      "description": "Combine multiple VCF datasets",
+      "tool_shed_repository": "vcfcombine",
+      "panel_section_name": "Variant Calling",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/vcfcombine/vcfcombine/1.0.0_rc3+galaxy0"
+    },
+    {
+      "name": "VCFleftAlign:",
+      "id": "vcfleftalign",
+      "description": "Left-align indels and complex variants in VCF dataset",
+      "tool_shed_repository": "vcfleftalign",
+      "panel_section_name": "Variant Calling",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/vcfleftalign/vcfleftalign/1.0.0_rc3+galaxy0"
+    },
+    {
+      "name": "VCFtoTab-delimited:",
+      "id": "vcf2tsv",
+      "description": "Convert VCF data into TAB-delimited format",
+      "tool_shed_repository": "vcf2tsv",
+      "panel_section_name": "Variant Calling",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/vcf2tsv/vcf2tsv/1.0.0_rc3+galaxy0"
+    },
+    {
+      "name": "VCFaddinfo:",
+      "id": "vcfaddinfo",
+      "description": "Adds info fields from the second dataset which are not present in the first dataset",
+      "tool_shed_repository": "vcfaddinfo",
+      "panel_section_name": "Variant Calling",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/vcfaddinfo/vcfaddinfo/1.0.0_rc3+galaxy0"
+    },
+    {
+      "name": "SnpEff chromosome-info:",
+      "id": "snpEff_get_chr_names",
+      "description": "list chromosome names/lengths",
+      "tool_shed_repository": "snpeff",
+      "panel_section_name": "Variant Calling",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/snpeff/snpEff_get_chr_names/4.3+T.galaxy2"
+    },
+    {
+      "name": "SNP distance matrix",
+      "id": "snp_dists",
+      "description": "Compute distance in SNPs between all sequences in a FASTA file",
+      "tool_shed_repository": "snp_dists",
+      "panel_section_name": "Variant Calling",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/snp_dists/snp_dists/0.6.3+galaxy0"
+    },
+    {
+      "name": "Tag pileup frequency",
+      "id": "tag_pileup_frequency",
+      "description": "",
+      "tool_shed_repository": "tag_pileup_frequency",
+      "panel_section_name": "Variant Calling",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/tag_pileup_frequency/tag_pileup_frequency/1.0.1"
+    },
+    {
+      "name": "Finds SNP sites",
+      "id": "snp_sites",
+      "description": "from a multi-FASTA alignment file",
+      "tool_shed_repository": "snp_sites",
+      "panel_section_name": "Variant Calling",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/snp_sites/snp_sites/2.5.1+galaxy0"
+    },
+    {
+      "name": "ExomeDepth",
+      "id": "exomedepth",
+      "description": "Calls copy number variants (CNVs) from targeted sequence data",
+      "tool_shed_repository": "exomedepth",
+      "panel_section_name": "Variant Calling",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/crs4/exomedepth/exomedepth/1.1.0"
+    },
+    {
+      "name": "SnpEff build:",
+      "id": "snpEff_build_gb",
+      "description": "database from Genbank or GFF record",
+      "tool_shed_repository": "snpeff",
+      "panel_section_name": "Variant Calling",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/snpeff/snpEff_build_gb/4.3+T.galaxy4"
+    },
+    {
+      "name": "MiXCR Analyze",
+      "id": "mixcr_analyze",
+      "description": "immuno clonotyes from sequence data",
+      "tool_shed_repository": "mixcr_analyze",
+      "panel_section_name": "Variant Calling",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/mixcr_analyze/mixcr_analyze/3.0.5.0"
+    },
+    {
+      "name": "TB Variant Filter",
+      "id": "tb_variant_filter",
+      "description": "M. tuberculosis H37Rv VCF filter",
+      "tool_shed_repository": "tb_variant_filter",
+      "panel_section_name": "Variant Calling",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/tb_variant_filter/tb_variant_filter/0.1.3+galaxy0"
+    },
+    {
+      "name": "TB Variant Report",
+      "id": "tbvcfreport",
+      "description": "- generate HTML report from SnpEff annotated M.tb VCF(s)",
+      "tool_shed_repository": "tbvcfreport",
+      "panel_section_name": "Variant Calling",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/tbvcfreport/tbvcfreport/0.1.7+galaxy0"
+    },
+    {
+      "name": "SnpEff databases:",
+      "id": "snpEff_databases",
+      "description": "list available databases",
+      "tool_shed_repository": "snpeff",
+      "panel_section_name": "Variant Calling",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/snpeff/snpEff_databases/4.3+T.galaxy2"
+    },
+    {
+      "name": "basil",
+      "id": "basil",
+      "description": "Breakpoint detection, including large insertions",
+      "tool_shed_repository": "basil",
+      "panel_section_name": "Variant Calling",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/basil/basil/1.2.0"
+    },
+    {
+      "name": "SnpEff download:",
+      "id": "snpEff_download",
+      "description": "download a pre-built database",
+      "tool_shed_repository": "snpeff",
+      "panel_section_name": "Variant Calling",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/snpeff/snpEff_download/4.3+T.galaxy2"
+    },
+    {
+      "name": "SnpSift Intervals",
+      "id": "snpSift_int",
+      "description": "Filter variants using intervals",
+      "tool_shed_repository": "snpsift",
+      "panel_section_name": "Variant Calling",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/snpsift/snpSift_int/4.3+t.galaxy0"
+    },
+    {
+      "name": "SnpSift rmInfo",
+      "id": "snpSift_rmInfo",
+      "description": "remove INFO field annotations",
+      "tool_shed_repository": "snpsift",
+      "panel_section_name": "Variant Calling",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/snpsift/snpSift_rmInfo/4.3+t.galaxy0"
+    },
+    {
+      "name": "SnpSift Annotate",
+      "id": "snpSift_annotate",
+      "description": "SNPs from dbSnp",
+      "tool_shed_repository": "snpsift",
+      "panel_section_name": "Variant Calling",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/snpsift/snpSift_annotate/4.3+t.galaxy1"
+    },
+    {
+      "name": "SnpSift Variant Type",
+      "id": "snpsift_vartype",
+      "description": "Annotate with variant type",
+      "tool_shed_repository": "snpsift",
+      "panel_section_name": "Variant Calling",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/snpsift/snpsift_vartype/4.3.1"
+    },
+    {
+      "name": "SnpSift CaseControl",
+      "id": "snpSift_caseControl",
+      "description": "Count samples are in 'case' and 'control' groups.",
+      "tool_shed_repository": "snpsift",
+      "panel_section_name": "Variant Calling",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/snpsift/snpSift_caseControl/4.3+t.galaxy0"
+    },
+    {
+      "name": "SnpSift Extract Fields",
+      "id": "snpSift_extractFields",
+      "description": "from a VCF file into a tabular file",
+      "tool_shed_repository": "snpsift",
+      "panel_section_name": "Variant Calling",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/snpsift/snpSift_extractFields/4.3+t.galaxy0"
+    },
+    {
+      "name": "SnpSift vcfCheck",
+      "id": "snpSift_vcfCheck",
+      "description": "basic checks for VCF specification compliance",
+      "tool_shed_repository": "snpsift",
+      "panel_section_name": "Variant Calling",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/snpsift/snpSift_vcfCheck/4.3+t.galaxy0"
+    },
+    {
+      "name": "SnpEff eff:",
+      "id": "snpEff",
+      "description": "annotate variants",
+      "tool_shed_repository": "snpeff",
+      "panel_section_name": "Variant Calling",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/snpeff/snpEff/4.3+T.galaxy1"
+    },
+    {
+      "name": "SnpSift GeneSets",
+      "id": "snpSift_geneSets",
+      "description": "Annotating GeneSets, such as Gene Ontology, KEGG, Reactome",
+      "tool_shed_repository": "snpsift_genesets",
+      "panel_section_name": "Variant Calling",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/snpsift_genesets/snpSift_geneSets/4.3.0"
+    },
+    {
+      "name": "SnpSift dbNSFP",
+      "id": "snpSift_dbnsfp",
+      "description": "Add annotations from dbNSFP or similar annotation DBs",
+      "tool_shed_repository": "snpsift_dbnsfp",
+      "panel_section_name": "Variant Calling",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/snpsift_dbnsfp/snpSift_dbnsfp/4.3.0"
+    },
+    {
+      "name": "SnpSift dbNSFP",
+      "id": "snpSift_dbnsfp_generic",
+      "description": "Add Annotations from dbNSFP and similar annotation DBs",
+      "tool_shed_repository": "snpsift_dbnsfp_generic",
+      "panel_section_name": "Variant Calling",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/snpsift_dbnsfp_generic/snpSift_dbnsfp_generic/4.1.1"
+    },
+    {
+      "name": "SnpEff Ensembl CDS",
+      "id": "SnpEff-cds-report",
+      "description": "Report Variant coding sequence changes for SnpEffects",
+      "tool_shed_repository": "snpeff_cds_report",
+      "panel_section_name": "Variant Calling",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/jjohnson/snpeff_cds_report/SnpEff-cds-report/1.2"
+    },
+    {
+      "name": "SnpEff to Peptide fasta",
+      "id": "snpeff_to_peptides",
+      "description": "to create a Search DB fasta for variant SAP peptides",
+      "tool_shed_repository": "snpeff_to_peptides",
+      "panel_section_name": "Variant Calling",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/jjohnson/snpeff_to_peptides/snpeff_to_peptides/0.0.1"
+    },
+    {
+      "name": "Naive Variant Caller",
+      "id": "naive_variant_caller",
+      "description": "- tabulate variable sites from BAM datasets",
+      "tool_shed_repository": "naive_variant_caller",
+      "panel_section_name": "Variant Calling",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/blankenberg/naive_variant_caller/naive_variant_caller/0.0.1"
+    },
+    {
+      "name": "Variant Annotator",
+      "id": "allele_counts_1",
+      "description": "process variant counts",
+      "tool_shed_repository": "allele_counts",
+      "panel_section_name": "Variant Calling",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/nick/allele_counts/allele_counts_1/1.1"
+    },
+    {
+      "name": "SnpSift Intervals",
+      "id": "snpSift_int",
+      "description": "Filter variants using intervals",
+      "tool_shed_repository": "snpeff",
+      "panel_section_name": "Variant Calling",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/snpeff/snpSift_int/3.4"
+    },
+    {
+      "name": "SnpSift Annotate",
+      "id": "snpSift_annotate",
+      "description": "SNPs from dbSnp",
+      "tool_shed_repository": "snpeff",
+      "panel_section_name": "Variant Calling",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/snpeff/snpSift_annotate/3.4"
+    },
+    {
+      "name": "SnpSift Filter",
+      "id": "snpSift_filter",
+      "description": "Filter variants using arbitrary expressions",
+      "tool_shed_repository": "snpeff",
+      "panel_section_name": "Variant Calling",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/snpeff/snpSift_filter/3.4"
+    },
+    {
+      "name": "SnpSift CaseControl",
+      "id": "snpSift_caseControl",
+      "description": "Count samples are in 'case' and 'control' groups.",
+      "tool_shed_repository": "snpeff",
+      "panel_section_name": "Variant Calling",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/snpeff/snpSift_caseControl/3.4"
+    },
+    {
+      "name": "CRISPR Studio",
+      "id": "crispr_studio",
+      "description": "facilitate and accelerate CRISPR array visualization from a GFF3 file generated with CRISPRDetect",
+      "tool_shed_repository": "crispr_studio",
+      "panel_section_name": "Genome editing",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/crispr_studio/crispr_studio/1+galaxy0"
+    },
+    {
+      "name": "parse mykrobe predict",
+      "id": "sonneityping",
+      "description": "for Shigella sonnei and tabulate results into a single tab-delimited file",
+      "tool_shed_repository": "sonneityping",
+      "panel_section_name": "Genome editing",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/sonneityping/sonneityping/20210201"
+    },
+    {
+      "name": "MAGeCKs test",
+      "id": "mageck_test",
+      "description": "- given a table of read counts, perform the sgRNA and gene ranking",
+      "tool_shed_repository": "mageck_test",
+      "panel_section_name": "Genome editing",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/mageck_test/mageck_test/0.5.8.1"
+    },
+    {
+      "name": "MAGeCK mle",
+      "id": "mageck_mle",
+      "description": "- perform maximum-likelihood estimation of gene essentiality scores",
+      "tool_shed_repository": "mageck_mle",
+      "panel_section_name": "Genome editing",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/mageck_mle/mageck_mle/0.5.8.1"
+    },
+    {
+      "name": "MAGeCK GSEA",
+      "id": "mageck_gsea",
+      "description": "- a fast implementation of Gene Set Enrichment Analysis",
+      "tool_shed_repository": "mageck_gsea",
+      "panel_section_name": "Genome editing",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/mageck_gsea/mageck_gsea/0.5.8"
+    },
+    {
+      "name": "MAGeCK count",
+      "id": "mageck_count",
+      "description": "- collect sgRNA read counts from read mapping files",
+      "tool_shed_repository": "mageck_count",
+      "panel_section_name": "Genome editing",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/mageck_count/mageck_count/0.5.8.4"
+    },
+    {
+      "name": "MAGeCK pathway",
+      "id": "mageck_pathway",
+      "description": "- given a ranked gene list, test whether one pathway is enriched",
+      "tool_shed_repository": "mageck_pathway",
+      "panel_section_name": "Genome editing",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/mageck_pathway/mageck_pathway/0.5.8"
+    },
+    {
+      "name": "plotDEXSeq",
+      "id": "plotdexseq",
+      "description": "Visualization of the per gene DEXSeq results",
+      "tool_shed_repository": "dexseq",
+      "panel_section_name": "RNA Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/dexseq/plotdexseq/1.28.1.0"
+    },
+    {
+      "name": "Seurat",
+      "id": "seurat",
+      "description": "- toolkit for exploration of single-cell RNA-seq data",
+      "tool_shed_repository": "seurat",
+      "panel_section_name": "RNA Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/seurat/seurat/4.1.0+galaxy0"
+    },
+    {
+      "name": "Alleyoop",
+      "id": "alleyoop",
+      "description": "- post-processing and QC of Slamdunk analyses",
+      "tool_shed_repository": "slamdunk",
+      "panel_section_name": "RNA Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/slamdunk/alleyoop/0.4.3+galaxy1"
+    },
+    {
+      "name": "Slamdunk",
+      "id": "slamdunk",
+      "description": "- streamlining SLAM-seq analysis with ultra-high sensitivity",
+      "tool_shed_repository": "slamdunk",
+      "panel_section_name": "RNA Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/slamdunk/slamdunk/0.4.3+galaxy1"
+    },
+    {
+      "name": "Cuffmerge",
+      "id": "cuffmerge",
+      "description": "merge together several Cufflinks assemblies",
+      "tool_shed_repository": "cuffmerge",
+      "panel_section_name": "RNA Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/cuffmerge/cuffmerge/2.2.1.3"
+    },
+    {
+      "name": "Salmon quantmerge",
+      "id": "salmonquantmerge",
+      "description": "Merge multiple quantification results into a single file",
+      "tool_shed_repository": "salmonquantmerge",
+      "panel_section_name": "RNA Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/salmonquantmerge/salmonquantmerge/1.5.1+galaxy0"
+    },
+    {
+      "name": "EGSEA",
+      "id": "egsea",
+      "description": "easy and efficient ensemble gene set testing",
+      "tool_shed_repository": "egsea",
+      "panel_section_name": "RNA Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/egsea/egsea/1.20.0"
+    },
+    {
+      "name": "TargetFinder",
+      "id": "targetfinder",
+      "description": "plant small RNA target prediction tool",
+      "tool_shed_repository": "targetfinder",
+      "panel_section_name": "RNA Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/rnateam/targetfinder/targetfinder/1.7.0+galaxy1"
+    },
+    {
+      "name": "MiGMAP",
+      "id": "migmap",
+      "description": "mapper for full-length T- and B-cell repertoire sequencing",
+      "tool_shed_repository": "migmap",
+      "panel_section_name": "RNA Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/migmap/migmap/1.0.3+galaxy2"
+    },
+    {
+      "name": "Kallisto pseudo",
+      "id": "kallisto_pseudo",
+      "description": "- run pseudoalignment on RNA-Seq transcripts",
+      "tool_shed_repository": "kallisto_pseudo",
+      "panel_section_name": "RNA Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/kallisto_pseudo/kallisto_pseudo/0.46.2+galaxy0"
+    },
+    {
+      "name": "Kallisto quant",
+      "id": "kallisto_quant",
+      "description": "- quantify abundances of RNA-Seq transcripts",
+      "tool_shed_repository": "kallisto_quant",
+      "panel_section_name": "RNA Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/kallisto_quant/kallisto_quant/0.46.2+galaxy0"
+    },
+    {
+      "name": "Remove Unwanted Variation",
+      "id": "ruvseq",
+      "description": "from RNA-seq data",
+      "tool_shed_repository": "ruvseq",
+      "panel_section_name": "RNA Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/ruvseq/ruvseq/1.26.0+galaxy0"
+    },
+    {
+      "name": "Salmon quant",
+      "id": "salmon",
+      "description": "Perform dual-phase, reads or mapping-based estimation of transcript abundance from RNA-seq reads",
+      "tool_shed_repository": "salmon",
+      "panel_section_name": "RNA Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/salmon/salmon/1.5.1+galaxy0"
+    },
+    {
+      "name": "GenomicSuperSignature",
+      "id": "genomic_super_signature",
+      "description": "interpretation of RNAseq experiments",
+      "tool_shed_repository": "genomic_super_signature",
+      "panel_section_name": "RNA Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/genomic_super_signature/genomic_super_signature/1.2.0+galaxy0"
+    },
+    {
+      "name": "Filter Combined Transcripts",
+      "id": "filter_combined_via_tracking",
+      "description": "using tracking file",
+      "tool_shed_repository": "filter_transcripts_via_tracking",
+      "panel_section_name": "RNA Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/filter_transcripts_via_tracking/filter_combined_via_tracking/0.1"
+    },
+    {
+      "name": "eXpress",
+      "id": "express",
+      "description": "Quantify the abundances of a set of target sequences from sampled subsequences",
+      "tool_shed_repository": "express",
+      "panel_section_name": "RNA Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/express/express/1.1.1"
+    },
+    {
+      "name": "maSigPro",
+      "id": "masigpro",
+      "description": "Significant Gene Expression Profile Differences in Time Course Gene Expression Data",
+      "tool_shed_repository": "masigpro",
+      "panel_section_name": "RNA Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/masigpro/masigpro/1.49.3.1+galaxy1"
+    },
+    {
+      "name": "Cufflinks",
+      "id": "cufflinks",
+      "description": "transcript assembly and FPKM (RPKM) estimates for RNA-Seq data",
+      "tool_shed_repository": "cufflinks",
+      "panel_section_name": "RNA Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/cufflinks/cufflinks/2.2.1.3"
+    },
+    {
+      "name": "Cuffdiff",
+      "id": "cuffdiff",
+      "description": "find significant changes in transcript expression, splicing, and promoter use",
+      "tool_shed_repository": "cuffdiff",
+      "panel_section_name": "RNA Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/cuffdiff/cuffdiff/2.2.1.6"
+    },
+    {
+      "name": "Cuffcompare",
+      "id": "cuffcompare",
+      "description": "compare assembled transcripts to a reference annotation and track Cufflinks transcripts across multiple experiments",
+      "tool_shed_repository": "cuffcompare",
+      "panel_section_name": "RNA Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/cuffcompare/cuffcompare/2.2.1.2"
+    },
+    {
+      "name": "scPipe",
+      "id": "scpipe",
+      "description": "- preprocessing pipeline for single cell RNA-seq",
+      "tool_shed_repository": "scpipe",
+      "panel_section_name": "RNA Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/scpipe/scpipe/1.0.0+galaxy2"
+    },
+    {
+      "name": "TEtranscripts",
+      "id": "tetoolkit_tetranscripts",
+      "description": "annotates reads to genes and transposable elements",
+      "tool_shed_repository": "tetoolkit_tetranscripts",
+      "panel_section_name": "RNA Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/tetoolkit_tetranscripts/tetoolkit_tetranscripts/2.2.1+galaxy0"
+    },
+    {
+      "name": "footprint",
+      "id": "footprint",
+      "description": "",
+      "tool_shed_repository": "footprint",
+      "panel_section_name": "RNA Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/rnateam/footprint/footprint/1.0.0"
+    },
+    {
+      "name": "Cuffnorm",
+      "id": "cuffnorm",
+      "description": "Create normalized expression levels",
+      "tool_shed_repository": "cuffnorm",
+      "panel_section_name": "RNA Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/cuffnorm/cuffnorm/2.2.1.3"
+    },
+    {
+      "name": "cummeRbund",
+      "id": "cummeRbund",
+      "description": "visualize Cuffdiff output",
+      "tool_shed_repository": "cummerbund",
+      "panel_section_name": "RNA Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/cummerbund/cummeRbund/2.16.0+galaxy1"
+    },
+    {
+      "name": "htseq-count",
+      "id": "htseq_count",
+      "description": "- Count aligned reads in a BAM file that overlap features in a GFF file",
+      "tool_shed_repository": "htseq_count",
+      "panel_section_name": "RNA Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/lparsons/htseq_count/htseq_count/0.9.1+galaxy1"
+    },
+    {
+      "name": "sRNAPipe",
+      "id": "sRNAPipe",
+      "description": "In-depth study of small RNA",
+      "tool_shed_repository": "srnapipe",
+      "panel_section_name": "RNA Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/brasset_jensen/srnapipe/sRNAPipe/1.1.1"
+    },
+    {
+      "name": "GraphProt",
+      "id": "graphprot_predict_profile",
+      "description": "- Train models and predict RBP binding profiles",
+      "tool_shed_repository": "graphprot_predict_profile",
+      "panel_section_name": "RNA Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/rnateam/graphprot_predict_profile/graphprot_predict_profile/1.1.7+galaxy1"
+    },
+    {
+      "name": "Visualize",
+      "id": "heinz_visualization",
+      "description": "the optimal scoring subnetwork",
+      "tool_shed_repository": "heinz",
+      "panel_section_name": "RNA Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/heinz/heinz_visualization/0.1.1"
+    },
+    {
+      "name": "QualiMap Counts QC",
+      "id": "qualimap_counts",
+      "description": "",
+      "tool_shed_repository": "qualimap_counts",
+      "panel_section_name": "RNA Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/qualimap_counts/qualimap_counts/2.2.2c"
+    },
+    {
+      "name": "QualiMap RNA-Seq QC",
+      "id": "qualimap_rnaseq",
+      "description": "",
+      "tool_shed_repository": "qualimap_rnaseq",
+      "panel_section_name": "RNA Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/qualimap_rnaseq/qualimap_rnaseq/2.2.2c+galaxy1"
+    },
+    {
+      "name": "Filter with SortMeRNA",
+      "id": "bg_sortmerna",
+      "description": "Fast and accurate filtering of ribosomal RNAs in metatranscriptomic data",
+      "tool_shed_repository": "sortmerna",
+      "panel_section_name": "RNA Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/rnateam/sortmerna/bg_sortmerna/2.1b.4"
+    },
+    {
+      "name": "GLASSgo",
+      "id": "glassgo",
+      "description": "sRNA homolog finder",
+      "tool_shed_repository": "glassgo",
+      "panel_section_name": "RNA Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/computationaltranscriptomics/glassgo/glassgo/1.5.2"
+    },
+    {
+      "name": "IntaRNA",
+      "id": "intarna",
+      "description": "Efficient RNA-RNA interaction prediction incorporating accessibility and seeding of interaction sites.",
+      "tool_shed_repository": "intarna",
+      "panel_section_name": "RNA Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/rnateam/intarna/intarna/3.1.1"
+    },
+    {
+      "name": "Cross-contamination Barcode Filter",
+      "id": "crosscontamination_barcode_filter",
+      "description": "for use in plate-based barcoded analyses",
+      "tool_shed_repository": "crosscontamination_barcode_filter",
+      "panel_section_name": "RNA Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/crosscontamination_barcode_filter/crosscontamination_barcode_filter/0.3"
+    },
+    {
+      "name": "Extract and cluster differentially expressed transcripts",
+      "id": "trinity_analyze_diff_expr",
+      "description": "from a Trinity assembly",
+      "tool_shed_repository": "trinity_analyze_diff_expr",
+      "panel_section_name": "RNA Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/trinity_analyze_diff_expr/trinity_analyze_diff_expr/2.8.4+galaxy1"
+    },
+    {
+      "name": "Select Sequences",
+      "id": "selectsequencesfrommsa",
+      "description": "Tool to select representative sequences from a multiple sequence alignment.",
+      "tool_shed_repository": "selectsequencesfrommsa",
+      "panel_section_name": "RNA Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/rnateam/selectsequencesfrommsa/selectsequencesfrommsa/1.0.5"
+    },
+    {
+      "name": "Cofold",
+      "id": "cofold",
+      "description": "An RNA secondary structure prediction method that takes co-transcriptional folding into account",
+      "tool_shed_repository": "cofold",
+      "panel_section_name": "RNA Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/rnateam/cofold/cofold/2.0.4.0"
+    },
+    {
+      "name": "RNAz Cluster",
+      "id": "rnaz_cluster",
+      "description": "",
+      "tool_shed_repository": "rnaz_cluster",
+      "panel_section_name": "RNA Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/rnaz_cluster/rnaz_cluster/2.1"
+    },
+    {
+      "name": "Dr. Disco (classify)",
+      "id": "dr_disco_classify",
+      "description": "Classifies detected break-points in RNA-seq based on corresponding statistics and blacklists",
+      "tool_shed_repository": "dr_disco",
+      "panel_section_name": "RNA Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/erasmus-medical-center/dr_disco/dr_disco_classify/0.14.0"
+    },
+    {
+      "name": "Dr. Disco (fix)",
+      "id": "dr_disco_fix",
+      "description": "Fixes chimeric alignments from STAR",
+      "tool_shed_repository": "dr_disco",
+      "panel_section_name": "RNA Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/erasmus-medical-center/dr_disco/dr_disco_fix/0.14.0"
+    },
+    {
+      "name": "Dr. Disco (bam-extract)",
+      "id": "dr_disco_bam_extract",
+      "description": "Extracts reads from two targeted regions",
+      "tool_shed_repository": "dr_disco",
+      "panel_section_name": "RNA Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/erasmus-medical-center/dr_disco/dr_disco_bam_extract/0.14.0"
+    },
+    {
+      "name": "Dr. Disco (integrate)",
+      "id": "dr_disco_integrate",
+      "description": "Merges corresponding genomic breaks and exon-to-exon junctions",
+      "tool_shed_repository": "dr_disco",
+      "panel_section_name": "RNA Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/erasmus-medical-center/dr_disco/dr_disco_integrate/0.14.0"
+    },
+    {
+      "name": "Dr. Disco (detect)",
+      "id": "dr_disco_detect",
+      "description": "Detects break-points in RNA-seq",
+      "tool_shed_repository": "dr_disco",
+      "panel_section_name": "RNA Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/erasmus-medical-center/dr_disco/dr_disco_detect/0.14.0"
+    },
+    {
+      "name": "MEA",
+      "id": "mea",
+      "description": "Predict MEA structures and compare structures of RNAs",
+      "tool_shed_repository": "mea",
+      "panel_section_name": "RNA Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/rnateam/mea/mea/0.6.4.1"
+    },
+    {
+      "name": "CMCV",
+      "id": "cmcv",
+      "description": "visualization of comparisons between RNA family models (CM)",
+      "tool_shed_repository": "cmcv",
+      "panel_section_name": "RNA Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/rnateam/cmcv/cmcv/1.0.8"
+    },
+    {
+      "name": "RNAz Randomize Aln",
+      "id": "rnaz_randomize_aln",
+      "description": "",
+      "tool_shed_repository": "rnaz_randomize_aln",
+      "panel_section_name": "RNA Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/rnaz_randomize_aln/rnaz_randomize_aln/2.1"
+    },
+    {
+      "name": "RNAz Select Seqs",
+      "id": "rnaz_select_seqs",
+      "description": "",
+      "tool_shed_repository": "rnaz_select_seqs",
+      "panel_section_name": "RNA Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/rnaz_select_seqs/rnaz_select_seqs/2.1"
+    },
+    {
+      "name": "RNAz windows",
+      "id": "rnaz_window",
+      "description": "",
+      "tool_shed_repository": "rnaz_window",
+      "panel_section_name": "RNA Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/rnaz_window/rnaz_window/2.1"
+    },
+    {
+      "name": "Annotate RNAz",
+      "id": "rnaz_annotate",
+      "description": "",
+      "tool_shed_repository": "rnaz_annotate",
+      "panel_section_name": "RNA Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/rnaz_annotate/rnaz_annotate/2.1"
+    },
+    {
+      "name": "Annotate DESeq2/DEXSeq output tables",
+      "id": "deg_annotate",
+      "description": "Append annotation from GTF to differential expression tool outputs",
+      "tool_shed_repository": "deg_annotate",
+      "panel_section_name": "RNA Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/deg_annotate/deg_annotate/1.1.0"
+    },
+    {
+      "name": "LocARNA Multiple Aligner",
+      "id": "locarna_multiple",
+      "description": "Multiple Alignment and Folding of RNAs (mlocarna)",
+      "tool_shed_repository": "locarna_multiple",
+      "panel_section_name": "RNA Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/rnateam/locarna_multiple/locarna_multiple/1.9.0.1"
+    },
+    {
+      "name": "cmv",
+      "id": "cmv",
+      "description": "CMV is a tool for visualization of RNA family models, also known as covariance models (CM)",
+      "tool_shed_repository": "cmv",
+      "panel_section_name": "RNA Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/rnateam/cmv/cmv/1.0.8"
+    },
+    {
+      "name": "ribotaper part 2: metagene analysis for P-sites definition",
+      "id": "ribotaper_create_metaplots",
+      "description": "",
+      "tool_shed_repository": "ribotaper",
+      "panel_section_name": "RNA Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/rnateam/ribotaper/ribotaper_create_metaplots/0.1.0"
+    },
+    {
+      "name": "ribotaper part 3: ribosome profiling",
+      "id": "ribotaper_ribosome_profiling",
+      "description": "",
+      "tool_shed_repository": "ribotaper",
+      "panel_section_name": "RNA Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/rnateam/ribotaper/ribotaper_ribosome_profiling/0.1.0"
+    },
+    {
+      "name": "ribotaper part 1: creation of annotation files",
+      "id": "ribotaper_create_annotation",
+      "description": "",
+      "tool_shed_repository": "ribotaper",
+      "panel_section_name": "RNA Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/rnateam/ribotaper/ribotaper_create_annotation/0.1.0"
+    },
+    {
+      "name": "PIPmiR PIPELINE",
+      "id": "pipmir",
+      "description": "a method to identify novel plant miRNA",
+      "tool_shed_repository": "pipmir",
+      "panel_section_name": "RNA Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/rnateam/pipmir/pipmir/0.1.0"
+    },
+    {
+      "name": "NASTIseq",
+      "id": "nastiseq",
+      "description": "Identify cis-NATs using ssRNA-seq",
+      "tool_shed_repository": "nastiseq",
+      "panel_section_name": "RNA Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/rnateam/nastiseq/nastiseq/1.0"
+    },
+    {
+      "name": "FlaiMapper",
+      "id": "flaimapper",
+      "description": "detects small ncRNA derived fragments in small RNA-Seq data",
+      "tool_shed_repository": "flaimapper",
+      "panel_section_name": "RNA Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/yhoogstrate/flaimapper/flaimapper/3.0.0-0"
+    },
+    {
+      "name": "Get motifs from AREsite2",
+      "id": "AREsite2_REST",
+      "description": "AREsite2 REST Interface",
+      "tool_shed_repository": "aresite2",
+      "panel_section_name": "RNA Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/rnateam/aresite2/AREsite2_REST/0.1.2"
+    },
+    {
+      "name": "FuMa",
+      "id": "fuma",
+      "description": "match detected fusion genes based on gene names (in particular for RNA-Seq)",
+      "tool_shed_repository": "fuma",
+      "panel_section_name": "RNA Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/yhoogstrate/fuma/fuma/3.0.5-g0"
+    },
+    {
+      "name": "RNAlien",
+      "id": "RNAlien",
+      "description": "Unsupervised covariance model construction from a single input sequence",
+      "tool_shed_repository": "rnalien",
+      "panel_section_name": "RNA Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/rnateam/rnalien/RNAlien/1.3.6"
+    },
+    {
+      "name": "BlockClust",
+      "id": "blockclust",
+      "description": "efficient clustering and classification of non-coding RNAs from short read RNA-seq profiles",
+      "tool_shed_repository": "blockclust",
+      "panel_section_name": "RNA Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/rnateam/blockclust/blockclust/1.1.0"
+    },
+    {
+      "name": "RNASeq samples quality check",
+      "id": "trinity_samples_qccheck",
+      "description": "for transcript quantification",
+      "tool_shed_repository": "trinity_samples_qccheck",
+      "panel_section_name": "RNA Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/trinity_samples_qccheck/trinity_samples_qccheck/2.8.4"
+    },
+    {
+      "name": "Describe samples",
+      "id": "describe_samples",
+      "description": "and replicates",
+      "tool_shed_repository": "describe_samples",
+      "panel_section_name": "RNA Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/describe_samples/describe_samples/2.8.4"
+    },
+    {
+      "name": "Partition genes into expression clusters",
+      "id": "trinity_define_clusters_by_cutting_tree",
+      "description": "after differential expression analysis using a Trinity assembly",
+      "tool_shed_repository": "trinity_define_clusters_by_cutting_tree",
+      "panel_section_name": "RNA Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/trinity_define_clusters_by_cutting_tree/trinity_define_clusters_by_cutting_tree/2.8.4+galaxy1"
+    },
+    {
+      "name": "Gene Body Coverage (BAM)",
+      "id": "rseqc_geneBody_coverage",
+      "description": "Read coverage over gene body.",
+      "tool_shed_repository": "rseqc",
+      "panel_section_name": "RNA Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/nilesh/rseqc/rseqc_geneBody_coverage/2.6.4.3"
+    },
+    {
+      "name": "Fit a BUM model",
+      "id": "heinz_bum",
+      "description": "with p-values",
+      "tool_shed_repository": "heinz",
+      "panel_section_name": "RNA Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/heinz/heinz_bum/1.0"
+    },
+    {
+      "name": "Identify optimal scoring subnetwork",
+      "id": "heinz",
+      "description": "using Heinz",
+      "tool_shed_repository": "heinz",
+      "panel_section_name": "RNA Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/heinz/heinz/1.0"
+    },
+    {
+      "name": "Calculate a Heinz score",
+      "id": "heinz_scoring",
+      "description": "for each node",
+      "tool_shed_repository": "heinz",
+      "panel_section_name": "RNA Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/heinz/heinz_scoring/1.0"
+    },
+    {
+      "name": "ssHMM",
+      "id": "sshmm",
+      "description": "- RNA sequence-structure motif finder",
+      "tool_shed_repository": "sshmm",
+      "panel_section_name": "RNA Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/rnateam/sshmm/sshmm/1.0.7"
+    },
+    {
+      "name": "pizzly",
+      "id": "pizzly",
+      "description": "- fast fusion detection using kallisto",
+      "tool_shed_repository": "pizzly",
+      "panel_section_name": "RNA Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/pizzly/pizzly/0.37.3.1"
+    },
+    {
+      "name": "RCAS",
+      "id": "rcas",
+      "description": "- RNA Centric Annotation System",
+      "tool_shed_repository": "rcas",
+      "panel_section_name": "RNA Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/rnateam/rcas/rcas/1.5.4"
+    },
+    {
+      "name": "Gene Body Coverage (Bigwig)",
+      "id": "rseqc_geneBody_coverage2",
+      "description": "Read coverage over gene body",
+      "tool_shed_repository": "rseqc",
+      "panel_section_name": "RNA Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/nilesh/rseqc/rseqc_geneBody_coverage2/2.6.4.1"
+    },
+    {
+      "name": "RPKM Saturation",
+      "id": "rseqc_RPKM_saturation",
+      "description": "calculates raw count and RPKM values for transcript at exon, intron, and mRNA level",
+      "tool_shed_repository": "rseqc",
+      "panel_section_name": "RNA Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/nilesh/rseqc/rseqc_RPKM_saturation/2.6.4.1"
+    },
+    {
+      "name": "Infer Experiment",
+      "id": "rseqc_infer_experiment",
+      "description": "speculates how RNA-seq were configured",
+      "tool_shed_repository": "rseqc",
+      "panel_section_name": "RNA Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/nilesh/rseqc/rseqc_infer_experiment/2.6.4.1"
+    },
+    {
+      "name": "RNA fragment size",
+      "id": "rseqc_RNA_fragment_size",
+      "description": "calculates the fragment size for each gene/transcript",
+      "tool_shed_repository": "rseqc",
+      "panel_section_name": "RNA Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/nilesh/rseqc/rseqc_RNA_fragment_size/2.6.4.1"
+    },
+    {
+      "name": "Transcript Integrity Number",
+      "id": "rseqc_tin",
+      "description": "evaluates RNA integrity at a transcript level",
+      "tool_shed_repository": "rseqc",
+      "panel_section_name": "RNA Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/nilesh/rseqc/rseqc_tin/2.6.4.1"
+    },
+    {
+      "name": "Junction Saturation",
+      "id": "rseqc_junction_saturation",
+      "description": "detects splice junctions from each subset and compares them to reference gene model",
+      "tool_shed_repository": "rseqc",
+      "panel_section_name": "RNA Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/nilesh/rseqc/rseqc_junction_saturation/2.6.4.1"
+    },
+    {
+      "name": "FPKM Count",
+      "id": "rseqc_FPKM_count",
+      "description": "calculates raw read count, FPM, and FPKM for each gene",
+      "tool_shed_repository": "rseqc",
+      "panel_section_name": "RNA Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/nilesh/rseqc/rseqc_FPKM_count/2.6.4.1"
+    },
+    {
+      "name": "Read Distribution",
+      "id": "rseqc_read_distribution",
+      "description": "calculates how mapped reads were distributed over genome feature",
+      "tool_shed_repository": "rseqc",
+      "panel_section_name": "RNA Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/nilesh/rseqc/rseqc_read_distribution/2.6.4.1"
+    },
+    {
+      "name": "RNAcode",
+      "id": "rbc_rnacode",
+      "description": "Analyze the protein coding potential in MSA.",
+      "tool_shed_repository": "rnacode",
+      "panel_section_name": "RNA Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/rnateam/rnacode/rbc_rnacode/0.3.1"
+    },
+    {
+      "name": "Junction Annotation",
+      "id": "rseqc_junction_annotation",
+      "description": "compares detected splice junctions to reference gene model",
+      "tool_shed_repository": "rseqc",
+      "panel_section_name": "RNA Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/nilesh/rseqc/rseqc_junction_annotation/2.6.4.1"
+    },
+    {
+      "name": "Inner Distance",
+      "id": "rseqc_inner_distance",
+      "description": "calculate the inner distance (or insert size) between two paired RNA reads",
+      "tool_shed_repository": "rseqc",
+      "panel_section_name": "RNA Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/nilesh/rseqc/rseqc_inner_distance/2.6.4.1"
+    },
+    {
+      "name": "RNAz",
+      "id": "rnaz",
+      "description": "predicting structurally conserved and thermodynamically stable RNA secondary structures",
+      "tool_shed_repository": "rnaz",
+      "panel_section_name": "RNA Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/rnaz/rnaz/2.1.1"
+    },
+    {
+      "name": "RNAshapes",
+      "id": "RNAshapes",
+      "description": "RNA Secondary structure prediction",
+      "tool_shed_repository": "rnashapes",
+      "panel_section_name": "RNA Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/rnateam/rnashapes/RNAshapes/3.3.0"
+    },
+    {
+      "name": "RNAfold",
+      "id": "viennarna_rnafold",
+      "description": "Calculate minimum free energy secondary structures and partition function of RNAs",
+      "tool_shed_repository": "viennarna_rnafold",
+      "panel_section_name": "RNA Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/rnateam/viennarna_rnafold/viennarna_rnafold/2.2.10.4"
+    },
+    {
+      "name": "IDR",
+      "id": "idr",
+      "description": "compare ranked list of identifications",
+      "tool_shed_repository": "idr",
+      "panel_section_name": "RNA Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/idr/idr/2.0.3"
+    },
+    {
+      "name": "RNAcofold",
+      "id": "viennarna_rnacofold",
+      "description": "Calculate secondary structures of two RNAs with dimerization",
+      "tool_shed_repository": "viennarna_rnacofold",
+      "panel_section_name": "RNA Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/rnateam/viennarna_rnacofold/viennarna_rnacofold/2.2.10.0"
+    },
+    {
+      "name": "RNAalifold",
+      "id": "viennarna_rnaalifold",
+      "description": "Calculate minimum free energy secondary structures and partition function on a multiple alignment file",
+      "tool_shed_repository": "viennarna_rnaalifold",
+      "panel_section_name": "RNA Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/rnateam/viennarna_rnaalifold/viennarna_rnaalifold/2.2.10.1"
+    },
+    {
+      "name": "Deletion Profile",
+      "id": "rseqc_deletion_profile",
+      "description": "calculates the distributions of deleted nucleotides across reads",
+      "tool_shed_repository": "rseqc",
+      "panel_section_name": "RNA Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/nilesh/rseqc/rseqc_deletion_profile/2.6.4"
+    },
+    {
+      "name": "Read NVC",
+      "id": "rseqc_read_NVC",
+      "description": "to check the nucleotide composition bias",
+      "tool_shed_repository": "rseqc",
+      "panel_section_name": "RNA Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/nilesh/rseqc/rseqc_read_NVC/2.6.4"
+    },
+    {
+      "name": "BAM/SAM Mapping Stats",
+      "id": "rseqc_bam_stat",
+      "description": "reads mapping statistics for a provided BAM or SAM file.",
+      "tool_shed_repository": "rseqc",
+      "panel_section_name": "RNA Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/nilesh/rseqc/rseqc_bam_stat/2.6.4"
+    },
+    {
+      "name": "Read Duplication",
+      "id": "rseqc_read_duplication",
+      "description": "determines reads duplication rate with sequence-based and mapping-based strategies",
+      "tool_shed_repository": "rseqc",
+      "panel_section_name": "RNA Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/nilesh/rseqc/rseqc_read_duplication/2.6.4"
+    },
+    {
+      "name": "Read GC",
+      "id": "rseqc_read_GC",
+      "description": "determines GC% and read count",
+      "tool_shed_repository": "rseqc",
+      "panel_section_name": "RNA Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/nilesh/rseqc/rseqc_read_GC/2.6.4"
+    },
+    {
+      "name": "Insertion Profile",
+      "id": "rseqc_insertion_profile",
+      "description": "calculates the distribution of inserted nucleotides across reads",
+      "tool_shed_repository": "rseqc",
+      "panel_section_name": "RNA Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/nilesh/rseqc/rseqc_insertion_profile/2.6.4"
+    },
+    {
+      "name": "BAM to Wiggle",
+      "id": "rseqc_bam2wig",
+      "description": "converts all types of RNA-seq data from .bam to .wig",
+      "tool_shed_repository": "rseqc",
+      "panel_section_name": "RNA Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/nilesh/rseqc/rseqc_bam2wig/2.6.4"
+    },
+    {
+      "name": "Clipping Profile",
+      "id": "rseqc_clipping_profile",
+      "description": "estimates clipping profile of RNA-seq reads from BAM or SAM file",
+      "tool_shed_repository": "rseqc",
+      "panel_section_name": "RNA Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/nilesh/rseqc/rseqc_clipping_profile/2.6.4"
+    },
+    {
+      "name": "Read Quality",
+      "id": "rseqc_read_quality",
+      "description": "determines Phred quality score",
+      "tool_shed_repository": "rseqc",
+      "panel_section_name": "RNA Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/nilesh/rseqc/rseqc_read_quality/2.6.4"
+    },
+    {
+      "name": "Hexamer frequency",
+      "id": "rseqc_read_hexamer",
+      "description": "calculates hexamer (6mer) frequency for reads, genomes, and mRNA sequences",
+      "tool_shed_repository": "rseqc",
+      "panel_section_name": "RNA Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/nilesh/rseqc/rseqc_read_hexamer/2.6.4"
+    },
+    {
+      "name": "Mismatch Profile",
+      "id": "rseqc_mismatch_profile",
+      "description": "calculates the distribution of mismatches across reads",
+      "tool_shed_repository": "rseqc",
+      "panel_section_name": "RNA Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/nilesh/rseqc/rseqc_mismatch_profile/2.6.4"
+    },
+    {
+      "name": "segemehl",
+      "id": "segemehl",
+      "description": "short read mapping with gaps",
+      "tool_shed_repository": "segemehl",
+      "panel_section_name": "RNA Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/rnateam/segemehl/segemehl/0.2.0.3"
+    },
+    {
+      "name": "Sailfish",
+      "id": "sailfish",
+      "description": "transcript quantification from RNA-seq data",
+      "tool_shed_repository": "sailfish",
+      "panel_section_name": "RNA Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/sailfish/sailfish/0.10.1.1"
+    },
+    {
+      "name": "Cuffquant",
+      "id": "cuffquant",
+      "description": "Precompute gene expression levels",
+      "tool_shed_repository": "cuffquant",
+      "panel_section_name": "RNA Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/cuffquant/cuffquant/2.2.1.1"
+    },
+    {
+      "name": "RNAeval",
+      "id": "viennarna_rnaeval",
+      "description": "Calculate energy of RNA sequences with given secondary structure",
+      "tool_shed_repository": "viennarna_rnaeval",
+      "panel_section_name": "RNA Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/rnateam/viennarna_rnaeval/viennarna_rnaeval/2.2.10.0"
+    },
+    {
+      "name": "RNAplex",
+      "id": "viennarna_rnaplex",
+      "description": "Find targets of a query RNA",
+      "tool_shed_repository": "viennarna_rnaplex",
+      "panel_section_name": "RNA Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/rnateam/viennarna_rnaplex/viennarna_rnaplex/2.2.10.0"
+    },
+    {
+      "name": "RNA2Dfold",
+      "id": "viennarna_rna2dfold",
+      "description": "explore structure space between two reference structures",
+      "tool_shed_repository": "viennarna_rna2dfold",
+      "panel_section_name": "RNA Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/rnateam/viennarna_rna2dfold/viennarna_rna2dfold/2.2.10.0"
+    },
+    {
+      "name": "RNApaln",
+      "id": "viennarna_rnapaln",
+      "description": "RNA alignment based on sequence base pairing propensities",
+      "tool_shed_repository": "viennarna_rnapaln",
+      "panel_section_name": "RNA Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/rnateam/viennarna_rnapaln/viennarna_rnapaln/2.2.10.0"
+    },
+    {
+      "name": "RNAplot",
+      "id": "viennarna_rnaplot",
+      "description": "Draw RNA Secondary Structures",
+      "tool_shed_repository": "viennarna_rnaplot",
+      "panel_section_name": "RNA Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/rnateam/viennarna_rnaplot/viennarna_rnaplot/2.2.10.0"
+    },
+    {
+      "name": "RNAsnoop",
+      "id": "viennarna_rnasnoop",
+      "description": "Find targets of a query H/ACA snoRNA",
+      "tool_shed_repository": "viennarna_rnasnoop",
+      "panel_section_name": "RNA Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/rnateam/viennarna_rnasnoop/viennarna_rnasnoop/2.2.10.0"
+    },
+    {
+      "name": "Kinfold",
+      "id": "viennarna_kinfold",
+      "description": "Simulates the stochastic folding kinetics of RNA sequences into secondary structures.",
+      "tool_shed_repository": "viennarna_kinfold",
+      "panel_section_name": "RNA Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/rnateam/viennarna_kinfold/viennarna_kinfold/1.3.0.0"
+    },
+    {
+      "name": "RNAaliduplex",
+      "id": "viennarna_rnaaliduplex",
+      "description": "find binding sites of two RNA alignments",
+      "tool_shed_repository": "viennarna_rnaaliduplex",
+      "panel_section_name": "RNA Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/rnateam/viennarna_rnaaliduplex/viennarna_rnaaliduplex/2.2.10.0"
+    },
+    {
+      "name": "RNAduplex",
+      "id": "viennarna_rnaduplex",
+      "description": "Compute the structure upon hybridization of two RNA strands",
+      "tool_shed_repository": "viennarna_rnaduplex",
+      "panel_section_name": "RNA Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/rnateam/viennarna_rnaduplex/viennarna_rnaduplex/2.2.10.0"
+    },
+    {
+      "name": "RNAdistance",
+      "id": "viennarna_rnadistance",
+      "description": "Calculate distance between secondary structures of two RNAs",
+      "tool_shed_repository": "viennarna_rnadistance",
+      "panel_section_name": "RNA Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/rnateam/viennarna_rnadistance/viennarna_rnadistance/2.2.10.0"
+    },
+    {
+      "name": "RNApdist",
+      "id": "viennarna_rnadpdist",
+      "description": "Calculate distances between thermodynamic RNA secondary structure ensembles",
+      "tool_shed_repository": "viennarna_rnadpdist",
+      "panel_section_name": "RNA Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/rnateam/viennarna_rnadpdist/viennarna_rnadpdist/2.2.10.0"
+    },
+    {
+      "name": "RNALfold",
+      "id": "viennarna_rnalfold",
+      "description": "calculates locally stable secondary structures of RNA",
+      "tool_shed_repository": "viennarna_rnalfold",
+      "panel_section_name": "RNA Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/rnateam/viennarna_rnalfold/viennarna_rnalfold/2.2.10.0"
+    },
+    {
+      "name": "RNAPKplex",
+      "id": "viennarna_rnapkplex",
+      "description": "predicts RNA secondary structures including pseudoknots",
+      "tool_shed_repository": "viennarna_rnapkplex",
+      "panel_section_name": "RNA Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/rnateam/viennarna_rnapkplex/viennarna_rnapkplex/2.2.10.0"
+    },
+    {
+      "name": "RNAup",
+      "id": "viennarna_rnaup",
+      "description": "Calculate the thermodynamics of RNA-RNA interactions",
+      "tool_shed_repository": "viennarna_rnaup",
+      "panel_section_name": "RNA Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/rnateam/viennarna_rnaup/viennarna_rnaup/2.2.10.0"
+    },
+    {
+      "name": "RNALalifold",
+      "id": "viennarna_rnalalifold",
+      "description": "Calculate locally stable secondary structures for a set of aligned RNAs",
+      "tool_shed_repository": "viennarna_rnalalifold",
+      "panel_section_name": "RNA Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/rnateam/viennarna_rnalalifold/viennarna_rnalalifold/2.2.10.0"
+    },
+    {
+      "name": "RNAinverse",
+      "id": "viennarna_rnainverse",
+      "description": "Calculate RNA sequence from secondary structure",
+      "tool_shed_repository": "viennarna_rnainverse",
+      "panel_section_name": "RNA Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/rnateam/viennarna_rnainverse/viennarna_rnainverse/2.2.10.0"
+    },
+    {
+      "name": "RNAheat",
+      "id": "viennarna_rnaheat",
+      "description": "Calculate energies of RNA in a temperature range",
+      "tool_shed_repository": "viennarna_rnaheat",
+      "panel_section_name": "RNA Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/rnateam/viennarna_rnaheat/viennarna_rnaheat/2.2.10.0"
+    },
+    {
+      "name": "RNAsubopt",
+      "id": "viennarna_rnasubopt",
+      "description": "Calculates suboptimal secondary structures of RNAs",
+      "tool_shed_repository": "viennarna_rnasubopt",
+      "panel_section_name": "RNA Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/rnateam/viennarna_rnasubopt/viennarna_rnasubopt/2.2.10.0"
+    },
+    {
+      "name": "remuRNA",
+      "id": "remurna",
+      "description": "Measurement of Single Nucleotide Polymorphism induced Changes of RNA Conformation",
+      "tool_shed_repository": "remurna",
+      "panel_section_name": "RNA Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/rnateam/remurna/remurna/1.0.0"
+    },
+    {
+      "name": "RNAsnp",
+      "id": "rnasnp",
+      "description": "Efficient detection of local RNA secondary structure changes induced by SNPs",
+      "tool_shed_repository": "rnasnp",
+      "panel_section_name": "RNA Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/rnateam/rnasnp/rnasnp/1.2.0"
+    },
+    {
+      "name": "LocARNA",
+      "id": "mlocarna",
+      "description": "Multiple Alignment and Folding of RNAs",
+      "tool_shed_repository": "mlocarna",
+      "panel_section_name": "RNA Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/rnateam/mlocarna/mlocarna/1.8.12.0"
+    },
+    {
+      "name": "PARalyzer",
+      "id": "paralyzer",
+      "description": "A method to map interaction sites between RNA-binding proteins      and their targets",
+      "tool_shed_repository": "paralyzer",
+      "panel_section_name": "RNA Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/rnateam/paralyzer/paralyzer/1.5"
+    },
+    {
+      "name": "CIRCexplorer",
+      "id": "circexplorer",
+      "description": "",
+      "tool_shed_repository": "circexplorer",
+      "panel_section_name": "RNA Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/circexplorer/circexplorer/1.1.9.0"
+    },
+    {
+      "name": "RNAcommender",
+      "id": "rbc_rnacommender",
+      "description": "genome-wide recommendation of RNA-protein interactions",
+      "tool_shed_repository": "rnacommender",
+      "panel_section_name": "RNA Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/rnateam/rnacommender/rbc_rnacommender/0.1.1"
+    },
+    {
+      "name": "RPKM Count",
+      "id": "rseqc_RPKM_count",
+      "description": "calculates raw count and RPKM values for transcript at exon, intron, and mRNA level",
+      "tool_shed_repository": "rseqc",
+      "panel_section_name": "RNA Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/nilesh/rseqc/rseqc_RPKM_count/2.4"
+    },
+    {
+      "name": "Tophat Fusion Post",
+      "id": "tophat_fusion_post",
+      "description": "post-processing to identify fusion genes",
+      "tool_shed_repository": "tophat_fusion_post",
+      "panel_section_name": "RNA Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/tophat_fusion_post/tophat_fusion_post/0.1"
+    },
+    {
+      "name": "blockbuster",
+      "id": "blockbuster",
+      "description": "detects blocks of overlapping reads using a gaussian-distribution approach",
+      "tool_shed_repository": "blockbuster",
+      "panel_section_name": "RNA Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/rnateam/blockbuster/blockbuster/0.1.2"
+    },
+    {
+      "name": "Kinwalker",
+      "id": "rbc_kinwalker",
+      "description": "cotranscriptional folding of RNAs",
+      "tool_shed_repository": "kinwalker",
+      "panel_section_name": "RNA Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/rnateam/kinwalker/rbc_kinwalker/1.0"
+    },
+    {
+      "name": "antaRNA",
+      "id": "antarna",
+      "description": "Ant Colony Optimized RNA Sequence Design",
+      "tool_shed_repository": "antarna",
+      "panel_section_name": "RNA Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/rnateam/antarna/antarna/1.1"
+    },
+    {
+      "name": "RNABOB",
+      "id": "rbc_rnabob",
+      "description": "Fast Pattern searching for RNA secondary structures",
+      "tool_shed_repository": "rnabob",
+      "panel_section_name": "RNA Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/rnateam/rnabob/rbc_rnabob/2.2.1.0"
+    },
+    {
+      "name": "Get RT Stop Counts",
+      "id": "get_read_pipeline",
+      "description": "derives the reverse transcriptase (RT) stop count on each nucleotide from a mapped file provided by the Iterative Mapping module",
+      "tool_shed_repository": "structurefold",
+      "panel_section_name": "RNA Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/tyty/structurefold/get_read_pipeline/1.0"
+    },
+    {
+      "name": "RNA Structure Prediction",
+      "id": "predict_pipeline",
+      "description": "predict RNA structures with or without experimental constraints from the Reactivity Calculation module",
+      "tool_shed_repository": "structurefold",
+      "panel_section_name": "RNA Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/tyty/structurefold/predict_pipeline/1.0"
+    },
+    {
+      "name": "Iterative Mapping",
+      "id": "iterative_map_pipeline",
+      "description": "iteratively maps the raw reads of RNA structural data to the reference transcriptome",
+      "tool_shed_repository": "structurefold",
+      "panel_section_name": "RNA Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/tyty/structurefold/iterative_map_pipeline/1.0"
+    },
+    {
+      "name": "Reactivity Calculation",
+      "id": "react_cal_pipeline",
+      "description": "calculates structural reactivity on each nucleotide based on RT stop counts from the Get RT Stop Counts module",
+      "tool_shed_repository": "structurefold",
+      "panel_section_name": "RNA Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/tyty/structurefold/react_cal_pipeline/1.0"
+    },
+    {
+      "name": "Extract CuffDiff",
+      "id": "cummerbund_to_cuffdiff",
+      "description": "tabular files from a cummeRbund database",
+      "tool_shed_repository": "cummerbund_to_tabular",
+      "panel_section_name": "RNA Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/cummerbund_to_tabular/cummerbund_to_cuffdiff/1.0.1"
+    },
+    {
+      "name": "MiRDeep2 Mapper",
+      "id": "rbc_mirdeep2_mapper",
+      "description": "process and map reads to a reference genome",
+      "tool_shed_repository": "mirdeep2_mapper",
+      "panel_section_name": "RNA Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/rnateam/mirdeep2_mapper/rbc_mirdeep2_mapper/2.0.0"
+    },
+    {
+      "name": "MiRDeep2 Quantifier",
+      "id": "rbc_mirdeep2_quantifier",
+      "description": "fast quantitation of reads mapping to known miRBase precursors",
+      "tool_shed_repository": "mirdeep2_quantifier",
+      "panel_section_name": "RNA Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/rnateam/mirdeep2_quantifier/rbc_mirdeep2_quantifier/2.0.0"
+    },
+    {
+      "name": "MiRDeep2",
+      "id": "rbc_mirdeep2",
+      "description": "identification of novel and known miRNAs",
+      "tool_shed_repository": "mirdeep2",
+      "panel_section_name": "RNA Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/rnateam/mirdeep2/rbc_mirdeep2/2.0.0"
+    },
+    {
+      "name": "RSEM prepare reference",
+      "id": "rsem_prepare_reference",
+      "description": "",
+      "tool_shed_repository": "rsem",
+      "panel_section_name": "RNA Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/jjohnson/rsem/rsem_prepare_reference/1.1.17"
+    },
+    {
+      "name": "RSEM calculate expression",
+      "id": "rsem_calculate_expression",
+      "description": "RNA-Seq by Expectation-Maximization",
+      "tool_shed_repository": "rsem",
+      "panel_section_name": "RNA Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/jjohnson/rsem/rsem_calculate_expression/1.1.17"
+    },
+    {
+      "name": "RSEM trinity fasta to gene map",
+      "id": "extract_transcript_to_gene_map_from_trinity",
+      "description": "extract transcript to gene map from trinity",
+      "tool_shed_repository": "rsem",
+      "panel_section_name": "RNA Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/jjohnson/rsem/extract_transcript_to_gene_map_from_trinity/1.1.17"
+    },
+    {
+      "name": "CCAT",
+      "id": "peakcalling_ccat",
+      "description": "Control-based ChIP-seq Analysis Tool",
+      "tool_shed_repository": "ccat",
+      "panel_section_name": "Peak Calling",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/ccat/peakcalling_ccat/0.0.2"
+    },
+    {
+      "name": "MACS",
+      "id": "peakcalling_macs",
+      "description": "Model-based Analysis of ChIP-Seq",
+      "tool_shed_repository": "macs",
+      "panel_section_name": "Peak Calling",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/macs/peakcalling_macs/1.0.1"
+    },
+    {
+      "name": "SICER",
+      "id": "peakcalling_sicer",
+      "description": "Statistical approach for the Identification of ChIP-Enriched Regions",
+      "tool_shed_repository": "sicer",
+      "panel_section_name": "Peak Calling",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/sicer/peakcalling_sicer/1.1"
+    },
+    {
+      "name": "Genrich",
+      "id": "genrich",
+      "description": "Detecting sites of genomic enrichment",
+      "tool_shed_repository": "genrich",
+      "panel_section_name": "Peak Calling",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/genrich/genrich/0.5+galaxy2"
+    },
+    {
+      "name": "DiffBind",
+      "id": "diffbind",
+      "description": "differential binding analysis of ChIP-Seq peak data",
+      "tool_shed_repository": "diffbind",
+      "panel_section_name": "Peak Calling",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/diffbind/diffbind/2.10.0"
+    },
+    {
+      "name": "PEAKachu",
+      "id": "peakachu",
+      "description": "Calls Peaks in CLIP data",
+      "tool_shed_repository": "peakachu",
+      "panel_section_name": "Peak Calling",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/rnateam/peakachu/peakachu/0.1.0.2"
+    },
+    {
+      "name": "zerone",
+      "id": "zerone",
+      "description": "",
+      "tool_shed_repository": "zerone",
+      "panel_section_name": "Peak Calling",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/zerone/zerone/1.0"
+    },
+    {
+      "name": "PureCLIP",
+      "id": "pureclip",
+      "description": "- HMM based peak caller designed for eCLIP/iCLIP data",
+      "tool_shed_repository": "pureclip",
+      "panel_section_name": "Peak Calling",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/pureclip/pureclip/1.0.4"
+    },
+    {
+      "name": "JAMM",
+      "id": "jamm",
+      "description": "Calls peaks on NGS data",
+      "tool_shed_repository": "jamm",
+      "panel_section_name": "Peak Calling",
+      "help": "",
+      "guid": "testtoolshed.g2.bx.psu.edu/repos/messersc/jamm/jamm/1.0.7"
+    },
+    {
+      "name": "Piranha",
+      "id": "piranha",
+      "description": "peak-caller for CLIP- and RIP-Seq data",
+      "tool_shed_repository": "piranha",
+      "panel_section_name": "Peak Calling",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/rnateam/piranha/piranha/0.1.0"
+    },
+    {
+      "name": "bwameth",
+      "id": "bwameth",
+      "description": "Fast and accurate aligner of BS-Seq reads.",
+      "tool_shed_repository": "bwameth",
+      "panel_section_name": "Epigenetics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/bwameth/bwameth/0.2.3+galaxy0"
+    },
+    {
+      "name": "MethylDackel",
+      "id": "pileometh",
+      "description": "A tool for processing bisulfite sequencing alignments",
+      "tool_shed_repository": "pileometh",
+      "panel_section_name": "Epigenetics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/pileometh/pileometh/0.5.2+galaxy0"
+    },
+    {
+      "name": "Filter",
+      "id": "vcf_filter",
+      "description": "a VCF file",
+      "tool_shed_repository": "vcf_filter",
+      "panel_section_name": "Epigenetics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/vcf_filter/vcf_filter/1.0.0"
+    },
+    {
+      "name": "SEACR",
+      "id": "seacr",
+      "description": "for sparse enrichment analysis",
+      "tool_shed_repository": "seacr",
+      "panel_section_name": "Epigenetics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/seacr/seacr/1.3+galaxy1"
+    },
+    {
+      "name": "MOABS",
+      "id": "moabs",
+      "description": "MOdel based Analysis of Bisulfite Sequencing data",
+      "tool_shed_repository": "moabs",
+      "panel_section_name": "Epigenetics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/moabs/moabs/1.3.4.6+galaxy1"
+    },
+    {
+      "name": "Minfi Preprocess Quantile",
+      "id": "minfi_ppquantile",
+      "description": "implements stratified quantile normalization preprocessing",
+      "tool_shed_repository": "ewastools",
+      "panel_section_name": "Epigenetics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/kpbioteam/ewastools/minfi_ppquantile/1.28.0"
+    },
+    {
+      "name": "Minfi Rset",
+      "id": "minfi_rset",
+      "description": "store Beta values and/or M values",
+      "tool_shed_repository": "ewastools",
+      "panel_section_name": "Epigenetics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/kpbioteam/ewastools/minfi_rset/1.28.0"
+    },
+    {
+      "name": "Minfi Drop SNPs",
+      "id": "minfi_dropsnp",
+      "description": "drop the probes that contain either a SNP at the CpG interrogation or at the single nucleotide extension",
+      "tool_shed_repository": "ewastools",
+      "panel_section_name": "Epigenetics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/kpbioteam/ewastools/minfi_dropsnp/1.28.0"
+    },
+    {
+      "name": "Minfi Mset",
+      "id": "minfi_mset",
+      "description": "Create objects contains CpGs signals",
+      "tool_shed_repository": "ewastools",
+      "panel_section_name": "Epigenetics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/kpbioteam/ewastools/minfi_mset/1.28.0"
+    },
+    {
+      "name": "Minfi Read 450k",
+      "id": "minfi_read450k",
+      "description": "load .IDAT files",
+      "tool_shed_repository": "ewastools",
+      "panel_section_name": "Epigenetics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/kpbioteam/ewastools/minfi_read450k/2.1.0"
+    },
+    {
+      "name": "Minfi Preprocess Funnorm",
+      "id": "minfi_ppfun",
+      "description": "implements the functional normalization algorithm",
+      "tool_shed_repository": "ewastools",
+      "panel_section_name": "Epigenetics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/kpbioteam/ewastools/minfi_ppfun/1.28.0"
+    },
+    {
+      "name": "Minfi DMP",
+      "id": "minfi_dmp",
+      "description": "to find differentially methylated positions",
+      "tool_shed_repository": "ewastools",
+      "panel_section_name": "Epigenetics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/kpbioteam/ewastools/minfi_dmp/1.28.0"
+    },
+    {
+      "name": "Minfi DMR",
+      "id": "minfi_dmr",
+      "description": "to find differentially methylated regions",
+      "tool_shed_repository": "ewastools",
+      "panel_section_name": "Epigenetics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/kpbioteam/ewastools/minfi_dmr/1.28.0"
+    },
+    {
+      "name": "Minfi Get CN",
+      "id": "minfi_getcn",
+      "description": "get the coordinating node associated with this D1Client object",
+      "tool_shed_repository": "ewastools",
+      "panel_section_name": "Epigenetics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/kpbioteam/ewastools/minfi_getcn/1.28.0"
+    },
+    {
+      "name": "Minfi Get Beta",
+      "id": "minfi_getbeta",
+      "description": "obtain Beta value matrix",
+      "tool_shed_repository": "ewastools",
+      "panel_section_name": "Epigenetics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/kpbioteam/ewastools/minfi_getbeta/1.28.0"
+    },
+    {
+      "name": "Minfi Get SNPs",
+      "id": "minfi_getsnp",
+      "description": "retrieve the chromosome and the position of each SNP",
+      "tool_shed_repository": "ewastools",
+      "panel_section_name": "Epigenetics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/kpbioteam/ewastools/minfi_getsnp/1.28.0"
+    },
+    {
+      "name": "Minfi Map to Genome",
+      "id": "minfi_maptogenome",
+      "description": "mapping Ilumina methylation array data to the genome",
+      "tool_shed_repository": "ewastools",
+      "panel_section_name": "Epigenetics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/kpbioteam/ewastools/minfi_maptogenome/1.28.0"
+    },
+    {
+      "name": "Minfi Get M",
+      "id": "minfi_getM",
+      "description": "returns the Fisher information corresponding to a model and a design",
+      "tool_shed_repository": "ewastools",
+      "panel_section_name": "Epigenetics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/kpbioteam/ewastools/minfi_getM/1.28.0"
+    },
+    {
+      "name": "Minfi QC",
+      "id": "minfi_qc",
+      "description": "provides a simple quality control matrix and plot",
+      "tool_shed_repository": "ewastools",
+      "panel_section_name": "Epigenetics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/kpbioteam/ewastools/minfi_qc/1.28.0"
+    },
+    {
+      "name": "Infinium Human Methylation BeadChip",
+      "id": "minfi_analysis",
+      "description": "Determines differentially methylated regions and positions from Infinium Methylation Assays",
+      "tool_shed_repository": "ewastools",
+      "panel_section_name": "Epigenetics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/kpbioteam/ewastools/minfi_analysis/2.1.0"
+    },
+    {
+      "name": "metilene",
+      "id": "metilene",
+      "description": "calling differentially methylated regions from bisulfite sequencing data",
+      "tool_shed_repository": "metilene",
+      "panel_section_name": "Epigenetics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/rnateam/metilene/metilene/0.2.6.1"
+    },
+    {
+      "name": "Hicup Truncater",
+      "id": "hicup_truncater",
+      "description": "terminates sequence reads at specified Hi-C ligation junctions.",
+      "tool_shed_repository": "hicup_truncater",
+      "panel_section_name": "Epigenetics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/hicup_truncater/hicup_truncater/0.6.1.0"
+    },
+    {
+      "name": "Hicup Pipeline",
+      "id": "hicup_hicup",
+      "description": "controls the other programs in the HiCUP pipeline.",
+      "tool_shed_repository": "hicup_hicup",
+      "panel_section_name": "Epigenetics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/hicup_hicup/hicup_hicup/0.6.1.0"
+    },
+    {
+      "name": "Hicup Filter",
+      "id": "hicup_filter",
+      "description": "classifies read pairs, identifying valid Hi-C di-tags",
+      "tool_shed_repository": "hicup_filter",
+      "panel_section_name": "Epigenetics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/hicup_filter/hicup_filter/0.6.1.0"
+    },
+    {
+      "name": "Hicup Digester",
+      "id": "hicup_digester",
+      "description": "cuts throughout a selected genome at one or two specified restriction sites.",
+      "tool_shed_repository": "hicup_digester",
+      "panel_section_name": "Epigenetics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/hicup_digester/hicup_digester/0.6.1.0"
+    },
+    {
+      "name": "Hicup Deduplicator",
+      "id": "hicup_deduplicator",
+      "description": "removes duplicated di-tags (retaining one copy of each) from the data set.",
+      "tool_shed_repository": "hicup_deduplicator",
+      "panel_section_name": "Epigenetics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/hicup_deduplicator/hicup_deduplicator/0.6.1.0"
+    },
+    {
+      "name": "EpiCSeg - Chromatin segmentation",
+      "id": "epicseg_segment",
+      "description": "",
+      "tool_shed_repository": "epicseg",
+      "panel_section_name": "Epigenetics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/rnateam/epicseg/epicseg_segment/1.0"
+    },
+    {
+      "name": "Hicup Mapper",
+      "id": "hicup_mapper",
+      "description": "aligns paired reads independently to a reference genome and retains reads where both partners align.",
+      "tool_shed_repository": "hicup_mapper",
+      "panel_section_name": "Epigenetics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/hicup_mapper/hicup_mapper/0.5.10.0"
+    },
+    {
+      "name": "HyPhy-CFEL",
+      "id": "hyphy_cfel",
+      "description": "Test for Differences in Selective Pressures at Individual Sites among Clades and Sets of Branches",
+      "tool_shed_repository": "hyphy_cfel",
+      "panel_section_name": "Phylogenetics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/hyphy_cfel/hyphy_cfel/2.5.36+galaxy1"
+    },
+    {
+      "name": "Replace ambiguous codons",
+      "id": "hyphy_strike_ambigs",
+      "description": "in a multiple alignment using HyPhy",
+      "tool_shed_repository": "hyphy_strike_ambigs",
+      "panel_section_name": "Phylogenetics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/hyphy_strike_ambigs/hyphy_strike_ambigs/2.5.36"
+    },
+    {
+      "name": "HyPhy-Conv",
+      "id": "hyphy_conv",
+      "description": "translate an in-frame codon alignment to proteins",
+      "tool_shed_repository": "hyphy_conv",
+      "panel_section_name": "Phylogenetics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/hyphy_conv/hyphy_conv/2.5.36+galaxy1"
+    },
+    {
+      "name": "NextAlign",
+      "id": "nextalign",
+      "description": "Viral genome sequence alignment",
+      "tool_shed_repository": "nextalign",
+      "panel_section_name": "Phylogenetics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/nextalign/nextalign/1.11.0+galaxy0"
+    },
+    {
+      "name": "Gene Copy Number Finder",
+      "id": "ete_gene_csv_finder",
+      "description": "from a genetree using the ETE Toolkit",
+      "tool_shed_repository": "ete",
+      "panel_section_name": "Phylogenetics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/earlhaminst/ete/ete_gene_csv_finder/3.1.2"
+    },
+    {
+      "name": "ETE GeneTree splitter",
+      "id": "ete_genetree_splitter",
+      "description": "from a genetree using the ETE Toolkit",
+      "tool_shed_repository": "ete",
+      "panel_section_name": "Phylogenetics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/earlhaminst/ete/ete_genetree_splitter/3.1.2"
+    },
+    {
+      "name": "Homology Classifier and Filter",
+      "id": "ete_homology_classifier",
+      "description": "from a genetree using the ETE Toolkit",
+      "tool_shed_repository": "ete",
+      "panel_section_name": "Phylogenetics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/earlhaminst/ete/ete_homology_classifier/3.1.2"
+    },
+    {
+      "name": "ETE taxa DB generator",
+      "id": "ete_init_taxdb",
+      "description": "generates the ETE sqlite DB from the NCBI taxdump.tar.gz",
+      "tool_shed_repository": "ete",
+      "panel_section_name": "Phylogenetics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/earlhaminst/ete/ete_init_taxdb/3.1.2"
+    },
+    {
+      "name": "ETE lineage generator",
+      "id": "ete_lineage_generator",
+      "description": "from a list of species/taxids using the ETE Toolkit",
+      "tool_shed_repository": "ete",
+      "panel_section_name": "Phylogenetics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/earlhaminst/ete/ete_lineage_generator/3.1.2+galaxy1"
+    },
+    {
+      "name": "ETE mod",
+      "id": "ete3_mod",
+      "description": "manipulates tree topology by rooting, pruning or sorting branches",
+      "tool_shed_repository": "ete",
+      "panel_section_name": "Phylogenetics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/earlhaminst/ete/ete3_mod/3.1.2"
+    },
+    {
+      "name": "ETE species tree generator",
+      "id": "ete_species_tree_generator",
+      "description": "from a list of species using the ETE Toolkit",
+      "tool_shed_repository": "ete",
+      "panel_section_name": "Phylogenetics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/earlhaminst/ete/ete_species_tree_generator/3.1.2"
+    },
+    {
+      "name": "Nextclade",
+      "id": "nextclade",
+      "description": "Viral genome clade assignment, mutation calling, and sequence quality checks",
+      "tool_shed_repository": "nextclade",
+      "panel_section_name": "Phylogenetics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/nextclade/nextclade/1.11.0+galaxy0"
+    },
+    {
+      "name": "Pangolin",
+      "id": "pangolin",
+      "description": "Phylogenetic Assignment of Outbreak Lineages",
+      "tool_shed_repository": "pangolin",
+      "panel_section_name": "Phylogenetics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/pangolin/pangolin/3.1.20+galaxy0"
+    },
+    {
+      "name": "SNP distance matrix",
+      "id": "snp_dists",
+      "description": "Compute distance in SNPs between all sequences in a FASTA file",
+      "tool_shed_repository": "snp_dists",
+      "panel_section_name": "Phylogenetics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/snp_dists/snp_dists/0.8.2+galaxy0"
+    },
+    {
+      "name": "HyPhy-Summary",
+      "id": "hyphy_summary",
+      "description": "generate summary report of HyPhy analyses",
+      "tool_shed_repository": "hyphy_summary",
+      "panel_section_name": "Phylogenetics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/hyphy_summary/hyphy_summary/1.2.0"
+    },
+    {
+      "name": "Annotate",
+      "id": "hyphy_annotate",
+      "description": "a newick tree with HyPhy",
+      "tool_shed_repository": "hyphy_annotate",
+      "panel_section_name": "Phylogenetics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/hyphy_annotate/hyphy_annotate/2.5.36+galaxy0"
+    },
+    {
+      "name": "UShER matUtils",
+      "id": "usher_matutils",
+      "description": "analyze, edit, and manipulate mutation annotated tree files",
+      "tool_shed_repository": "usher_matutils",
+      "panel_section_name": "Phylogenetics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/usher_matutils/usher_matutils/0.2.1+galaxy0"
+    },
+    {
+      "name": "UShER",
+      "id": "usher",
+      "description": "ultrafast sample placement on existing trees",
+      "tool_shed_repository": "usher",
+      "panel_section_name": "Phylogenetics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/usher/usher/0.2.1+galaxy0"
+    },
+    {
+      "name": "sarscov2formatter",
+      "id": "sarscov2formatter",
+      "description": "",
+      "tool_shed_repository": "sarscov2formatter",
+      "panel_section_name": "Phylogenetics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/sarscov2formatter/sarscov2formatter/1.0+galaxy0"
+    },
+    {
+      "name": "T-Coffee",
+      "id": "t_coffee",
+      "description": "multiple sequence alignment",
+      "tool_shed_repository": "t_coffee",
+      "panel_section_name": "Phylogenetics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/earlhaminst/t_coffee/t_coffee/13.45.0.4846264"
+    },
+    {
+      "name": "Phyogenetic reconstruction with RAxML",
+      "id": "raxml",
+      "description": "- Maximum Likelihood based inference of large phylogenetic trees",
+      "tool_shed_repository": "raxml",
+      "panel_section_name": "Genome Diversity",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/raxml/raxml/8.2.4+galaxy2"
+    },
+    {
+      "name": "GeneSeqToFamily preparation",
+      "id": "gstf_preparation",
+      "description": "converts data for the workflow",
+      "tool_shed_repository": "gstf_preparation",
+      "panel_section_name": "Phylogenetics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/earlhaminst/gstf_preparation/gstf_preparation/0.4.3"
+    },
+    {
+      "name": "PhyML",
+      "id": "phyml",
+      "description": "Phylogeny software based on the maximum-likelihood method.",
+      "tool_shed_repository": "phyml",
+      "panel_section_name": "Phylogenetics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/phyml/phyml/3.3.20190909"
+    },
+    {
+      "name": "sarscov2summary",
+      "id": "sarscov2summary",
+      "description": "",
+      "tool_shed_repository": "sarscov2summary",
+      "panel_section_name": "Phylogenetics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/sarscov2summary/sarscov2summary/0.1"
+    },
+    {
+      "name": "hcluster_sg parser",
+      "id": "hcluster_sg_parser",
+      "description": "converts hcluster_sg 3-column output into lists of IDs",
+      "tool_shed_repository": "hcluster_sg_parser",
+      "panel_section_name": "Phylogenetics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/earlhaminst/hcluster_sg_parser/hcluster_sg_parser/0.2.1"
+    },
+    {
+      "name": "TreeBeST best",
+      "id": "treebest_best",
+      "description": "Generate a phylogenetic tree using CDS alignment and species tree",
+      "tool_shed_repository": "treebest_best",
+      "panel_section_name": "Phylogenetics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/earlhaminst/treebest_best/treebest_best/1.9.2.post0"
+    },
+    {
+      "name": "Species tree generator",
+      "id": "species_tree_generator",
+      "description": "from a list of species using the ETE Toolkit",
+      "tool_shed_repository": "ete",
+      "panel_section_name": "Phylogenetics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/earlhaminst/ete/species_tree_generator/3.0.0b35"
+    },
+    {
+      "name": "Gene Align and Family Aggregator",
+      "id": "gafa",
+      "description": "generates an SQLite database that can be visualised with Aequatus",
+      "tool_shed_repository": "gafa",
+      "panel_section_name": "Phylogenetics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/earlhaminst/gafa/gafa/0.3.0"
+    },
+    {
+      "name": "TreeBeST best",
+      "id": "treebest_best_wrapper",
+      "description": "Generate a phylogenetic tree using CDS alignment and species tree",
+      "tool_shed_repository": "treebest_best",
+      "panel_section_name": "Phylogenetics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/earlhaminst/treebest_best/treebest_best_wrapper/1.9.2"
+    },
+    {
+      "name": "FASTA header converter",
+      "id": "fasta_header_converter",
+      "description": "to append species information",
+      "tool_shed_repository": "treebest_best",
+      "panel_section_name": "Phylogenetics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/earlhaminst/treebest_best/fasta_header_converter/0.1.1"
+    },
+    {
+      "name": "hcluster_sg",
+      "id": "hcluster_sg",
+      "description": "Hierarchically clustering on a sparse graph",
+      "tool_shed_repository": "hcluster_sg",
+      "panel_section_name": "Phylogenetics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/earlhaminst/hcluster_sg/hcluster_sg/0.5.1.1"
+    },
+    {
+      "name": "BLAST parser",
+      "id": "blast_parser",
+      "description": "Convert 12- or 24-column BLAST output into 3-column hcluster_sg input",
+      "tool_shed_repository": "blast_parser",
+      "panel_section_name": "Phylogenetics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/earlhaminst/blast_parser/blast_parser/0.1.2"
+    },
+    {
+      "name": "VCF to pgSnp",
+      "id": "vcf2pgSnp",
+      "description": "Convert from VCF to pgSnp format",
+      "tool_shed_repository": "vcf2pgsnp",
+      "panel_section_name": "Phenotype Association",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/vcf2pgsnp/vcf2pgSnp/1.0.0"
+    },
+    {
+      "name": "snpFreq",
+      "id": "hgv_snpFreq",
+      "description": "significant SNPs in case-control data",
+      "tool_shed_repository": "snpfreq",
+      "panel_section_name": "Phenotype Association",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/snpfreq/hgv_snpFreq/1.0.1"
+    },
+    {
+      "name": "FunDO",
+      "id": "hgv_funDo",
+      "description": "human genes associated with disease terms",
+      "tool_shed_repository": "hgv_fundo",
+      "panel_section_name": "Phenotype Association",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/hgv_fundo/hgv_funDo/1.0.0"
+    },
+    {
+      "name": "HVIS",
+      "id": "hgv_hilbertvis",
+      "description": "visualization of genomic data with the Hilbert curve",
+      "tool_shed_repository": "hgv_hilbertvis",
+      "panel_section_name": "Phenotype Association",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/hgv_hilbertvis/hgv_hilbertvis/1.0.0"
+    },
+    {
+      "name": "Separate pgSnp alleles",
+      "id": "dividePgSnp",
+      "description": "into columns",
+      "tool_shed_repository": "divide_pg_snp",
+      "panel_section_name": "Phenotype Association",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/divide_pg_snp/dividePgSnp/1.0.0"
+    },
+    {
+      "name": "CTD",
+      "id": "ctdBatch_1",
+      "description": "analysis of chemicals, diseases, or genes",
+      "tool_shed_repository": "ctd_batch",
+      "panel_section_name": "Phenotype Association",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/ctd_batch/ctdBatch_1/1.0.0"
+    },
+    {
+      "name": "Construct Expression Set Object",
+      "id": "music_construct_eset",
+      "description": "Create an ExpressionSet object from tabular and textual data",
+      "tool_shed_repository": "music_construct_eset",
+      "panel_section_name": "Single-cell",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/music_construct_eset/music_construct_eset/0.1.1+galaxy3"
+    },
+    {
+      "name": "MuSiC Deconvolution",
+      "id": "music_deconvolution",
+      "description": "estimate cell type proportions in bulk RNA-seq data",
+      "tool_shed_repository": "music_deconvolution",
+      "panel_section_name": "Single-cell",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/music_deconvolution/music_deconvolution/0.1.1+galaxy3"
+    },
+    {
+      "name": "MuSiC Compare",
+      "id": "music_compare",
+      "description": "estimate and compare cell type proportions in multiple sets of bulk RNA-seq data",
+      "tool_shed_repository": "music_compare",
+      "panel_section_name": "Single-cell",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/music_compare/music_compare/0.1.1+galaxy3"
+    },
+    {
+      "name": "Cluster Inspection using RaceID",
+      "id": "raceid_inspectclusters",
+      "description": "examines gene expression within clusters",
+      "tool_shed_repository": "raceid_inspectclusters",
+      "panel_section_name": "Single-cell",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/raceid_inspectclusters/raceid_inspectclusters/3.1"
+    },
+    {
+      "name": "Initial processing using RaceID",
+      "id": "raceid_filtnormconf",
+      "description": "performs filtering, normalisation, and confounder removal to generate a normalised and filtered count matrix of single-cell RNA data",
+      "tool_shed_repository": "raceid_filtnormconf",
+      "panel_section_name": "Single-cell",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/raceid_filtnormconf/raceid_filtnormconf/3.1"
+    },
+    {
+      "name": "Clustering using RaceID",
+      "id": "raceid_clustering",
+      "description": "performs clustering, outlier detection, dimensional reduction",
+      "tool_shed_repository": "raceid_clustering",
+      "panel_section_name": "Single-cell",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/raceid_clustering/raceid_clustering/3.1"
+    },
+    {
+      "name": "Lineage computation using StemID",
+      "id": "raceid_trajectory",
+      "description": "generates lineage from prior clustering",
+      "tool_shed_repository": "raceid_trajectory",
+      "panel_section_name": "Single-cell",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/raceid_trajectory/raceid_trajectory/3.1"
+    },
+    {
+      "name": "Lineage Branch Analysis using StemID",
+      "id": "raceid_inspecttrajectory",
+      "description": "inspects branches of a lineage tree",
+      "tool_shed_repository": "raceid_inspecttrajectory",
+      "panel_section_name": "Single-cell",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/raceid_inspecttrajectory/raceid_inspecttrajectory/3.1"
+    },
+    {
+      "name": "Alevin",
+      "id": "alevin",
+      "description": "Quantification and analysis of 3\u2019 tagged-end single-cell sequencing data",
+      "tool_shed_repository": "alevin",
+      "panel_section_name": "Single-cell",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/alevin/alevin/1.5.1+galaxy0"
+    },
+    {
+      "name": "Import Anndata and loom",
+      "id": "anndata_import",
+      "description": "from different format",
+      "tool_shed_repository": "anndata_import",
+      "panel_section_name": "Single-cell",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/anndata_import/anndata_import/0.7.5+galaxy0"
+    },
+    {
+      "name": "Export AnnData and loom files",
+      "id": "anndata_export",
+      "description": "Interconvert AnnData and Loom formats",
+      "tool_shed_repository": "anndata_export",
+      "panel_section_name": "Single-cell",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/anndata_export/anndata_export/0.7.5+galaxy0"
+    },
+    {
+      "name": "Manipulate AnnData",
+      "id": "anndata_manipulate",
+      "description": "object",
+      "tool_shed_repository": "anndata_manipulate",
+      "panel_section_name": "Single-cell",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/anndata_manipulate/anndata_manipulate/0.7.5+galaxy0"
+    },
+    {
+      "name": "Inspect Expression Set Object",
+      "id": "music_inspect_eset",
+      "description": "Inspect an ExpressionSet object by a variety of attributes",
+      "tool_shed_repository": "music_inspect_eset",
+      "panel_section_name": "Single-cell",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/music_inspect_eset/music_inspect_eset/0.1.1+galaxy3"
+    },
+    {
+      "name": "Inspect AnnData",
+      "id": "anndata_inspect",
+      "description": "object",
+      "tool_shed_repository": "anndata_inspect",
+      "panel_section_name": "Single-cell",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/anndata_inspect/anndata_inspect/0.7.5+galaxy0"
+    },
+    {
+      "name": "Manipulate loom object",
+      "id": "modify_loom",
+      "description": "Add layers, or row/column attributes to a loom file",
+      "tool_shed_repository": "modify_loom",
+      "panel_section_name": "Single-cell",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/modify_loom/modify_loom/0.7.5+galaxy0"
+    },
+    {
+      "name": "DropletUtils Read10x",
+      "id": "dropletutils_read_10x",
+      "description": "into SingleCellExperiment object",
+      "tool_shed_repository": "dropletutils_read_10x",
+      "panel_section_name": "Single-cell",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/dropletutils_read_10x/dropletutils_read_10x/1.0.4+galaxy0"
+    },
+    {
+      "name": "DropletUtils emptyDrops",
+      "id": "dropletutils_empty_drops",
+      "description": "Distinguish between droplets containing cells and ambient RNA in a droplet-based single-cell RNA sequencing experiment.",
+      "tool_shed_repository": "dropletutils_empty_drops",
+      "panel_section_name": "Single-cell",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/dropletutils_empty_drops/dropletutils_empty_drops/1.0.4+galaxy0"
+    },
+    {
+      "name": "Slice Image",
+      "id": "ip_slice_image",
+      "description": "into smaller patches",
+      "tool_shed_repository": "slice_image",
+      "panel_section_name": "Single-cell",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/imgteam/slice_image/ip_slice_image/0.3"
+    },
+    {
+      "name": "Scanpy ParameterIterator",
+      "id": "scanpy_parameter_iterator",
+      "description": "produce an iteration over a defined parameter",
+      "tool_shed_repository": "scanpy_parameter_iterator",
+      "panel_section_name": "Scanpy",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_parameter_iterator/scanpy_parameter_iterator/0.0.1+galaxy1"
+    },
+    {
+      "name": "Scater: plot expression frequency",
+      "id": "scater_plot_exprs_freq",
+      "description": "Plot the frequency of expression against the mean expression level for SCE",
+      "tool_shed_repository": "scater_plot_exprs_freq",
+      "panel_section_name": "Single-cell",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/scater_plot_exprs_freq/scater_plot_exprs_freq/1.12.2"
+    },
+    {
+      "name": "Scater: normalize SCE",
+      "id": "scater_normalize",
+      "description": "Compute normalised expression values for SCE",
+      "tool_shed_repository": "scater_normalize",
+      "panel_section_name": "Single-cell",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/scater_normalize/scater_normalize/1.12.2"
+    },
+    {
+      "name": "CollectBaseDistributionByCycle",
+      "id": "picard_CollectBaseDistributionByCycle",
+      "description": "charts the nucleotide distribution per cycle in a SAM or BAM dataset",
+      "tool_shed_repository": "picard",
+      "panel_section_name": "Picard",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/picard/picard_CollectBaseDistributionByCycle/2.18.2.1"
+    },
+    {
+      "name": "AddOrReplaceReadGroups",
+      "id": "picard_AddOrReplaceReadGroups",
+      "description": "add or replaces read group information",
+      "tool_shed_repository": "picard",
+      "panel_section_name": "Picard",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/picard/picard_AddOrReplaceReadGroups/2.18.2.1"
+    },
+    {
+      "name": "MeanQualityByCycle",
+      "id": "picard_MeanQualityByCycle",
+      "description": "chart distribution of base qualities",
+      "tool_shed_repository": "picard",
+      "panel_section_name": "Picard",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/picard/picard_MeanQualityByCycle/2.18.2.1"
+    },
+    {
+      "name": "RevertOriginalBaseQualitiesAndAddMateCigar",
+      "id": "picard_RevertOriginalBaseQualitiesAndAddMateCigar",
+      "description": "revert the original base qualities and add the mate cigar tag",
+      "tool_shed_repository": "picard",
+      "panel_section_name": "Picard",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/picard/picard_RevertOriginalBaseQualitiesAndAddMateCigar/2.18.2.1"
+    },
+    {
+      "name": "CollectHsMetrics",
+      "id": "picard_CollectHsMetrics",
+      "description": "compute metrics about datasets generated through hybrid-selection (e.g. exome)",
+      "tool_shed_repository": "picard",
+      "panel_section_name": "Picard",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/picard/picard_CollectHsMetrics/2.18.2"
+    },
+    {
+      "name": "SortSam",
+      "id": "picard_SortSam",
+      "description": "sort SAM/BAM dataset",
+      "tool_shed_repository": "picard",
+      "panel_section_name": "Picard",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/picard/picard_SortSam/2.18.2.1"
+    },
+    {
+      "name": "RevertSam",
+      "id": "picard_RevertSam",
+      "description": "revert SAM/BAM datasets to a previous state",
+      "tool_shed_repository": "picard",
+      "panel_section_name": "Picard",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/picard/picard_RevertSam/2.18.2.1"
+    },
+    {
+      "name": "FixMateInformation",
+      "id": "picard_FixMateInformation",
+      "description": "ensure that all mate-pair information is in sync between each read and it's mate pair",
+      "tool_shed_repository": "picard",
+      "panel_section_name": "Picard",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/picard/picard_FixMateInformation/2.18.2.1"
+    },
+    {
+      "name": "Collect Alignment Summary Metrics",
+      "id": "picard_CASM",
+      "description": "writes a file containing summary alignment metrics",
+      "tool_shed_repository": "picard",
+      "panel_section_name": "Picard",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/picard/picard_CASM/2.18.2.1"
+    },
+    {
+      "name": "NormalizeFasta",
+      "id": "picard_NormalizeFasta",
+      "description": "normalize fasta datasets",
+      "tool_shed_repository": "picard",
+      "panel_section_name": "Picard",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/picard/picard_NormalizeFasta/2.18.2.1"
+    },
+    {
+      "name": "Downsample SAM/BAM",
+      "id": "picard_DownsampleSam",
+      "description": "Downsample a file to retain a subset of the reads",
+      "tool_shed_repository": "picard",
+      "panel_section_name": "Picard",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/picard/picard_DownsampleSam/2.18.2.1"
+    },
+    {
+      "name": "MergeBamAlignment",
+      "id": "picard_MergeBamAlignment",
+      "description": "merge alignment data with additional info stored in an unmapped BAM dataset",
+      "tool_shed_repository": "picard",
+      "panel_section_name": "Picard",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/picard/picard_MergeBamAlignment/2.18.2.1"
+    },
+    {
+      "name": "MarkDuplicatesWithMateCigar",
+      "id": "picard_MarkDuplicatesWithMateCigar",
+      "description": "examine aligned records in BAM datasets to locate duplicate molecules",
+      "tool_shed_repository": "picard",
+      "panel_section_name": "Picard",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/picard/picard_MarkDuplicatesWithMateCigar/2.18.2.2"
+    },
+    {
+      "name": "CleanSam",
+      "id": "picard_CleanSam",
+      "description": "perform SAM/BAM grooming",
+      "tool_shed_repository": "picard",
+      "panel_section_name": "Picard",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/picard/picard_CleanSam/2.18.2.1"
+    },
+    {
+      "name": "MergeSamFiles",
+      "id": "picard_MergeSamFiles",
+      "description": "merges multiple SAM/BAM datasets into one",
+      "tool_shed_repository": "picard",
+      "panel_section_name": "Picard",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/picard/picard_MergeSamFiles/2.18.2.1"
+    },
+    {
+      "name": "MarkDuplicates",
+      "id": "picard_MarkDuplicates",
+      "description": "examine aligned records in BAM datasets to locate duplicate molecules",
+      "tool_shed_repository": "picard",
+      "panel_section_name": "Picard",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/picard/picard_MarkDuplicates/2.18.2.3"
+    },
+    {
+      "name": "ValidateSamFile",
+      "id": "picard_ValidateSamFile",
+      "description": "assess validity of SAM/BAM dataset",
+      "tool_shed_repository": "picard",
+      "panel_section_name": "Picard",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/picard/picard_ValidateSamFile/2.18.2.1"
+    },
+    {
+      "name": "QualityScoreDistribution",
+      "id": "picard_QualityScoreDistribution",
+      "description": "chart quality score distribution",
+      "tool_shed_repository": "picard",
+      "panel_section_name": "Picard",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/picard/picard_QualityScoreDistribution/2.18.2.1"
+    },
+    {
+      "name": "CollectRnaSeqMetrics",
+      "id": "picard_CollectRnaSeqMetrics",
+      "description": "collect metrics about the alignment of RNA to various functional classes of loci in the genome",
+      "tool_shed_repository": "picard",
+      "panel_section_name": "Picard",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/picard/picard_CollectRnaSeqMetrics/2.18.2.2"
+    },
+    {
+      "name": "BedToIntervalList",
+      "id": "picard_BedToIntervalList",
+      "description": "convert coordinate data into picard interval list format",
+      "tool_shed_repository": "picard",
+      "panel_section_name": "Picard",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/picard/picard_BedToIntervalList/2.18.2.1"
+    },
+    {
+      "name": "CollectWgsMetrics",
+      "id": "picard_CollectWgsMetrics",
+      "description": "compute metrics for evaluating of whole genome sequencing experiments",
+      "tool_shed_repository": "picard",
+      "panel_section_name": "Picard",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/picard/picard_CollectWgsMetrics/2.18.2.1"
+    },
+    {
+      "name": "Picard Collect Sequencing Artifact Metrics",
+      "id": "picard_artifact_metrics",
+      "description": "Collect metrics to quantify single-base sequencing artifacts",
+      "tool_shed_repository": "picard",
+      "panel_section_name": "Picard",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/picard/picard_artifact_metrics/2.18.2.1"
+    },
+    {
+      "name": "CollectGcBiasMetrics",
+      "id": "picard_CollectGcBiasMetrics",
+      "description": "charts the GC bias metrics",
+      "tool_shed_repository": "picard",
+      "panel_section_name": "Picard",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/picard/picard_CollectGcBiasMetrics/2.18.2.1"
+    },
+    {
+      "name": "FilterSamReads",
+      "id": "picard_FilterSamReads",
+      "description": "include or exclude aligned and unaligned reads and read lists",
+      "tool_shed_repository": "picard",
+      "panel_section_name": "Picard",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/picard/picard_FilterSamReads/2.18.2.1"
+    },
+    {
+      "name": "AddCommentsToBam",
+      "id": "picard_AddCommentsToBam",
+      "description": "add comments to BAM dataset",
+      "tool_shed_repository": "picard",
+      "panel_section_name": "Picard",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/picard/picard_AddCommentsToBam/2.18.2.1"
+    },
+    {
+      "name": "EstimateLibraryComplexity",
+      "id": "picard_EstimateLibraryComplexity",
+      "description": "assess sequence library complexity from read sequences",
+      "tool_shed_repository": "picard",
+      "panel_section_name": "Picard",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/picard/picard_EstimateLibraryComplexity/2.18.2.1"
+    },
+    {
+      "name": "CollectInsertSizeMetrics",
+      "id": "picard_CollectInsertSizeMetrics",
+      "description": "plots distribution of insert sizes",
+      "tool_shed_repository": "picard",
+      "panel_section_name": "Picard",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/picard/picard_CollectInsertSizeMetrics/2.18.2.1"
+    },
+    {
+      "name": "SAM/BAM Alignment Summary Metrics",
+      "id": "PicardASMetrics",
+      "description": "",
+      "tool_shed_repository": "picard",
+      "panel_section_name": "Picard",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/picard/PicardASMetrics/1.56.0"
+    },
+    {
+      "name": "BAM Index Statistics",
+      "id": "picard_BamIndexStats",
+      "description": "",
+      "tool_shed_repository": "picard",
+      "panel_section_name": "Picard",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/picard/picard_BamIndexStats/1.56.0"
+    },
+    {
+      "name": "Add or Replace Groups",
+      "id": "picard_ARRG",
+      "description": "",
+      "tool_shed_repository": "picard",
+      "panel_section_name": "Picard",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/picard/picard_ARRG/1.56.0"
+    },
+    {
+      "name": "Estimate Library Complexity",
+      "id": "rgEstLibComp",
+      "description": "",
+      "tool_shed_repository": "picard",
+      "panel_section_name": "Picard",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/picard/rgEstLibComp/1.56.0"
+    },
+    {
+      "name": "Insertion size metrics",
+      "id": "PicardInsertSize",
+      "description": "for PAIRED data",
+      "tool_shed_repository": "picard",
+      "panel_section_name": "Picard",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/picard/PicardInsertSize/1.56.0"
+    },
+    {
+      "name": "Paired Read Mate Fixer",
+      "id": "rgPicFixMate",
+      "description": "for paired data",
+      "tool_shed_repository": "picard",
+      "panel_section_name": "Picard",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/picard/rgPicFixMate/1.56.0"
+    },
+    {
+      "name": "bamCompare",
+      "id": "deeptools_bam_compare",
+      "description": "normalizes and compares two BAM or CRAM files to obtain the ratio, log2ratio or difference between them",
+      "tool_shed_repository": "deeptools_bam_compare",
+      "panel_section_name": "deepTools",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/deeptools_bam_compare/deeptools_bam_compare/3.5.1.0.0"
+    },
+    {
+      "name": "bamPEFragmentSize",
+      "id": "deeptools_bam_pe_fragmentsize",
+      "description": "Estimate the predominant cDNA fragment length from paired-end sequenced BAM/CRAM files",
+      "tool_shed_repository": "deeptools_bam_pe_fragmentsize",
+      "panel_section_name": "deepTools",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/deeptools_bam_pe_fragmentsize/deeptools_bam_pe_fragmentsize/3.5.1.0.0"
+    },
+    {
+      "name": "multiBamSummary",
+      "id": "deeptools_multi_bam_summary",
+      "description": "calculates average read coverages for a list of two or more BAM/CRAM files",
+      "tool_shed_repository": "deeptools_multi_bam_summary",
+      "panel_section_name": "deepTools",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/deeptools_multi_bam_summary/deeptools_multi_bam_summary/3.5.1.0.0"
+    },
+    {
+      "name": "computeMatrix",
+      "id": "deeptools_compute_matrix",
+      "description": "prepares data for plotting a heatmap or a profile of given regions",
+      "tool_shed_repository": "deeptools_compute_matrix",
+      "panel_section_name": "deepTools",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/deeptools_compute_matrix/deeptools_compute_matrix/3.5.1.0.0"
+    },
+    {
+      "name": "plotEnrichment",
+      "id": "deeptools_plot_enrichment",
+      "description": "plots read/fragment coverage over sets of regions",
+      "tool_shed_repository": "deeptools_plot_enrichment",
+      "panel_section_name": "deepTools",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/deeptools_plot_enrichment/deeptools_plot_enrichment/3.5.1.0.0"
+    },
+    {
+      "name": "bamCoverage",
+      "id": "deeptools_bam_coverage",
+      "description": "generates a coverage bigWig file from a given BAM or CRAM file",
+      "tool_shed_repository": "deeptools_bam_coverage",
+      "panel_section_name": "deepTools",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/deeptools_bam_coverage/deeptools_bam_coverage/3.5.1.0.0"
+    },
+    {
+      "name": "bigwigCompare",
+      "id": "deeptools_bigwig_compare",
+      "description": "normalizes and compares two bigWig files to obtain the ratio, log2ratio or difference between them",
+      "tool_shed_repository": "deeptools_bigwig_compare",
+      "panel_section_name": "deepTools",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/deeptools_bigwig_compare/deeptools_bigwig_compare/3.5.1.0.0"
+    },
+    {
+      "name": "plotHeatmap",
+      "id": "deeptools_plot_heatmap",
+      "description": "creates a heatmap for score distributions across genomic regions",
+      "tool_shed_repository": "deeptools_plot_heatmap",
+      "panel_section_name": "deepTools",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/deeptools_plot_heatmap/deeptools_plot_heatmap/3.5.1.0.1"
+    },
+    {
+      "name": "correctGCBias",
+      "id": "deeptools_correct_gc_bias",
+      "description": "uses the output from computeGCBias to generate GC-corrected BAM/CRAM files",
+      "tool_shed_repository": "deeptools_correct_gc_bias",
+      "panel_section_name": "deepTools",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/deeptools_correct_gc_bias/deeptools_correct_gc_bias/3.5.1.0.0"
+    },
+    {
+      "name": "alignmentsieve",
+      "id": "deeptools_alignmentsieve",
+      "description": "Filter BAM/CRAM files according to specified parameters",
+      "tool_shed_repository": "deeptools_alignmentsieve",
+      "panel_section_name": "deepTools",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/deeptools_alignmentsieve/deeptools_alignmentsieve/3.5.1.0.0"
+    },
+    {
+      "name": "computeMatrixOperations",
+      "id": "deeptools_compute_matrix_operations",
+      "description": "Modify or combine the output of computeMatrix in a variety of ways.",
+      "tool_shed_repository": "deeptools_compute_matrix_operations",
+      "panel_section_name": "deepTools",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/deeptools_compute_matrix_operations/deeptools_compute_matrix_operations/3.5.1.0.0"
+    },
+    {
+      "name": "plotFingerprint",
+      "id": "deeptools_plot_fingerprint",
+      "description": "plots profiles of BAM files; useful for assessing ChIP signal strength",
+      "tool_shed_repository": "deeptools_plot_fingerprint",
+      "panel_section_name": "deepTools",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/deeptools_plot_fingerprint/deeptools_plot_fingerprint/3.5.1.0.0"
+    },
+    {
+      "name": "plotCoverage",
+      "id": "deeptools_plot_coverage",
+      "description": "assesses the sequencing depth of BAM/CRAM files",
+      "tool_shed_repository": "deeptools_plot_coverage",
+      "panel_section_name": "deepTools",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/deeptools_plot_coverage/deeptools_plot_coverage/3.5.1.0.0"
+    },
+    {
+      "name": "plotCorrelation",
+      "id": "deeptools_plot_correlation",
+      "description": "Create a heatmap or scatterplot of correlation scores between different samples",
+      "tool_shed_repository": "deeptools_plot_correlation",
+      "panel_section_name": "deepTools",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/deeptools_plot_correlation/deeptools_plot_correlation/3.5.1.0.0"
+    },
+    {
+      "name": "plotProfile",
+      "id": "deeptools_plot_profile",
+      "description": "creates a profile plot for score distributions across genomic regions",
+      "tool_shed_repository": "deeptools_plot_profile",
+      "panel_section_name": "deepTools",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/deeptools_plot_profile/deeptools_plot_profile/3.5.1.0.0"
+    },
+    {
+      "name": "multiBigwigSummary",
+      "id": "deeptools_multi_bigwig_summary",
+      "description": "calculates average scores for a list of two or more bigwig files",
+      "tool_shed_repository": "deeptools_multi_bigwig_summary",
+      "panel_section_name": "deepTools",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/deeptools_multi_bigwig_summary/deeptools_multi_bigwig_summary/3.5.1.0.0"
+    },
+    {
+      "name": "computeGCBias",
+      "id": "deeptools_compute_gc_bias",
+      "description": "Determine the GC bias of your sequenced reads",
+      "tool_shed_repository": "deeptools_compute_gc_bias",
+      "panel_section_name": "deepTools",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/deeptools_compute_gc_bias/deeptools_compute_gc_bias/3.5.1.0.0"
+    },
+    {
+      "name": "plotPCA",
+      "id": "deeptools_plot_pca",
+      "description": "Generate principal component analysis (PCA) plots from multiBamSummary or multiBigwigSummary output",
+      "tool_shed_repository": "deeptools_plot_pca",
+      "panel_section_name": "deepTools",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/deeptools_plot_pca/deeptools_plot_pca/3.5.1.0.0"
+    },
+    {
+      "name": "estimateReadFiltering",
+      "id": "deeptools_estimatereadfiltering",
+      "description": "estimates the number of reads that would be filtered given certain criteria",
+      "tool_shed_repository": "deeptools_estimatereadfiltering",
+      "panel_section_name": "deepTools",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/deeptools_estimatereadfiltering/deeptools_estimatereadfiltering/3.3.2.0.0"
+    },
+    {
+      "name": "Hicup Deduplicator",
+      "id": "hicup_deduplicator",
+      "description": "removes duplicated di-tags (retaining one copy of each) from the data set.",
+      "tool_shed_repository": "hicup_deduplicator",
+      "panel_section_name": "deepTools",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/hicup_deduplicator/hicup_deduplicator/0.1.0"
+    },
+    {
+      "name": "GEMINI query",
+      "id": "gemini_query",
+      "description": "Querying the GEMINI database",
+      "tool_shed_repository": "gemini_query",
+      "panel_section_name": "Gemini",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/gemini_query/gemini_query/0.20.1+galaxy1"
+    },
+    {
+      "name": "GEMINI annotate",
+      "id": "gemini_annotate",
+      "description": "the variants in an existing GEMINI database with additional information",
+      "tool_shed_repository": "gemini_annotate",
+      "panel_section_name": "Gemini",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/gemini_annotate/gemini_annotate/0.20.1+galaxy2"
+    },
+    {
+      "name": "GEMINI load",
+      "id": "gemini_load",
+      "description": "Loading a VCF file into GEMINI",
+      "tool_shed_repository": "gemini_load",
+      "panel_section_name": "Gemini",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/gemini_load/gemini_load/0.20.1+galaxy2"
+    },
+    {
+      "name": "GEMINI database info",
+      "id": "gemini_db_info",
+      "description": "Retrieve information about tables, columns and annotation data stored in a GEMINI database",
+      "tool_shed_repository": "gemini_db_info",
+      "panel_section_name": "Gemini",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/gemini_db_info/gemini_db_info/0.20.1"
+    },
+    {
+      "name": "GEMINI pathways",
+      "id": "gemini_pathways",
+      "description": "Map genes and variants to KEGG pathways",
+      "tool_shed_repository": "gemini_pathways",
+      "panel_section_name": "Gemini",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/gemini_pathways/gemini_pathways/0.20.1"
+    },
+    {
+      "name": "GEMINI windower",
+      "id": "gemini_windower",
+      "description": "Compute sliding window statistics from variants",
+      "tool_shed_repository": "gemini_windower",
+      "panel_section_name": "Gemini",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/gemini_windower/gemini_windower/0.20.1"
+    },
+    {
+      "name": "GEMINI inheritance pattern",
+      "id": "gemini_inheritance",
+      "description": "based identification of candidate genes",
+      "tool_shed_repository": "gemini_inheritance",
+      "panel_section_name": "Gemini",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/gemini_inheritance/gemini_inheritance/0.20.1"
+    },
+    {
+      "name": "GEMINI interactions",
+      "id": "gemini_interactions",
+      "description": "Find genes among variants that are interacting partners",
+      "tool_shed_repository": "gemini_interactions",
+      "panel_section_name": "Gemini",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/gemini_interactions/gemini_interactions/0.20.1"
+    },
+    {
+      "name": "GEMINI qc",
+      "id": "gemini_qc",
+      "description": "Quality control tool",
+      "tool_shed_repository": "gemini_qc",
+      "panel_section_name": "Gemini",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/gemini_qc/gemini_qc/0.20.1"
+    },
+    {
+      "name": "GEMINI set_somatic",
+      "id": "gemini_set_somatic",
+      "description": "Tag somatic mutations in a GEMINI database",
+      "tool_shed_repository": "gemini_set_somatic",
+      "panel_section_name": "Gemini",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/gemini_set_somatic/gemini_set_somatic/0.20.1"
+    },
+    {
+      "name": "GEMINI roh",
+      "id": "gemini_roh",
+      "description": "Identifying runs of homozygosity",
+      "tool_shed_repository": "gemini_roh",
+      "panel_section_name": "Gemini",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/gemini_roh/gemini_roh/0.20.1"
+    },
+    {
+      "name": "GEMINI fusions",
+      "id": "gemini_fusions",
+      "description": "Identify somatic fusion genes from a GEMINI database",
+      "tool_shed_repository": "gemini_fusions",
+      "panel_section_name": "Gemini",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/gemini_fusions/gemini_fusions/0.20.1"
+    },
+    {
+      "name": "GEMINI lof_sieve",
+      "id": "gemini_lof_sieve",
+      "description": "Filter LoF variants by transcript position and type",
+      "tool_shed_repository": "gemini_lof_sieve",
+      "panel_section_name": "Gemini",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/gemini_lof_sieve/gemini_lof_sieve/0.20.1"
+    },
+    {
+      "name": "GEMINI actionable_mutations",
+      "id": "gemini_actionable_mutations",
+      "description": "Retrieve genes with actionable somatic mutations via COSMIC and DGIdb",
+      "tool_shed_repository": "gemini_actionable_mutations",
+      "panel_section_name": "Gemini",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/gemini_actionable_mutations/gemini_actionable_mutations/0.20.1"
+    },
+    {
+      "name": "GEMINI amend",
+      "id": "gemini_amend",
+      "description": "Amend an already loaded GEMINI database.",
+      "tool_shed_repository": "gemini_amend",
+      "panel_section_name": "Gemini",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/gemini_amend/gemini_amend/0.20.1"
+    },
+    {
+      "name": "GEMINI stats",
+      "id": "gemini_stats",
+      "description": "Compute useful variant statistics",
+      "tool_shed_repository": "gemini_stats",
+      "panel_section_name": "Gemini",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/gemini_stats/gemini_stats/0.20.1"
+    },
+    {
+      "name": "GEMINI gene_wise",
+      "id": "gemini_gene_wise",
+      "description": "Discover per-gene variant patterns across families",
+      "tool_shed_repository": "gemini_gene_wise",
+      "panel_section_name": "Gemini",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/gemini_gene_wise/gemini_gene_wise/0.20.1"
+    },
+    {
+      "name": "GEMINI burden",
+      "id": "gemini_burden",
+      "description": "perform sample-wise gene-level burden calculations",
+      "tool_shed_repository": "gemini_burden",
+      "panel_section_name": "Gemini",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/gemini_burden/gemini_burden/0.20.1"
+    },
+    {
+      "name": "pepwheel",
+      "id": "EMBOSS: pepwheel72",
+      "description": "Shows protein sequences as helices",
+      "tool_shed_repository": "emboss_5",
+      "panel_section_name": "EMBOSS",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/emboss_5/EMBOSS: pepwheel72/5.0.0.1"
+    },
+    {
+      "name": "wordcount",
+      "id": "EMBOSS: wordcount109",
+      "description": "Counts words of a specified size in a DNA sequence",
+      "tool_shed_repository": "emboss_5",
+      "panel_section_name": "EMBOSS",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/emboss_5/EMBOSS: wordcount109/5.0.0.1"
+    },
+    {
+      "name": "trimest",
+      "id": "EMBOSS: trimest102",
+      "description": "Trim poly-A tails off EST sequences",
+      "tool_shed_repository": "emboss_5",
+      "panel_section_name": "EMBOSS",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/emboss_5/EMBOSS: trimest102/5.0.0.1"
+    },
+    {
+      "name": "pepwindow",
+      "id": "EMBOSS: pepwindow73",
+      "description": "Displays protein hydropathy",
+      "tool_shed_repository": "emboss_5",
+      "panel_section_name": "EMBOSS",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/emboss_5/EMBOSS: pepwindow73/5.0.0.1"
+    },
+    {
+      "name": "pepwindowall",
+      "id": "EMBOSS: pepwindowall74",
+      "description": "Displays protein hydropathy of a set of sequences",
+      "tool_shed_repository": "emboss_5",
+      "panel_section_name": "EMBOSS",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/emboss_5/EMBOSS: pepwindowall74/5.0.0.1"
+    },
+    {
+      "name": "charge",
+      "id": "EMBOSS: charge8",
+      "description": "Protein charge plot",
+      "tool_shed_repository": "emboss_5",
+      "panel_section_name": "EMBOSS",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/emboss_5/EMBOSS: charge8/5.0.0.1"
+    },
+    {
+      "name": "degapseq",
+      "id": "EMBOSS: degapseq20",
+      "description": "Removes gap characters from sequences",
+      "tool_shed_repository": "emboss_5",
+      "panel_section_name": "EMBOSS",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/emboss_5/EMBOSS: degapseq20/5.0.0"
+    },
+    {
+      "name": "infoseq",
+      "id": "EMBOSS: infoseq46",
+      "description": "Displays some simple information about sequences",
+      "tool_shed_repository": "emboss_5",
+      "panel_section_name": "EMBOSS",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/emboss_5/EMBOSS: infoseq46/5.0.0"
+    },
+    {
+      "name": "splitter",
+      "id": "EMBOSS: splitter92",
+      "description": "Split a sequence into (overlapping) smaller sequences",
+      "tool_shed_repository": "emboss_5",
+      "panel_section_name": "EMBOSS",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/emboss_5/EMBOSS: splitter92/5.0.0.1"
+    },
+    {
+      "name": "skipseq",
+      "id": "EMBOSS: skipseq91",
+      "description": "Reads and writes sequences, skipping first few",
+      "tool_shed_repository": "emboss_5",
+      "panel_section_name": "EMBOSS",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/emboss_5/EMBOSS: skipseq91/5.0.0.1"
+    },
+    {
+      "name": "needle",
+      "id": "EMBOSS: needle56",
+      "description": "Needleman-Wunsch global alignment",
+      "tool_shed_repository": "emboss_5",
+      "panel_section_name": "EMBOSS",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/emboss_5/EMBOSS: needle56/5.0.0.1"
+    },
+    {
+      "name": "patmatdb",
+      "id": "EMBOSS: patmatdb67",
+      "description": "Search a protein sequence with a motif",
+      "tool_shed_repository": "emboss_5",
+      "panel_section_name": "EMBOSS",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/emboss_5/EMBOSS: patmatdb67/5.0.0"
+    },
+    {
+      "name": "marscan",
+      "id": "EMBOSS: marscan49",
+      "description": "Finds MAR/SAR sites in nucleic sequences",
+      "tool_shed_repository": "emboss_5",
+      "panel_section_name": "EMBOSS",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/emboss_5/EMBOSS: marscan49/5.0.0"
+    },
+    {
+      "name": "water",
+      "id": "EMBOSS: water107",
+      "description": "Smith-Waterman local alignment",
+      "tool_shed_repository": "emboss_5",
+      "panel_section_name": "EMBOSS",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/emboss_5/EMBOSS: water107/5.0.0.1"
+    },
+    {
+      "name": "getorf",
+      "id": "EMBOSS: getorf42",
+      "description": "Finds and extracts open reading frames (ORFs)",
+      "tool_shed_repository": "emboss_5",
+      "panel_section_name": "EMBOSS",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/emboss_5/EMBOSS: getorf42/5.0.0.1"
+    },
+    {
+      "name": "lindna",
+      "id": "EMBOSS: lindna48",
+      "description": "Draws linear maps of DNA constructs",
+      "tool_shed_repository": "emboss_5",
+      "panel_section_name": "EMBOSS",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/emboss_5/EMBOSS: lindna48/5.0.0.1"
+    },
+    {
+      "name": "msbar",
+      "id": "EMBOSS: msbar55",
+      "description": "Mutate sequence beyond all recognition",
+      "tool_shed_repository": "emboss_5",
+      "panel_section_name": "EMBOSS",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/emboss_5/EMBOSS: msbar55/5.0.0.1"
+    },
+    {
+      "name": "oddcomp",
+      "id": "EMBOSS: oddcomp64",
+      "description": "Find protein sequence regions with a biased composition",
+      "tool_shed_repository": "emboss_5",
+      "panel_section_name": "EMBOSS",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/emboss_5/EMBOSS: oddcomp64/5.0.0.1"
+    },
+    {
+      "name": "fuzztran",
+      "id": "EMBOSS: fuzztran39",
+      "description": "Protein pattern search after translation",
+      "tool_shed_repository": "emboss_5",
+      "panel_section_name": "EMBOSS",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/emboss_5/EMBOSS: fuzztran39/5.0.0.1"
+    },
+    {
+      "name": "tcode",
+      "id": "EMBOSS: tcode97",
+      "description": "Fickett TESTCODE statistic to identify protein-coding DNA",
+      "tool_shed_repository": "emboss_5",
+      "panel_section_name": "EMBOSS",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/emboss_5/EMBOSS: tcode97/5.0.0.1"
+    },
+    {
+      "name": "pepcoil",
+      "id": "EMBOSS: pepcoil68",
+      "description": "Predicts coiled coil regions",
+      "tool_shed_repository": "emboss_5",
+      "panel_section_name": "EMBOSS",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/emboss_5/EMBOSS: pepcoil68/5.0.0.1"
+    },
+    {
+      "name": "helixturnhelix",
+      "id": "EMBOSS: helixturnhelix43",
+      "description": "Report nucleic acid binding motifs",
+      "tool_shed_repository": "emboss_5",
+      "panel_section_name": "EMBOSS",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/emboss_5/EMBOSS: helixturnhelix43/5.0.0.1"
+    },
+    {
+      "name": "iep",
+      "id": "EMBOSS: iep45",
+      "description": "Calculates the isoelectric point of a protein",
+      "tool_shed_repository": "emboss_5",
+      "panel_section_name": "EMBOSS",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/emboss_5/EMBOSS: iep45/5.0.0.1"
+    },
+    {
+      "name": "merger",
+      "id": "EMBOSS: merger54",
+      "description": "Merge two overlapping nucleic acid sequences",
+      "tool_shed_repository": "emboss_5",
+      "panel_section_name": "EMBOSS",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/emboss_5/EMBOSS: merger54/5.0.0.1"
+    },
+    {
+      "name": "equicktandem",
+      "id": "EMBOSS: equicktandem31",
+      "description": "Finds tandem repeats",
+      "tool_shed_repository": "emboss_5",
+      "panel_section_name": "EMBOSS",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/emboss_5/EMBOSS: equicktandem31/5.0.0.1"
+    },
+    {
+      "name": "newcpgseek",
+      "id": "EMBOSS: newcpgseek58",
+      "description": "Reports CpG rich region",
+      "tool_shed_repository": "emboss_5",
+      "panel_section_name": "EMBOSS",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/emboss_5/EMBOSS: newcpgseek58/5.0.0.1"
+    },
+    {
+      "name": "extractseq",
+      "id": "EMBOSS: extractseq35",
+      "description": "Extract regions from a sequence",
+      "tool_shed_repository": "emboss_5",
+      "panel_section_name": "EMBOSS",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/emboss_5/EMBOSS: extractseq35/5.0.0"
+    },
+    {
+      "name": "dreg",
+      "id": "EMBOSS: dreg27",
+      "description": "Regular expression search of a nucleotide sequence",
+      "tool_shed_repository": "emboss_5",
+      "panel_section_name": "EMBOSS",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/emboss_5/EMBOSS: dreg27/5.0.0+galaxy1"
+    },
+    {
+      "name": "maskfeat",
+      "id": "EMBOSS: maskfeat50",
+      "description": "Mask off features of a sequence",
+      "tool_shed_repository": "emboss_5",
+      "panel_section_name": "EMBOSS",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/emboss_5/EMBOSS: maskfeat50/5.0.0"
+    },
+    {
+      "name": "newcpgreport",
+      "id": "EMBOSS: newcpgreport57",
+      "description": "Report CpG rich areas",
+      "tool_shed_repository": "emboss_5",
+      "panel_section_name": "EMBOSS",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/emboss_5/EMBOSS: newcpgreport57/5.0.0.1"
+    },
+    {
+      "name": "codcmp",
+      "id": "EMBOSS: codcmp12",
+      "description": "Codon usage table comparison",
+      "tool_shed_repository": "emboss_5",
+      "panel_section_name": "EMBOSS",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/emboss_5/EMBOSS: codcmp12/5.0.0"
+    },
+    {
+      "name": "dottup",
+      "id": "EMBOSS: dottup26",
+      "description": "Displays a wordmatch dotplot of two sequences",
+      "tool_shed_repository": "emboss_5",
+      "panel_section_name": "EMBOSS",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/emboss_5/EMBOSS: dottup26/5.0.0.1"
+    },
+    {
+      "name": "supermatcher",
+      "id": "EMBOSS: supermatcher95",
+      "description": "Match large sequences against one or more other sequences",
+      "tool_shed_repository": "emboss_5",
+      "panel_section_name": "EMBOSS",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/emboss_5/EMBOSS: supermatcher95/5.0.0.1"
+    },
+    {
+      "name": "nthseq",
+      "id": "EMBOSS: nthseq62",
+      "description": "Writes one sequence from a multiple set of sequences",
+      "tool_shed_repository": "emboss_5",
+      "panel_section_name": "EMBOSS",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/emboss_5/EMBOSS: nthseq62/5.0.0.1"
+    },
+    {
+      "name": "primersearch",
+      "id": "EMBOSS: primersearch81",
+      "description": "Searches DNA sequences for matches with primer pairs",
+      "tool_shed_repository": "emboss_5",
+      "panel_section_name": "EMBOSS",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/emboss_5/EMBOSS: primersearch81/5.0.0.1"
+    },
+    {
+      "name": "fuzznuc",
+      "id": "EMBOSS: fuzznuc37",
+      "description": "Nucleic acid pattern search",
+      "tool_shed_repository": "emboss_5",
+      "panel_section_name": "EMBOSS",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/emboss_5/EMBOSS: fuzznuc37/5.0.3"
+    },
+    {
+      "name": "cutseq",
+      "id": "EMBOSS: cutseq18",
+      "description": "Removes a specified section from a sequence",
+      "tool_shed_repository": "emboss_5",
+      "panel_section_name": "EMBOSS",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/emboss_5/EMBOSS: cutseq18/5.0.0.1"
+    },
+    {
+      "name": "tranalign",
+      "id": "EMBOSS: tranalign100",
+      "description": "Align nucleic coding regions given the aligned proteins",
+      "tool_shed_repository": "emboss_5",
+      "panel_section_name": "EMBOSS",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/emboss_5/EMBOSS: tranalign100/5.0.0"
+    },
+    {
+      "name": "fuzzpro",
+      "id": "EMBOSS: fuzzpro38",
+      "description": "Protein pattern search",
+      "tool_shed_repository": "emboss_5",
+      "panel_section_name": "EMBOSS",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/emboss_5/EMBOSS: fuzzpro38/5.0.0.1"
+    },
+    {
+      "name": "cai custom",
+      "id": "EMBOSS: cai_custom6",
+      "description": "CAI codon adaptation index using custom codon usage file",
+      "tool_shed_repository": "emboss_5",
+      "panel_section_name": "EMBOSS",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/emboss_5/EMBOSS: cai_custom6/5.0.0"
+    },
+    {
+      "name": "noreturn",
+      "id": "EMBOSS: noreturn60",
+      "description": "Removes carriage return from ASCII files",
+      "tool_shed_repository": "emboss_5",
+      "panel_section_name": "EMBOSS",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/emboss_5/EMBOSS: noreturn60/5.0.0"
+    },
+    {
+      "name": "dotpath",
+      "id": "EMBOSS: dotpath25",
+      "description": "Non-overlapping wordmatch dotplot of two sequences",
+      "tool_shed_repository": "emboss_5",
+      "panel_section_name": "EMBOSS",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/emboss_5/EMBOSS: dotpath25/5.0.0.1"
+    },
+    {
+      "name": "etandem",
+      "id": "EMBOSS: etandem33",
+      "description": "Looks for tandem repeats in a nucleotide sequence",
+      "tool_shed_repository": "emboss_5",
+      "panel_section_name": "EMBOSS",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/emboss_5/EMBOSS: etandem33/5.0.0.1"
+    },
+    {
+      "name": "octanol",
+      "id": "EMBOSS: octanol63",
+      "description": "Displays protein hydropathy",
+      "tool_shed_repository": "emboss_5",
+      "panel_section_name": "EMBOSS",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/emboss_5/EMBOSS: octanol63/5.0.0.1"
+    },
+    {
+      "name": "sigcleave",
+      "id": "EMBOSS: sigcleave88",
+      "description": "Reports protein signal cleavage sites",
+      "tool_shed_repository": "emboss_5",
+      "panel_section_name": "EMBOSS",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/emboss_5/EMBOSS: sigcleave88/5.0.0.1"
+    },
+    {
+      "name": "wobble",
+      "id": "EMBOSS: wobble108",
+      "description": "Wobble base plot",
+      "tool_shed_repository": "emboss_5",
+      "panel_section_name": "EMBOSS",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/emboss_5/EMBOSS: wobble108/5.0.0.1"
+    },
+    {
+      "name": "wordmatch",
+      "id": "EMBOSS: wordmatch110",
+      "description": "Finds all exact matches of a given size between 2 sequences",
+      "tool_shed_repository": "emboss_5",
+      "panel_section_name": "EMBOSS",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/emboss_5/EMBOSS: wordmatch110/5.0.0.1"
+    },
+    {
+      "name": "union",
+      "id": "EMBOSS: union105",
+      "description": "Reads sequence fragments and builds one sequence",
+      "tool_shed_repository": "emboss_5",
+      "panel_section_name": "EMBOSS",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/emboss_5/EMBOSS: union105/5.0.0"
+    },
+    {
+      "name": "megamerger",
+      "id": "EMBOSS: megamerger53",
+      "description": "Merge two large overlapping nucleic acid sequences",
+      "tool_shed_repository": "emboss_5",
+      "panel_section_name": "EMBOSS",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/emboss_5/EMBOSS: megamerger53/5.0.0.1"
+    },
+    {
+      "name": "preg",
+      "id": "EMBOSS: preg78",
+      "description": "Regular expression search of a protein sequence",
+      "tool_shed_repository": "emboss_5",
+      "panel_section_name": "EMBOSS",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/emboss_5/EMBOSS: preg78/5.0.0+galaxy1"
+    },
+    {
+      "name": "prettyseq",
+      "id": "EMBOSS: prettyseq80",
+      "description": "Output sequence with translated ranges",
+      "tool_shed_repository": "emboss_5",
+      "panel_section_name": "EMBOSS",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/emboss_5/EMBOSS: prettyseq80/5.0.0.1"
+    },
+    {
+      "name": "prettyplot",
+      "id": "EMBOSS: prettyplot79",
+      "description": "Displays aligned sequences, with colouring and boxing",
+      "tool_shed_repository": "emboss_5",
+      "panel_section_name": "EMBOSS",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/emboss_5/EMBOSS: prettyplot79/5.0.0.1"
+    },
+    {
+      "name": "einverted",
+      "id": "EMBOSS: einverted28",
+      "description": "Finds DNA inverted repeats",
+      "tool_shed_repository": "emboss_5",
+      "panel_section_name": "EMBOSS",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/emboss_5/EMBOSS: einverted28/5.0.0.1"
+    },
+    {
+      "name": "sixpack",
+      "id": "EMBOSS: sixpack90",
+      "description": "Display a DNA sequence with 6-frame translation and ORFs",
+      "tool_shed_repository": "emboss_5",
+      "panel_section_name": "EMBOSS",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/emboss_5/EMBOSS: sixpack90/5.0.0.1"
+    },
+    {
+      "name": "syco",
+      "id": "EMBOSS: syco96",
+      "description": "Synonymous codon usage Gribskov statistic plot",
+      "tool_shed_repository": "emboss_5",
+      "panel_section_name": "EMBOSS",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/emboss_5/EMBOSS: syco96/5.0.0.1"
+    },
+    {
+      "name": "cpgreport",
+      "id": "EMBOSS: cpgreport16",
+      "description": "Reports all CpG rich regions",
+      "tool_shed_repository": "emboss_5",
+      "panel_section_name": "EMBOSS",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/emboss_5/EMBOSS: cpgreport16/5.0.0.1"
+    },
+    {
+      "name": "pepstats",
+      "id": "EMBOSS: pepstats71",
+      "description": "Protein statistics",
+      "tool_shed_repository": "emboss_5",
+      "panel_section_name": "EMBOSS",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/emboss_5/EMBOSS: pepstats71/5.0.0"
+    },
+    {
+      "name": "palindrome",
+      "id": "EMBOSS: palindrome65",
+      "description": "Looks for inverted repeats in a nucleotide sequence",
+      "tool_shed_repository": "emboss_5",
+      "panel_section_name": "EMBOSS",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/emboss_5/EMBOSS: palindrome65/5.0.0.1"
+    },
+    {
+      "name": "hmoment",
+      "id": "EMBOSS: hmoment44",
+      "description": "Hydrophobic moment calculation",
+      "tool_shed_repository": "emboss_5",
+      "panel_section_name": "EMBOSS",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/emboss_5/EMBOSS: hmoment44/5.0.0.1"
+    },
+    {
+      "name": "twofeat",
+      "id": "EMBOSS: twofeat104",
+      "description": "Finds neighbouring pairs of features in sequences",
+      "tool_shed_repository": "emboss_5",
+      "panel_section_name": "EMBOSS",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/emboss_5/EMBOSS: twofeat104/5.0.0.1"
+    },
+    {
+      "name": "digest",
+      "id": "EMBOSS: digest23",
+      "description": "Protein proteolytic enzyme or reagent cleavage digest",
+      "tool_shed_repository": "emboss_5",
+      "panel_section_name": "EMBOSS",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/emboss_5/EMBOSS: digest23/5.0.0"
+    },
+    {
+      "name": "extractfeat",
+      "id": "EMBOSS: extractfeat34",
+      "description": "Extract features from a sequence",
+      "tool_shed_repository": "emboss_5",
+      "panel_section_name": "EMBOSS",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/emboss_5/EMBOSS: extractfeat34/5.0.0.1"
+    },
+    {
+      "name": "showfeat",
+      "id": "EMBOSS: showfeat85",
+      "description": "Show features of a sequence",
+      "tool_shed_repository": "emboss_5",
+      "panel_section_name": "EMBOSS",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/emboss_5/EMBOSS: showfeat85/5.0.0.1"
+    },
+    {
+      "name": "shuffleseq",
+      "id": "EMBOSS: shuffleseq87",
+      "description": "Shuffles a set of sequences maintaining composition",
+      "tool_shed_repository": "emboss_5",
+      "panel_section_name": "EMBOSS",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/emboss_5/EMBOSS: shuffleseq87/5.0.0.1"
+    },
+    {
+      "name": "dotmatcher",
+      "id": "EMBOSS: dotmatcher24",
+      "description": "Displays a thresholded dotplot of two sequences",
+      "tool_shed_repository": "emboss_5",
+      "panel_section_name": "EMBOSS",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/emboss_5/EMBOSS: dotmatcher24/5.0.0.1"
+    },
+    {
+      "name": "seqmatchall",
+      "id": "EMBOSS: seqmatchall83",
+      "description": "All-against-all comparison of a set of sequences",
+      "tool_shed_repository": "emboss_5",
+      "panel_section_name": "EMBOSS",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/emboss_5/EMBOSS: seqmatchall83/5.0.0.1"
+    },
+    {
+      "name": "matcher",
+      "id": "EMBOSS: matcher52",
+      "description": "Finds the best local alignments between two sequences",
+      "tool_shed_repository": "emboss_5",
+      "panel_section_name": "EMBOSS",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/emboss_5/EMBOSS: matcher52/5.0.0.1"
+    },
+    {
+      "name": "revseq",
+      "id": "EMBOSS: revseq82",
+      "description": "Reverse and complement a sequence",
+      "tool_shed_repository": "emboss_5",
+      "panel_section_name": "EMBOSS",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/emboss_5/EMBOSS: revseq82/5.0.0"
+    },
+    {
+      "name": "plotcon",
+      "id": "EMBOSS: plotcon75",
+      "description": "Plot quality of conservation of a sequence alignment",
+      "tool_shed_repository": "emboss_5",
+      "panel_section_name": "EMBOSS",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/emboss_5/EMBOSS: plotcon75/5.0.0.1"
+    },
+    {
+      "name": "trimseq",
+      "id": "EMBOSS: trimseq103",
+      "description": "Trim ambiguous bits off the ends of sequences",
+      "tool_shed_repository": "emboss_5",
+      "panel_section_name": "EMBOSS",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/emboss_5/EMBOSS: trimseq103/5.0.0.1"
+    },
+    {
+      "name": "pasteseq",
+      "id": "EMBOSS: pasteseq66",
+      "description": "Insert one sequence into another",
+      "tool_shed_repository": "emboss_5",
+      "panel_section_name": "EMBOSS",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/emboss_5/EMBOSS: pasteseq66/5.0.0.1"
+    },
+    {
+      "name": "est2genome",
+      "id": "EMBOSS: est2genome32",
+      "description": "Align EST and genomic DNA sequences",
+      "tool_shed_repository": "emboss_5",
+      "panel_section_name": "EMBOSS",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/emboss_5/EMBOSS: est2genome32/5.0.0.1"
+    },
+    {
+      "name": "diffseq",
+      "id": "EMBOSS: diffseq22",
+      "description": "Find differences between nearly identical sequences",
+      "tool_shed_repository": "emboss_5",
+      "panel_section_name": "EMBOSS",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/emboss_5/EMBOSS: diffseq22/5.0.0.1"
+    },
+    {
+      "name": "vectorstrip",
+      "id": "EMBOSS: vectorstrip106",
+      "description": "Strips out DNA between a pair of vector sequences",
+      "tool_shed_repository": "emboss_5",
+      "panel_section_name": "EMBOSS",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/emboss_5/EMBOSS: vectorstrip106/5.0.0.1"
+    },
+    {
+      "name": "polydot",
+      "id": "EMBOSS: polydot77",
+      "description": "Displays all-against-all dotplots of a set of sequences",
+      "tool_shed_repository": "emboss_5",
+      "panel_section_name": "EMBOSS",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/emboss_5/EMBOSS: polydot77/5.0.0.1"
+    },
+    {
+      "name": "transeq",
+      "id": "EMBOSS: transeq101",
+      "description": "Translate nucleic acid sequences",
+      "tool_shed_repository": "emboss_5",
+      "panel_section_name": "EMBOSS",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/emboss_5/EMBOSS: transeq101/5.0.0"
+    },
+    {
+      "name": "isochore",
+      "id": "EMBOSS: isochore47",
+      "description": "Plots isochores in large DNA sequences",
+      "tool_shed_repository": "emboss_5",
+      "panel_section_name": "EMBOSS",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/emboss_5/EMBOSS: isochore47/5.0.0.1"
+    },
+    {
+      "name": "backtranseq",
+      "id": "EMBOSS: backtranseq2",
+      "description": "Back translate a protein sequence",
+      "tool_shed_repository": "emboss_5",
+      "panel_section_name": "EMBOSS",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/emboss_5/EMBOSS: backtranseq2/6.6.0"
+    },
+    {
+      "name": "compseq",
+      "id": "EMBOSS: compseq14",
+      "description": "Count composition of dimer/trimer/etc words in a sequence",
+      "tool_shed_repository": "emboss_5",
+      "panel_section_name": "EMBOSS",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/emboss_5/EMBOSS: compseq14/5.0.0.1"
+    },
+    {
+      "name": "freak",
+      "id": "EMBOSS: freak36",
+      "description": "Residue/base frequency table or plot",
+      "tool_shed_repository": "emboss_5",
+      "panel_section_name": "EMBOSS",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/emboss_5/EMBOSS: freak36/5.0.0.1"
+    },
+    {
+      "name": "pepinfo",
+      "id": "EMBOSS: pepinfo69",
+      "description": "Plots simple amino acid properties in parallel",
+      "tool_shed_repository": "emboss_5",
+      "panel_section_name": "EMBOSS",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/emboss_5/EMBOSS: pepinfo69/5.0.0.1"
+    },
+    {
+      "name": "checktrans",
+      "id": "EMBOSS: checktrans9",
+      "description": "Reports STOP codons and ORF statistics of a protein",
+      "tool_shed_repository": "emboss_5",
+      "panel_section_name": "EMBOSS",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/emboss_5/EMBOSS: checktrans9/5.0.0.1"
+    },
+    {
+      "name": "antigenic",
+      "id": "EMBOSS: antigenic1",
+      "description": "Predicts potentially antigenic regions of a protein sequence, using the method of Kolaskar and Tongaonkar.",
+      "tool_shed_repository": "emboss_5",
+      "panel_section_name": "EMBOSS",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/emboss_5/EMBOSS: antigenic1/5.0.0.1"
+    },
+    {
+      "name": "banana",
+      "id": "EMBOSS: banana3",
+      "description": "Bending and curvature plot in B-DNA",
+      "tool_shed_repository": "emboss_5",
+      "panel_section_name": "EMBOSS",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/emboss_5/EMBOSS: banana3/5.0.0"
+    },
+    {
+      "name": "dan",
+      "id": "EMBOSS: dan19",
+      "description": "Calculates DNA RNA/DNA melting temperature",
+      "tool_shed_repository": "emboss_5",
+      "panel_section_name": "EMBOSS",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/emboss_5/EMBOSS: dan19/5.0.0.1"
+    },
+    {
+      "name": "epestfind",
+      "id": "EMBOSS: epestfind29",
+      "description": "Finds PEST motifs as potential proteolytic cleavage sites",
+      "tool_shed_repository": "emboss_5",
+      "panel_section_name": "EMBOSS",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/emboss_5/EMBOSS: epestfind29/5.0.0.1"
+    },
+    {
+      "name": "maskseq",
+      "id": "EMBOSS: maskseq51",
+      "description": "Mask off regions of a sequence",
+      "tool_shed_repository": "emboss_5",
+      "panel_section_name": "EMBOSS",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/emboss_5/EMBOSS: maskseq51/5.0.0"
+    },
+    {
+      "name": "geecee",
+      "id": "EMBOSS: geecee41",
+      "description": "Calculates fractional GC content of nucleic acid sequences",
+      "tool_shed_repository": "emboss_5",
+      "panel_section_name": "EMBOSS",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/emboss_5/EMBOSS: geecee41/5.0.0"
+    },
+    {
+      "name": "cpgplot",
+      "id": "EMBOSS: cpgplot15",
+      "description": "Plot CpG rich areas",
+      "tool_shed_repository": "emboss_5",
+      "panel_section_name": "EMBOSS",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/emboss_5/EMBOSS: cpgplot15/5.0.0"
+    },
+    {
+      "name": "notseq",
+      "id": "EMBOSS: notseq61",
+      "description": "Exclude a set of sequences and write out the remaining ones",
+      "tool_shed_repository": "emboss_5",
+      "panel_section_name": "EMBOSS",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/emboss_5/EMBOSS: notseq61/5.0.0"
+    },
+    {
+      "name": "seqret",
+      "id": "EMBOSS: seqret84",
+      "description": "Reads and writes sequences",
+      "tool_shed_repository": "emboss_5",
+      "panel_section_name": "EMBOSS",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/emboss_5/EMBOSS: seqret84/5.0.0"
+    },
+    {
+      "name": "plotorf",
+      "id": "EMBOSS: plotorf76",
+      "description": "Plot potential open reading frames",
+      "tool_shed_repository": "emboss_5",
+      "panel_section_name": "EMBOSS",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/emboss_5/EMBOSS: plotorf76/5.0.0"
+    },
+    {
+      "name": "cai",
+      "id": "EMBOSS: cai6",
+      "description": "CAI codon adaptation index",
+      "tool_shed_repository": "emboss_5",
+      "panel_section_name": "EMBOSS",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/emboss_5/EMBOSS: cai6/5.0.0"
+    },
+    {
+      "name": "btwisted",
+      "id": "EMBOSS: btwisted5",
+      "description": "Calculates the twisting in a B-DNA sequence",
+      "tool_shed_repository": "emboss_5",
+      "panel_section_name": "EMBOSS",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/emboss_5/EMBOSS: btwisted5/5.0.0"
+    },
+    {
+      "name": "newseq",
+      "id": "EMBOSS: newseq59",
+      "description": "Type in a short new sequence",
+      "tool_shed_repository": "emboss_5",
+      "panel_section_name": "EMBOSS",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/emboss_5/EMBOSS: newseq59/5.0.0"
+    },
+    {
+      "name": "chaos",
+      "id": "EMBOSS: chaos7",
+      "description": "Create a chaos game representation plot for a sequence",
+      "tool_shed_repository": "emboss_5",
+      "panel_section_name": "EMBOSS",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/emboss_5/EMBOSS: chaos7/5.0.0"
+    },
+    {
+      "name": "pepnet",
+      "id": "EMBOSS: pepnet70",
+      "description": "Displays proteins as a helical net",
+      "tool_shed_repository": "emboss_5",
+      "panel_section_name": "EMBOSS",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/emboss_5/EMBOSS: pepnet70/5.0.0"
+    },
+    {
+      "name": "textsearch",
+      "id": "EMBOSS: textsearch98",
+      "description": "Search sequence documentation. Slow, use SRS and Entrez!",
+      "tool_shed_repository": "emboss_5",
+      "panel_section_name": "EMBOSS",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/emboss_5/EMBOSS: textsearch98/5.0.0"
+    },
+    {
+      "name": "chips",
+      "id": "EMBOSS: chips10",
+      "description": "Codon usage statistics",
+      "tool_shed_repository": "emboss_5",
+      "panel_section_name": "EMBOSS",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/emboss_5/EMBOSS: chips10/5.0.0"
+    },
+    {
+      "name": "garnier",
+      "id": "EMBOSS: garnier40",
+      "description": "Predicts protein secondary structure",
+      "tool_shed_repository": "emboss_5",
+      "panel_section_name": "EMBOSS",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/emboss_5/EMBOSS: garnier40/5.0.0"
+    },
+    {
+      "name": "cusp",
+      "id": "EMBOSS: cusp17",
+      "description": "Create a codon usage table",
+      "tool_shed_repository": "emboss_5",
+      "panel_section_name": "EMBOSS",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/emboss_5/EMBOSS: cusp17/5.0.0"
+    },
+    {
+      "name": "descseq",
+      "id": "EMBOSS: descseq21",
+      "description": "Alter the name or description of a sequence",
+      "tool_shed_repository": "emboss_5",
+      "panel_section_name": "EMBOSS",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/emboss_5/EMBOSS: descseq21/5.0.0"
+    },
+    {
+      "name": "cirdna",
+      "id": "EMBOSS: cirdna11",
+      "description": "Draws circular maps of DNA constructs",
+      "tool_shed_repository": "emboss_5",
+      "panel_section_name": "EMBOSS",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/emboss_5/EMBOSS: cirdna11/5.0.0"
+    },
+    {
+      "name": "tmap",
+      "id": "EMBOSS: tmap99",
+      "description": "Displays membrane spanning regions",
+      "tool_shed_repository": "emboss_5",
+      "panel_section_name": "EMBOSS",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/emboss_5/EMBOSS: tmap99/5.0.0"
+    },
+    {
+      "name": "sirna",
+      "id": "EMBOSS: sirna89",
+      "description": "Finds siRNA duplexes in mRNA",
+      "tool_shed_repository": "emboss_5",
+      "panel_section_name": "EMBOSS",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/emboss_5/EMBOSS: sirna89/5.0.0"
+    },
+    {
+      "name": "coderet",
+      "id": "EMBOSS: coderet13",
+      "description": "Extract CDS, mRNA and translations from feature tables",
+      "tool_shed_repository": "emboss_5",
+      "panel_section_name": "EMBOSS",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/emboss_5/EMBOSS: coderet13/5.0.0"
+    },
+    {
+      "name": "biosed",
+      "id": "EMBOSS: biosed4",
+      "description": "Replace or delete sequence sections",
+      "tool_shed_repository": "emboss_5",
+      "panel_section_name": "EMBOSS",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/emboss_5/EMBOSS: biosed4/5.0.0"
+    },
+    {
+      "name": "BLAST XML to tabular",
+      "id": "blastxml_to_tabular",
+      "description": "Convert BLAST XML output to tabular",
+      "tool_shed_repository": "ncbi_blast_plus",
+      "panel_section_name": "NCBI Blast",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/ncbi_blast_plus/blastxml_to_tabular/2.10.1+galaxy1"
+    },
+    {
+      "name": "NCBI get species taxids",
+      "id": "get_species_taxids",
+      "description": "",
+      "tool_shed_repository": "ncbi_blast_plus",
+      "panel_section_name": "NCBI Blast",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/ncbi_blast_plus/get_species_taxids/2.10.1+galaxy1"
+    },
+    {
+      "name": "NCBI BLAST+ database info",
+      "id": "ncbi_blastdbcmd_info",
+      "description": "Show BLAST database information from blastdbcmd",
+      "tool_shed_repository": "ncbi_blast_plus",
+      "panel_section_name": "NCBI Blast",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/ncbi_blast_plus/ncbi_blastdbcmd_info/2.10.1+galaxy1"
+    },
+    {
+      "name": "NCBI BLAST+ blastdbcmd entry(s)",
+      "id": "ncbi_blastdbcmd_wrapper",
+      "description": "Extract sequence(s) from BLAST database",
+      "tool_shed_repository": "ncbi_blast_plus",
+      "panel_section_name": "NCBI Blast",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/ncbi_blast_plus/ncbi_blastdbcmd_wrapper/2.10.1+galaxy1"
+    },
+    {
+      "name": "NCBI BLAST+ blastn",
+      "id": "ncbi_blastn_wrapper",
+      "description": "Search nucleotide database with nucleotide query sequence(s)",
+      "tool_shed_repository": "ncbi_blast_plus",
+      "panel_section_name": "NCBI Blast",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/ncbi_blast_plus/ncbi_blastn_wrapper/2.10.1+galaxy1"
+    },
+    {
+      "name": "NCBI BLAST+ blastp",
+      "id": "ncbi_blastp_wrapper",
+      "description": "Search protein database with protein query sequence(s)",
+      "tool_shed_repository": "ncbi_blast_plus",
+      "panel_section_name": "NCBI Blast",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/ncbi_blast_plus/ncbi_blastp_wrapper/2.10.1+galaxy1"
+    },
+    {
+      "name": "NCBI BLAST+ blastx",
+      "id": "ncbi_blastx_wrapper",
+      "description": "Search protein database with translated nucleotide query sequence(s)",
+      "tool_shed_repository": "ncbi_blast_plus",
+      "panel_section_name": "NCBI Blast",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/ncbi_blast_plus/ncbi_blastx_wrapper/2.10.1+galaxy1"
+    },
+    {
+      "name": "NCBI BLAST+ convert2blastmask",
+      "id": "ncbi_convert2blastmask_wrapper",
+      "description": "Convert masking information in lower-case masked FASTA input to file formats suitable for makeblastdb",
+      "tool_shed_repository": "ncbi_blast_plus",
+      "panel_section_name": "NCBI Blast",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/ncbi_blast_plus/ncbi_convert2blastmask_wrapper/2.10.1+galaxy1"
+    },
+    {
+      "name": "NCBI BLAST+ dustmasker",
+      "id": "ncbi_dustmasker_wrapper",
+      "description": "masks low complexity regions",
+      "tool_shed_repository": "ncbi_blast_plus",
+      "panel_section_name": "NCBI Blast",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/ncbi_blast_plus/ncbi_dustmasker_wrapper/2.10.1+galaxy1"
+    },
+    {
+      "name": "NCBI BLAST+ makeblastdb",
+      "id": "ncbi_makeblastdb",
+      "description": "Make BLAST database",
+      "tool_shed_repository": "ncbi_blast_plus",
+      "panel_section_name": "NCBI Blast",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/ncbi_blast_plus/ncbi_makeblastdb/2.10.1+galaxy1"
+    },
+    {
+      "name": "NCBI BLAST+ makeprofiledb",
+      "id": "ncbi_makeprofiledb",
+      "description": "Make profile database",
+      "tool_shed_repository": "ncbi_blast_plus",
+      "panel_section_name": "NCBI Blast",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/ncbi_blast_plus/ncbi_makeprofiledb/2.10.1+galaxy1"
+    },
+    {
+      "name": "NCBI BLAST+ rpsblast",
+      "id": "ncbi_rpsblast_wrapper",
+      "description": "Search protein domain database (PSSMs) with protein query sequence(s)",
+      "tool_shed_repository": "ncbi_blast_plus",
+      "panel_section_name": "NCBI Blast",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/ncbi_blast_plus/ncbi_rpsblast_wrapper/2.10.1+galaxy1"
+    },
+    {
+      "name": "NCBI BLAST+ rpstblastn",
+      "id": "ncbi_rpstblastn_wrapper",
+      "description": "Search protein domain database (PSSMs) with translated nucleotide query sequence(s)",
+      "tool_shed_repository": "ncbi_blast_plus",
+      "panel_section_name": "NCBI Blast",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/ncbi_blast_plus/ncbi_rpstblastn_wrapper/2.10.1+galaxy1"
+    },
+    {
+      "name": "NCBI BLAST+ segmasker",
+      "id": "ncbi_segmasker_wrapper",
+      "description": "low-complexity regions in protein sequences",
+      "tool_shed_repository": "ncbi_blast_plus",
+      "panel_section_name": "NCBI Blast",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/ncbi_blast_plus/ncbi_segmasker_wrapper/2.10.1+galaxy1"
+    },
+    {
+      "name": "NCBI BLAST+ tblastn",
+      "id": "ncbi_tblastn_wrapper",
+      "description": "Search translated nucleotide database with protein query sequence(s)",
+      "tool_shed_repository": "ncbi_blast_plus",
+      "panel_section_name": "NCBI Blast",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/ncbi_blast_plus/ncbi_tblastn_wrapper/2.10.1+galaxy1"
+    },
+    {
+      "name": "NCBI BLAST+ tblastx",
+      "id": "ncbi_tblastx_wrapper",
+      "description": "Search translated nucleotide database with translated nucleotide query sequence(s)",
+      "tool_shed_repository": "ncbi_blast_plus",
+      "panel_section_name": "NCBI Blast",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/ncbi_blast_plus/ncbi_tblastx_wrapper/2.10.1+galaxy1"
+    },
+    {
+      "name": "Kraken taxonomic report",
+      "id": "kraken_taxonomy_report",
+      "description": "view report of classification for multiple samples",
+      "tool_shed_repository": "kraken_taxonomy_report",
+      "panel_section_name": "NCBI Blast",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/kraken_taxonomy_report/kraken_taxonomy_report/0.0.3"
+    },
+    {
+      "name": "BBTools: BBduk",
+      "id": "bbtools_bbduk",
+      "description": "decontamination using kmers",
+      "tool_shed_repository": "bbtools_bbduk",
+      "panel_section_name": "NCBI Blast",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/bbtools_bbduk/bbtools_bbduk/1.0.0+galaxy3"
+    },
+    {
+      "name": "Diamond",
+      "id": "bg_diamond",
+      "description": "alignment tool for short sequences against a protein database",
+      "tool_shed_repository": "diamond",
+      "panel_section_name": "NCBI Blast",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/diamond/bg_diamond/2.0.8.0"
+    },
+    {
+      "name": "Diamond makedb",
+      "id": "bg_diamond_makedb",
+      "description": "Build database from a FASTA file",
+      "tool_shed_repository": "diamond",
+      "panel_section_name": "NCBI Blast",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/diamond/bg_diamond_makedb/2.0.8"
+    },
+    {
+      "name": "Diamond view",
+      "id": "bg_diamond_view",
+      "description": "generate formatted output from DAA files",
+      "tool_shed_repository": "diamond",
+      "panel_section_name": "NCBI Blast",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/diamond/bg_diamond_view/2.0.8"
+    },
+    {
+      "name": "Krona pie chart",
+      "id": "taxonomy_krona_chart",
+      "description": "from taxonomic profile",
+      "tool_shed_repository": "taxonomy_krona_chart",
+      "panel_section_name": "NCBI Blast",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/crs4/taxonomy_krona_chart/taxonomy_krona_chart/2.7.1+galaxy0"
+    },
+    {
+      "name": "BBTools: BBMap",
+      "id": "bbtools_bbmap",
+      "description": "short-read aligner",
+      "tool_shed_repository": "bbtools_bbmap",
+      "panel_section_name": "NCBI Blast",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/bbtools_bbmap/bbtools_bbmap/1.0.0+galaxy1.0.0"
+    },
+    {
+      "name": "BBTools: call variants",
+      "id": "bbtools_callvariants",
+      "description": "in aligned Bam files",
+      "tool_shed_repository": "bbtools_callvariants",
+      "panel_section_name": "NCBI Blast",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/bbtools_callvariants/bbtools_callvariants/1.0.0+galaxy1.0.0"
+    },
+    {
+      "name": "Kraken-translate",
+      "id": "kraken-translate",
+      "description": "convert taxonomy IDs to names",
+      "tool_shed_repository": "kraken_translate",
+      "panel_section_name": "NCBI Blast",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/kraken_translate/kraken-translate/1.2.3"
+    },
+    {
+      "name": "Kraken-filter",
+      "id": "kraken-filter",
+      "description": "filter classification by confidence score",
+      "tool_shed_repository": "kraken_filter",
+      "panel_section_name": "NCBI Blast",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/kraken_filter/kraken-filter/1.2.3"
+    },
+    {
+      "name": "BLAST Reciprocal Best Hits (RBH)",
+      "id": "blast_reciprocal_best_hits",
+      "description": "from two FASTA files",
+      "tool_shed_repository": "blast_rbh",
+      "panel_section_name": "NCBI Blast",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/peterjc/blast_rbh/blast_reciprocal_best_hits/0.1.11"
+    },
+    {
+      "name": "Sub-sample sequences files",
+      "id": "sample_seqs",
+      "description": "e.g. to reduce coverage",
+      "tool_shed_repository": "sample_seqs",
+      "panel_section_name": "NCBI Blast",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/peterjc/sample_seqs/sample_seqs/0.2.1"
+    },
+    {
+      "name": "BLAST top hit descriptions",
+      "id": "blastxml_to_top_descr",
+      "description": "Make a table from BLAST output",
+      "tool_shed_repository": "blastxml_to_top_descr",
+      "panel_section_name": "NCBI Blast",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/peterjc/blastxml_to_top_descr/blastxml_to_top_descr/0.1.1"
+    },
+    {
+      "name": "hicPlotViewpoint",
+      "id": "hicexplorer_hicplotviewpoint",
+      "description": "plot interactions around a viewpoint",
+      "tool_shed_repository": "hicexplorer_hicplotviewpoint",
+      "panel_section_name": "HiCExplorer",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/hicexplorer_hicplotviewpoint/hicexplorer_hicplotviewpoint/3.6+galaxy0"
+    },
+    {
+      "name": "hicPlotMatrix",
+      "id": "hicexplorer_hicplotmatrix",
+      "description": "plot a Hi-C contact matrix heatmap",
+      "tool_shed_repository": "hicexplorer_hicplotmatrix",
+      "panel_section_name": "HiCExplorer",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/hicexplorer_hicplotmatrix/hicexplorer_hicplotmatrix/3.6+galaxy0"
+    },
+    {
+      "name": "hicFindTADs",
+      "id": "hicexplorer_hicfindtads",
+      "description": "identify TAD boundaries by computing the degree of separation of each Hi-C matrix bin",
+      "tool_shed_repository": "hicexplorer_hicfindtads",
+      "panel_section_name": "HiCExplorer",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/hicexplorer_hicfindtads/hicexplorer_hicfindtads/3.6+galaxy0"
+    },
+    {
+      "name": "hicCompareMatrices",
+      "id": "hicexplorer_hiccomparematrices",
+      "description": "normalize and compare two Hi-C contact matrices",
+      "tool_shed_repository": "hicexplorer_hiccomparematrices",
+      "panel_section_name": "HiCExplorer",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/hicexplorer_hiccomparematrices/hicexplorer_hiccomparematrices/3.6+galaxy0"
+    },
+    {
+      "name": "hicAggregateContacts",
+      "id": "hicexplorer_hicaggregatecontacts",
+      "description": "allow plotting of aggregated Hi-C contacts between regions specified in a file",
+      "tool_shed_repository": "hicexplorer_hicaggregatecontacts",
+      "panel_section_name": "HiCExplorer",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/hicexplorer_hicaggregatecontacts/hicexplorer_hicaggregatecontacts/3.6+galaxy0"
+    },
+    {
+      "name": "hicNormalize",
+      "id": "hicexplorer_hicnormalize",
+      "description": "normalizes a matrix to norm range or smallest read count",
+      "tool_shed_repository": "hicexplorer_hicnormalize",
+      "panel_section_name": "HiCExplorer",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/hicexplorer_hicnormalize/hicexplorer_hicnormalize/3.6+galaxy0"
+    },
+    {
+      "name": "hicSumMatrices",
+      "id": "hicexplorer_hicsummatrices",
+      "description": "combine Hi-C matrices of the same size",
+      "tool_shed_repository": "hicexplorer_hicsummatrices",
+      "panel_section_name": "HiCExplorer",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/hicexplorer_hicsummatrices/hicexplorer_hicsummatrices/3.6+galaxy0"
+    },
+    {
+      "name": "hicConvertFormat",
+      "id": "hicexplorer_hicconvertformat",
+      "description": "Convert between different file formats",
+      "tool_shed_repository": "hicexplorer_hicconvertformat",
+      "panel_section_name": "HiCExplorer",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/hicexplorer_hicconvertformat/hicexplorer_hicconvertformat/3.6+galaxy0"
+    },
+    {
+      "name": "hicAdjustMatrix",
+      "id": "hicexplorer_hicadjustmatrix",
+      "description": "adjust the shape of a Hi-C matrix",
+      "tool_shed_repository": "hicexplorer_hicadjustmatrix",
+      "panel_section_name": "HiCExplorer",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/hicexplorer_hicadjustmatrix/hicexplorer_hicadjustmatrix/3.6+galaxy0"
+    },
+    {
+      "name": "hicInfo",
+      "id": "hicexplorer_hicinfo",
+      "description": "get information about the content of a Hi-C matrix",
+      "tool_shed_repository": "hicexplorer_hicinfo",
+      "panel_section_name": "HiCExplorer",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/hicexplorer_hicinfo/hicexplorer_hicinfo/3.6+galaxy0"
+    },
+    {
+      "name": "hicHyperoptDetectLoops",
+      "id": "hicexplorer_hichyperoptDetectLoops",
+      "description": "optimizes parameters for hicDetectLoops",
+      "tool_shed_repository": "hicexplorer_hichyperoptdetectloops",
+      "panel_section_name": "HiCExplorer",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/hicexplorer_hichyperoptdetectloops/hicexplorer_hichyperoptDetectLoops/3.6+galaxy0"
+    },
+    {
+      "name": "scHicQualityControl",
+      "id": "schicexplorer_schicqualitycontrol",
+      "description": "quality control for single-cell Hi-C interaction matrices",
+      "tool_shed_repository": "schicexplorer_schicqualitycontrol",
+      "panel_section_name": "HiCExplorer",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/schicexplorer_schicqualitycontrol/schicexplorer_schicqualitycontrol/4.0"
+    },
+    {
+      "name": "chicPlotViewpoint",
+      "id": "hicexplorer_chicplotviewpoint",
+      "description": "creates plots for viewpoints",
+      "tool_shed_repository": "hicexplorer_chicplotviewpoint",
+      "panel_section_name": "HiCExplorer",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/hicexplorer_chicplotviewpoint/hicexplorer_chicplotviewpoint/3.6+galaxy0"
+    },
+    {
+      "name": "chicDifferentialTest",
+      "id": "hicexplorer_chicdifferentialtest",
+      "description": "computes differential interactions of viewpoints",
+      "tool_shed_repository": "hicexplorer_chicdifferentialtest",
+      "panel_section_name": "HiCExplorer",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/hicexplorer_chicdifferentialtest/hicexplorer_chicdifferentialtest/3.6+galaxy0"
+    },
+    {
+      "name": "chicAggregateStatistic",
+      "id": "hicexplorer_chicaggregatestatistic",
+      "description": "computes with a target file the to be tested regions for chicDifferentialTest",
+      "tool_shed_repository": "hicexplorer_chicaggregatestatistic",
+      "panel_section_name": "HiCExplorer",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/hicexplorer_chicaggregatestatistic/hicexplorer_chicaggregatestatistic/3.6+galaxy0"
+    },
+    {
+      "name": "chicSignificantInteractions",
+      "id": "hicexplorer_chicsignificantinteractions",
+      "description": "computes viewpoints with the given reference points and a background model",
+      "tool_shed_repository": "hicexplorer_chicsignificantinteractions",
+      "panel_section_name": "HiCExplorer",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/hicexplorer_chicsignificantinteractions/hicexplorer_chicsignificantinteractions/3.6+galaxy0"
+    },
+    {
+      "name": "chicViewpoint",
+      "id": "hicexplorer_chicviewpoint",
+      "description": "computes viewpoints with the given reference points and a background model.",
+      "tool_shed_repository": "hicexplorer_chicviewpoint",
+      "panel_section_name": "HiCExplorer",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/hicexplorer_chicviewpoint/hicexplorer_chicviewpoint/3.6+galaxy0"
+    },
+    {
+      "name": "hicDifferentialTAD",
+      "id": "hicexplorer_hicdifferentialtad",
+      "description": "searches for differential TADs",
+      "tool_shed_repository": "hicexplorer_hicdifferentialtad",
+      "panel_section_name": "HiCExplorer",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/hicexplorer_hicdifferentialtad/hicexplorer_hicdifferentialtad/3.6+galaxy0"
+    },
+    {
+      "name": "hicMergeDomains",
+      "id": "hicexplorer_hicmergedomains",
+      "description": "Merges TAD domains",
+      "tool_shed_repository": "hicexplorer_hicmergedomains",
+      "panel_section_name": "HiCExplorer",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/hicexplorer_hicmergedomains/hicexplorer_hicmergedomains/3.6+galaxy0"
+    },
+    {
+      "name": "chicQualityControl",
+      "id": "hicexplorer_chicqualitycontrol",
+      "description": "generates an estimate of the quality of each viewpoint",
+      "tool_shed_repository": "hicexplorer_chicqualitycontrol",
+      "panel_section_name": "HiCExplorer",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/hicexplorer_chicqualitycontrol/hicexplorer_chicqualitycontrol/3.6+galaxy0"
+    },
+    {
+      "name": "hicFindRestSite",
+      "id": "hicexplorer_hicfindrestrictionsites",
+      "description": "identify restriction enzyme sites",
+      "tool_shed_repository": "hicexplorer_hicfindrestrictionsites",
+      "panel_section_name": "HiCExplorer",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/hicexplorer_hicfindrestrictionsites/hicexplorer_hicfindrestrictionsites/3.6+galaxy0"
+    },
+    {
+      "name": "chicViewpointBackgroundModel",
+      "id": "hicexplorer_chicviewpointbackgroundmodel",
+      "description": "compute a background model for cHi-C / HiChIP data",
+      "tool_shed_repository": "hicexplorer_chicviewpointbackgroundmodel",
+      "panel_section_name": "HiCExplorer",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/hicexplorer_chicviewpointbackgroundmodel/hicexplorer_chicviewpointbackgroundmodel/3.6+galaxy0"
+    },
+    {
+      "name": "hicQuickQC",
+      "id": "hicexplorer_hicquickqc",
+      "description": "get a first quality estimate of Hi-C data",
+      "tool_shed_repository": "hicexplorer_hicquickqc",
+      "panel_section_name": "HiCExplorer",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/hicexplorer_hicquickqc/hicexplorer_hicquickqc/3.6+galaxy0"
+    },
+    {
+      "name": "hicBuildMatrix",
+      "id": "hicexplorer_hicbuildmatrix",
+      "description": "create a contact matrix",
+      "tool_shed_repository": "hicexplorer_hicbuildmatrix",
+      "panel_section_name": "HiCExplorer",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/hicexplorer_hicbuildmatrix/hicexplorer_hicbuildmatrix/3.6+galaxy0"
+    },
+    {
+      "name": "hicMergeMatrixBins",
+      "id": "hicexplorer_hicmergematrixbins",
+      "description": "merge adjacent bins from a Hi-C contact matrix to reduce its resolution",
+      "tool_shed_repository": "hicexplorer_hicmergematrixbins",
+      "panel_section_name": "HiCExplorer",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/hicexplorer_hicmergematrixbins/hicexplorer_hicmergematrixbins/3.6+galaxy0"
+    },
+    {
+      "name": "hicTransform",
+      "id": "hicexplorer_hictransform",
+      "description": "transform a matrix to obs/exp, pearson and covariance matrices",
+      "tool_shed_repository": "hicexplorer_hictransform",
+      "panel_section_name": "HiCExplorer",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/hicexplorer_hictransform/hicexplorer_hictransform/3.6+galaxy0"
+    },
+    {
+      "name": "hicCompartmentalization",
+      "id": "hicexplorer_hiccompartmentspolarization",
+      "description": "compute pairwise correlations between multiple Hi-C contact matrices",
+      "tool_shed_repository": "hicexplorer_hiccompartmentspolarization",
+      "panel_section_name": "HiCExplorer",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/hicexplorer_hiccompartmentspolarization/hicexplorer_hiccompartmentspolarization/3.6+galaxy0"
+    },
+    {
+      "name": "hicCorrelate",
+      "id": "hicexplorer_hiccorrelate",
+      "description": "compute pairwise correlations between multiple Hi-C contact matrices",
+      "tool_shed_repository": "hicexplorer_hiccorrelate",
+      "panel_section_name": "HiCExplorer",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/hicexplorer_hiccorrelate/hicexplorer_hiccorrelate/3.6+galaxy0"
+    },
+    {
+      "name": "hicDetectLoops",
+      "id": "hicexplorer_hicdetectloops",
+      "description": "searches for enriched regions",
+      "tool_shed_repository": "hicexplorer_hicdetectloops",
+      "panel_section_name": "HiCExplorer",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/hicexplorer_hicdetectloops/hicexplorer_hicdetectloops/3.6+galaxy0"
+    },
+    {
+      "name": "hicMergeLoops",
+      "id": "hicexplorer_hicmergeloops",
+      "description": "merge detected loops of different resolutions.",
+      "tool_shed_repository": "hicexplorer_hicmergeloops",
+      "panel_section_name": "HiCExplorer",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/hicexplorer_hicmergeloops/hicexplorer_hicmergeloops/3.6+galaxy0"
+    },
+    {
+      "name": "hicValidateLocations",
+      "id": "hicexplorer_hicvalidatelocations",
+      "description": "validate detected loops with protein peaks.",
+      "tool_shed_repository": "hicexplorer_hicvalidatelocations",
+      "panel_section_name": "HiCExplorer",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/hicexplorer_hicvalidatelocations/hicexplorer_hicvalidatelocations/3.6+galaxy0"
+    },
+    {
+      "name": "hicCorrectMatrix",
+      "id": "hicexplorer_hiccorrectmatrix",
+      "description": "run a Hi-C matrix correction algorithm",
+      "tool_shed_repository": "hicexplorer_hiccorrectmatrix",
+      "panel_section_name": "HiCExplorer",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/hicexplorer_hiccorrectmatrix/hicexplorer_hiccorrectmatrix/3.6+galaxy0"
+    },
+    {
+      "name": "hicPCA",
+      "id": "hicexplorer_hicpca",
+      "description": "compute the principal components for A / B compartment analysis",
+      "tool_shed_repository": "hicexplorer_hicpca",
+      "panel_section_name": "HiCExplorer",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/hicexplorer_hicpca/hicexplorer_hicpca/3.6+galaxy0"
+    },
+    {
+      "name": "hicPlotAverageRegions",
+      "id": "hicexplorer_hicplotaverageregions",
+      "description": "plot the average regions from hicAverageRegions",
+      "tool_shed_repository": "hicexplorer_hicplotaverageregions",
+      "panel_section_name": "HiCExplorer",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/hicexplorer_hicplotaverageregions/hicexplorer_hicplotaverageregions/3.6+galaxy0"
+    },
+    {
+      "name": "hicPlotDistVsCounts",
+      "id": "hicexplorer_hicplotdistvscounts",
+      "description": "compute distance vs Hi-C counts plot per chromosome",
+      "tool_shed_repository": "hicexplorer_hicplotdistvscounts",
+      "panel_section_name": "HiCExplorer",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/hicexplorer_hicplotdistvscounts/hicexplorer_hicplotdistvscounts/3.6+galaxy0"
+    },
+    {
+      "name": "hicAverageRegions",
+      "id": "hicexplorer_hicaverageregions",
+      "description": "sums Hi-C contacts around given reference points and computes their average.",
+      "tool_shed_repository": "hicexplorer_hicaverageregions",
+      "panel_section_name": "HiCExplorer",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/hicexplorer_hicaverageregions/hicexplorer_hicaverageregions/3.6+galaxy0"
+    },
+    {
+      "name": "hicPlotSVL",
+      "id": "hicexplorer_hicplotsvl",
+      "description": "plots the relation of short vs long range contacts",
+      "tool_shed_repository": "hicexplorer_hicplotsvl",
+      "panel_section_name": "HiCExplorer",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/hicexplorer_hicplotsvl/hicexplorer_hicplotsvl/3.6+galaxy0"
+    },
+    {
+      "name": "scHicCorrectMatrices",
+      "id": "schicexplorer_schiccorrectmatrices",
+      "description": "correct with KR algorithm single-cell Hi-C interaction matrices",
+      "tool_shed_repository": "schicexplorer_schiccorrectmatrices",
+      "panel_section_name": "HiCExplorer",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/schicexplorer_schiccorrectmatrices/schicexplorer_schiccorrectmatrices/4.0"
+    },
+    {
+      "name": "scHicPlotConsensusMatrices",
+      "id": "schicexplorer_schicplotconsensusmatrices",
+      "description": "plot single-cell Hi-C interaction matrices cluster consensus matrices",
+      "tool_shed_repository": "schicexplorer_schicplotconsensusmatrices",
+      "panel_section_name": "HiCExplorer",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/schicexplorer_schicplotconsensusmatrices/schicexplorer_schicplotconsensusmatrices/4.0"
+    },
+    {
+      "name": "scHicPlotClusterProfiles",
+      "id": "schicexplorer_schicplotclusterprofiles",
+      "description": "plot single-cell Hi-C interaction matrices cluster profiles",
+      "tool_shed_repository": "schicexplorer_schicplotclusterprofiles",
+      "panel_section_name": "HiCExplorer",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/schicexplorer_schicplotclusterprofiles/schicexplorer_schicplotclusterprofiles/4.0"
+    },
+    {
+      "name": "scHicNormalize",
+      "id": "schicexplorer_schicnormalize",
+      "description": "normalize single-cell Hi-C interaction matrices to the same read coverage",
+      "tool_shed_repository": "schicexplorer_schicnormalize",
+      "panel_section_name": "HiCExplorer",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/schicexplorer_schicnormalize/schicexplorer_schicnormalize/4.0"
+    },
+    {
+      "name": "scHicCreateBulkMatrix",
+      "id": "schicexplorer_schiccreatebulkmatrix",
+      "description": "creates the bulk matrix out of  single-cell Hi-C interaction matrices",
+      "tool_shed_repository": "schicexplorer_schiccreatebulkmatrix",
+      "panel_section_name": "HiCExplorer",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/schicexplorer_schiccreatebulkmatrix/schicexplorer_schiccreatebulkmatrix/4.0"
+    },
+    {
+      "name": "scHicMergeToSCool",
+      "id": "schicexplorer_schicmergetoscool",
+      "description": "merge multiple cool files to one scool file",
+      "tool_shed_repository": "schicexplorer_schicmergetoscool",
+      "panel_section_name": "HiCExplorer",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/schicexplorer_schicmergetoscool/schicexplorer_schicmergetoscool/4.0"
+    },
+    {
+      "name": "scHicMergeMatrixBins",
+      "id": "schicexplorer_schicmergematrixbins",
+      "description": "change the resolution of the scHi-C matrices",
+      "tool_shed_repository": "schicexplorer_schicmergematrixbins",
+      "panel_section_name": "HiCExplorer",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/schicexplorer_schicmergematrixbins/schicexplorer_schicmergematrixbins/4.0"
+    },
+    {
+      "name": "scHicInfo",
+      "id": "schicexplorer_schicinfo",
+      "description": "information about a single-cell scool matrix",
+      "tool_shed_repository": "schicexplorer_schicinfo",
+      "panel_section_name": "HiCExplorer",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/schicexplorer_schicinfo/schicexplorer_schicinfo/4.0"
+    },
+    {
+      "name": "scHicDemultiplex",
+      "id": "schicexplorer_schicdemultiplex",
+      "description": "demultiplexes Nagano 2017 raw fastq files",
+      "tool_shed_repository": "schicexplorer_schicdemultiplex",
+      "panel_section_name": "HiCExplorer",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/schicexplorer_schicdemultiplex/schicexplorer_schicdemultiplex/4.0"
+    },
+    {
+      "name": "scHicConsensusMatrices",
+      "id": "schicexplorer_schicconsensusmatrices",
+      "description": "creates per cluster one average matrix",
+      "tool_shed_repository": "schicexplorer_schicconsensusmatrices",
+      "panel_section_name": "HiCExplorer",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/schicexplorer_schicconsensusmatrices/schicexplorer_schicconsensusmatrices/4.0"
+    },
+    {
+      "name": "scHicClusterSVL",
+      "id": "schicexplorer_schicclustersvl",
+      "description": "clusters single-cell Hi-C interaction matrices with svl dimension reduction",
+      "tool_shed_repository": "schicexplorer_schicclustersvl",
+      "panel_section_name": "HiCExplorer",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/schicexplorer_schicclustersvl/schicexplorer_schicclustersvl/4.0"
+    },
+    {
+      "name": "scHicClusterMinHash",
+      "id": "schicexplorer_schicclusterminhash",
+      "description": "clusters single-cell Hi-C interaction matrices with MinHash dimension reduction",
+      "tool_shed_repository": "schicexplorer_schicclusterminhash",
+      "panel_section_name": "HiCExplorer",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/schicexplorer_schicclusterminhash/schicexplorer_schicclusterminhash/4.0"
+    },
+    {
+      "name": "scHicClusterCompartments",
+      "id": "schicexplorer_schicclustercompartments",
+      "description": "clusters single-cell Hi-C interaction matrices with A/B compartments dimension reduction",
+      "tool_shed_repository": "schicexplorer_schicclustercompartments",
+      "panel_section_name": "HiCExplorer",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/schicexplorer_schicclustercompartments/schicexplorer_schicclustercompartments/4.0"
+    },
+    {
+      "name": "scHicCluster",
+      "id": "schicexplorer_schiccluster",
+      "description": "clusters single-cell Hi-C interaction matrices on the raw data",
+      "tool_shed_repository": "schicexplorer_schiccluster",
+      "panel_section_name": "HiCExplorer",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/schicexplorer_schiccluster/schicexplorer_schiccluster/4.0"
+    },
+    {
+      "name": "scHicAdjustMatrix",
+      "id": "schicexplorer_schicadjustmatrix",
+      "description": "clusters single-cell Hi-C interaction matrices on the raw data",
+      "tool_shed_repository": "schicexplorer_schicadjustmatrix",
+      "panel_section_name": "HiCExplorer",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/schicexplorer_schicadjustmatrix/schicexplorer_schicadjustmatrix/4.0"
+    },
+    {
+      "name": "hicPlotTADs",
+      "id": "hicexplorer_hicplottads",
+      "description": "plot Hi-C contact matrices heatmaps alongside other data tracks",
+      "tool_shed_repository": "hicexplorer_hicplottads",
+      "panel_section_name": "HiCExplorer",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/hicexplorer_hicplottads/hicexplorer_hicplottads/2.1.4.0"
+    },
+    {
+      "name": "Stacks2: process shortreads",
+      "id": "stacks2_shortreads",
+      "description": "fast cleaning of randomly sheared genomic or transcriptomic data",
+      "tool_shed_repository": "stacks2_shortreads",
+      "panel_section_name": "RAD-seq",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/stacks2_shortreads/stacks2_shortreads/2.55+galaxy1"
+    },
+    {
+      "name": "Stacks2: reference map",
+      "id": "stacks2_refmap",
+      "description": "the Stacks pipeline with a reference genome (ref_map.pl)",
+      "tool_shed_repository": "stacks2_refmap",
+      "panel_section_name": "RAD-seq",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/stacks2_refmap/stacks2_refmap/2.55+galaxy1"
+    },
+    {
+      "name": "Stacks2: de novo map",
+      "id": "stacks2_denovomap",
+      "description": "the Stacks pipeline without a reference genome (denovo_map.pl)",
+      "tool_shed_repository": "stacks2_denovomap",
+      "panel_section_name": "RAD-seq",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/stacks2_denovomap/stacks2_denovomap/2.55+galaxy1"
+    },
+    {
+      "name": "Stacks2: process radtags",
+      "id": "stacks2_procrad",
+      "description": "the Stacks demultiplexing script",
+      "tool_shed_repository": "stacks2_procrad",
+      "panel_section_name": "RAD-seq",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/stacks2_procrad/stacks2_procrad/2.55+galaxy1"
+    },
+    {
+      "name": "Stacks2: populations",
+      "id": "stacks2_populations",
+      "description": "Calculate population-level summary statistics",
+      "tool_shed_repository": "stacks2_populations",
+      "panel_section_name": "RAD-seq",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/stacks2_populations/stacks2_populations/2.55+galaxy1"
+    },
+    {
+      "name": "Stacks2: gstacks",
+      "id": "stacks2_gstacks",
+      "description": "Call variants, genotypes and haplotype",
+      "tool_shed_repository": "stacks2_gstacks",
+      "panel_section_name": "RAD-seq",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/stacks2_gstacks/stacks2_gstacks/2.55+galaxy1"
+    },
+    {
+      "name": "Stacks2: ustacks",
+      "id": "stacks2_ustacks",
+      "description": "Identify unique stacks",
+      "tool_shed_repository": "stacks2_ustacks",
+      "panel_section_name": "RAD-seq",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/stacks2_ustacks/stacks2_ustacks/2.55+galaxy1"
+    },
+    {
+      "name": "Stacks2: kmer filter",
+      "id": "stacks2_kmerfilter",
+      "description": "Identify PCR clones",
+      "tool_shed_repository": "stacks2_kmerfilter",
+      "panel_section_name": "RAD-seq",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/stacks2_kmerfilter/stacks2_kmerfilter/2.55+galaxy1"
+    },
+    {
+      "name": "Stacks2: clone filter",
+      "id": "stacks2_clonefilter",
+      "description": "Identify PCR clones",
+      "tool_shed_repository": "stacks2_clonefilter",
+      "panel_section_name": "RAD-seq",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/stacks2_clonefilter/stacks2_clonefilter/2.55+galaxy1"
+    },
+    {
+      "name": "Stacks2: tsv2bam",
+      "id": "stacks2_tsv2bam",
+      "description": "Sort reads by RAD locus",
+      "tool_shed_repository": "stacks2_tsv2bam",
+      "panel_section_name": "RAD-seq",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/stacks2_tsv2bam/stacks2_tsv2bam/2.55+galaxy1"
+    },
+    {
+      "name": "Stacks2: sstacks",
+      "id": "stacks2_sstacks",
+      "description": "Match samples to the catalog",
+      "tool_shed_repository": "stacks2_sstacks",
+      "panel_section_name": "RAD-seq",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/stacks2_sstacks/stacks2_sstacks/2.55+galaxy1"
+    },
+    {
+      "name": "BayeScan",
+      "id": "BayeScan",
+      "description": "Detecting natural selection from population-based genetic data",
+      "tool_shed_repository": "bayescan",
+      "panel_section_name": "RAD-seq",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/bayescan/BayeScan/2.1"
+    },
+    {
+      "name": "Stacks2: cstacks",
+      "id": "stacks2_cstacks",
+      "description": "Generate catalog of loci",
+      "tool_shed_repository": "stacks2_cstacks",
+      "panel_section_name": "RAD-seq",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/stacks2_cstacks/stacks2_cstacks/2.55+galaxy1"
+    },
+    {
+      "name": "Image Converter",
+      "id": "graphicsmagick_image_convert",
+      "description": "",
+      "tool_shed_repository": "graphicsmagick_image_convert",
+      "panel_section_name": "Imaging",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/graphicsmagick_image_convert/graphicsmagick_image_convert/1.3.31"
+    },
+    {
+      "name": "NSPDK_candidateClusters",
+      "id": "NSPDK_candidateClust",
+      "description": "",
+      "tool_shed_repository": "graphclust_nspdk",
+      "panel_section_name": "GraphClust",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/rnateam/graphclust_nspdk/NSPDK_candidateClust/9.2.3.1"
+    },
+    {
+      "name": "Structure to GSPAN",
+      "id": "structure_to_gspan",
+      "description": "",
+      "tool_shed_repository": "structure_to_gspan",
+      "panel_section_name": "GraphClust",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/rnateam/structure_to_gspan/structure_to_gspan/0.4"
+    },
+    {
+      "name": "Preprocessing",
+      "id": "preproc",
+      "description": "",
+      "tool_shed_repository": "graphclust_preprocessing",
+      "panel_section_name": "GraphClust",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/rnateam/graphclust_preprocessing/preproc/0.5"
+    },
+    {
+      "name": "pgma_graphclust",
+      "id": "preMloc",
+      "description": "",
+      "tool_shed_repository": "graphclust_prepocessing_for_mlocarna",
+      "panel_section_name": "GraphClust",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/rnateam/graphclust_prepocessing_for_mlocarna/preMloc/0.4"
+    },
+    {
+      "name": "NSPDK_sparseVect",
+      "id": "nspdk_sparse",
+      "description": "",
+      "tool_shed_repository": "graphclust_nspdk",
+      "panel_section_name": "GraphClust",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/rnateam/graphclust_nspdk/nspdk_sparse/9.2.3"
+    },
+    {
+      "name": "locarna_graphclust",
+      "id": "locarna_best_subtree",
+      "description": "",
+      "tool_shed_repository": "graphclust_mlocarna",
+      "panel_section_name": "GraphClust",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/rnateam/graphclust_mlocarna/locarna_best_subtree/0.4"
+    },
+    {
+      "name": "fasta_to_gspan",
+      "id": "gspan",
+      "description": "",
+      "tool_shed_repository": "graphclust_fasta_to_gspan",
+      "panel_section_name": "GraphClust",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/rnateam/graphclust_fasta_to_gspan/gspan/0.4"
+    },
+    {
+      "name": "cluster_collection_report",
+      "id": "glob_report",
+      "description": "",
+      "tool_shed_repository": "graphclust_postprocessing",
+      "panel_section_name": "GraphClust",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/rnateam/graphclust_postprocessing/glob_report/0.5"
+    },
+    {
+      "name": "cmfinder",
+      "id": "cmFinder",
+      "description": "",
+      "tool_shed_repository": "graphclust_cmfinder",
+      "panel_section_name": "GraphClust",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/rnateam/graphclust_cmfinder/cmFinder/0.4"
+    },
+    {
+      "name": "Align GraphClust cluster ",
+      "id": "graphclust_align_cluster",
+      "description": "structural alignment and conservation analysis of predicted clusters",
+      "tool_shed_repository": "graphclust_align_cluster",
+      "panel_section_name": "GraphClust",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/rnateam/graphclust_align_cluster/graphclust_align_cluster/0.1"
+    },
+    {
+      "name": "Aggregate and filter alignment metrics",
+      "id": "graphclust_aggregate_alignments",
+      "description": "of individual clusters, like the output of graphclust_align_cluster",
+      "tool_shed_repository": "graphclust_aggregate_alignments",
+      "panel_section_name": "GraphClust",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/rnateam/graphclust_aggregate_alignments/graphclust_aggregate_alignments/0.1"
+    },
+    {
+      "name": "Graphclust glob_report collect clusters",
+      "id": "graphclust_glob_report_no_align",
+      "description": "",
+      "tool_shed_repository": "graphclust_postprocessing_no_align",
+      "panel_section_name": "GraphClust",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/rnateam/graphclust_postprocessing_no_align/graphclust_glob_report_no_align/0.5"
+    },
+    {
+      "name": "Motif_Finder_Plot",
+      "id": "motifFinderPlot",
+      "description": "",
+      "tool_shed_repository": "graphclust_motif_finder_plot",
+      "panel_section_name": "GraphClust",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/rnateam/graphclust_motif_finder_plot/motifFinderPlot/0.3"
+    },
+    {
+      "name": "Build covariance models",
+      "id": "infernal_cmbuild",
+      "description": "from sequence alignments (cmbuild)",
+      "tool_shed_repository": "infernal",
+      "panel_section_name": "GraphClust",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/infernal/infernal_cmbuild/1.1.0.2"
+    },
+    {
+      "name": "Search covariance model(s)",
+      "id": "infernal_cmsearch",
+      "description": "against a sequence database (cmsearch)",
+      "tool_shed_repository": "infernal",
+      "panel_section_name": "GraphClust",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/infernal/infernal_cmsearch/1.1.0.2"
+    },
+    {
+      "name": "Summary statistics",
+      "id": "infernal_cmstat",
+      "description": "for covariance model (cmstat)",
+      "tool_shed_repository": "infernal",
+      "panel_section_name": "GraphClust",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/infernal/infernal_cmstat/1.1.0.1"
+    },
+    {
+      "name": "MiModD Read Alignment",
+      "id": "mimodd_align",
+      "description": "maps sequence reads to a reference genome using SNAP",
+      "tool_shed_repository": "mimodd_aln",
+      "panel_section_name": "MiModD",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/wolma/mimodd_aln/mimodd_align/0.1.9"
+    },
+    {
+      "name": "MiModD File Information",
+      "id": "mimodd_info",
+      "description": "provides summary reports for supported sequence data formats.",
+      "tool_shed_repository": "mimodd_main",
+      "panel_section_name": "MiModD",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/wolma/mimodd_main/mimodd_info/0.1.8_1"
+    },
+    {
+      "name": "MiModD Report Variants",
+      "id": "mimodd_varreport",
+      "description": "in a human-friendly format that simplifies data exploration",
+      "tool_shed_repository": "mimodd_main",
+      "panel_section_name": "MiModD",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/wolma/mimodd_main/mimodd_varreport/0.1.8_1"
+    },
+    {
+      "name": "MiModD Extract Variant Sites",
+      "id": "mimodd_varextract",
+      "description": "from a BCF file",
+      "tool_shed_repository": "mimodd_main",
+      "panel_section_name": "MiModD",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/wolma/mimodd_main/mimodd_varextract/0.1.8_1"
+    },
+    {
+      "name": "MiModD NacreousMap",
+      "id": "mimodd_map",
+      "description": "maps phenotypically selected variants by multi-variant linkage analysis",
+      "tool_shed_repository": "mimodd_main",
+      "panel_section_name": "MiModD",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/wolma/mimodd_main/mimodd_map/0.1.8_1"
+    },
+    {
+      "name": "MiModD VCF Filter",
+      "id": "mimodd_vcf_filter",
+      "description": "extracts lines from a vcf variant file based on field-specific filters",
+      "tool_shed_repository": "mimodd_main",
+      "panel_section_name": "MiModD",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/wolma/mimodd_main/mimodd_vcf_filter/0.1.8_1"
+    },
+    {
+      "name": "MiModD Coverage Statistics",
+      "id": "mimodd_covstats",
+      "description": "calculates coverage statistics for a BCF file as generated by the MiModd Variant Calling tool",
+      "tool_shed_repository": "mimodd_main",
+      "panel_section_name": "MiModD",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/wolma/mimodd_main/mimodd_covstats/0.1.8_1"
+    },
+    {
+      "name": "MiModD Convert",
+      "id": "mimodd_convert",
+      "description": "converts sequence data into different formats",
+      "tool_shed_repository": "mimodd_main",
+      "panel_section_name": "MiModD",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/wolma/mimodd_main/mimodd_convert/0.1.8_1"
+    },
+    {
+      "name": "MiModD Variant Calling",
+      "id": "mimodd_varcall",
+      "description": "generates a BCF file of position-specific variant likelihoods and coverage information based on a reference sequence and reads aligned against it",
+      "tool_shed_repository": "mimodd_main",
+      "panel_section_name": "MiModD",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/wolma/mimodd_main/mimodd_varcall/0.1.8_1"
+    },
+    {
+      "name": "MiModD Run Annotation",
+      "id": "mimodd_header",
+      "description": "writes run metadata in SAM format for attaching it to sequenced reads data",
+      "tool_shed_repository": "mimodd_main",
+      "panel_section_name": "MiModD",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/wolma/mimodd_main/mimodd_header/0.1.8_1"
+    },
+    {
+      "name": "MiModD Reheader",
+      "id": "mimodd_reheader",
+      "description": "takes a BAM file and generates a copy with the original header (if any) replaced or modified by that found in a template SAM file",
+      "tool_shed_repository": "mimodd_main",
+      "panel_section_name": "MiModD",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/wolma/mimodd_main/mimodd_reheader/0.1.8_1"
+    },
+    {
+      "name": "MiModD Rebase Sites",
+      "id": "mimodd_rebase",
+      "description": "from a VCF file",
+      "tool_shed_repository": "mimodd_main",
+      "panel_section_name": "MiModD",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/wolma/mimodd_main/mimodd_rebase/0.1.8_1"
+    },
+    {
+      "name": "MiModD Deletion Calling (for PE data)",
+      "id": "mimodd_delcall",
+      "description": "predicts deletions in one or more aligned paired-end read samples based on coverage of the reference genome and on insert sizes",
+      "tool_shed_repository": "mimodd_main",
+      "panel_section_name": "MiModD",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/wolma/mimodd_main/mimodd_delcall/0.1.8_1"
+    },
+    {
+      "name": "MiModD Sort",
+      "id": "mimodd_sort",
+      "description": "takes a SAM/BAM dataset and generates a coordinate/name-sorted copy",
+      "tool_shed_repository": "mimodd_main",
+      "panel_section_name": "MiModD",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/wolma/mimodd_main/mimodd_sort/0.1.8_1"
+    },
+    {
+      "name": "LotuS2",
+      "id": "lotus2",
+      "description": "fast OTU processing pipeline",
+      "tool_shed_repository": "lotus2",
+      "panel_section_name": "Metagenomic Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/earlhaminst/lotus2/lotus2/2.19"
+    },
+    {
+      "name": "Customize the marker sequences and metadata",
+      "id": "customize_metaphlan_database",
+      "description": "from the MetaPhlAn database",
+      "tool_shed_repository": "customize_metaphlan_database",
+      "panel_section_name": "Metagenomic Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/customize_metaphlan_database/customize_metaphlan_database/3.0.14+galaxy0"
+    },
+    {
+      "name": "Merge",
+      "id": "merge_metaphlan_tables",
+      "description": "MetaPhlAn abundance tables",
+      "tool_shed_repository": "merge_metaphlan_tables",
+      "panel_section_name": "Metagenomic Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/merge_metaphlan_tables/merge_metaphlan_tables/3.0.14+galaxy0"
+    },
+    {
+      "name": "Calculate contig depths",
+      "id": "metabat2_jgi_summarize_bam_contig_depths",
+      "description": "for MetaBAT2",
+      "tool_shed_repository": "metabat2_jgi_summarize_bam_contig_depths",
+      "panel_section_name": "Metagenomic Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/metabat2_jgi_summarize_bam_contig_depths/metabat2_jgi_summarize_bam_contig_depths/2.15+galaxy0"
+    },
+    {
+      "name": "MALT analyzer",
+      "id": "malt_run",
+      "description": "",
+      "tool_shed_repository": "malt_run",
+      "panel_section_name": "Metagenomic Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/malt_run/malt_run/0.5.3+galaxy0"
+    },
+    {
+      "name": "MaAsLin 2",
+      "id": "maaslin2",
+      "description": "Microbiome Multivariable Association with Linear Models",
+      "tool_shed_repository": "maaslin2",
+      "panel_section_name": "Metagenomic Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/maaslin2/maaslin2/0.99.12+galaxy0"
+    },
+    {
+      "name": "Estimate Abundance at Taxonomic Level",
+      "id": "est_abundance",
+      "description": "Bayesian Reestimation of Abundance with KrakEN",
+      "tool_shed_repository": "bracken",
+      "panel_section_name": "Metagenomic Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/bracken/est_abundance/2.6.1+galaxy0"
+    },
+    {
+      "name": "Kraken2",
+      "id": "kraken2",
+      "description": "assign taxonomic labels to sequencing reads",
+      "tool_shed_repository": "kraken2",
+      "panel_section_name": "Metagenomic Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/kraken2/kraken2/2.1.1+galaxy1"
+    },
+    {
+      "name": "Kraken",
+      "id": "kraken",
+      "description": "assign taxonomic labels to sequencing reads",
+      "tool_shed_repository": "kraken",
+      "panel_section_name": "Metagenomic Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/kraken/kraken/1.3.1"
+    },
+    {
+      "name": "Kraken-report",
+      "id": "kraken-report",
+      "description": "view sample report of a classification",
+      "tool_shed_repository": "kraken_report",
+      "panel_section_name": "Metagenomic Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/kraken_report/kraken-report/1.3.1"
+    },
+    {
+      "name": "Kraken-mpa-report",
+      "id": "kraken-mpa-report",
+      "description": "view report of classification for multiple samples",
+      "tool_shed_repository": "kraken_report",
+      "panel_section_name": "Metagenomic Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/kraken_report/kraken-mpa-report/1.2.4"
+    },
+    {
+      "name": "MetaPhlAn",
+      "id": "metaphlan",
+      "description": "to profile the composition of microbial communities",
+      "tool_shed_repository": "metaphlan",
+      "panel_section_name": "Metagenomic Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/metaphlan/metaphlan/3.0.14+galaxy0"
+    },
+    {
+      "name": "Extract the marker sequences and metadata",
+      "id": "extract_metaphlan_database",
+      "description": "from the MetaPhlAn database",
+      "tool_shed_repository": "extract_metaphlan_database",
+      "panel_section_name": "Metagenomic Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/extract_metaphlan_database/extract_metaphlan_database/3.0.14+galaxy0"
+    },
+    {
+      "name": "MetaBAT2",
+      "id": "metabat2",
+      "description": "metagenome binning",
+      "tool_shed_repository": "metabat2",
+      "panel_section_name": "Metagenomic Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/metabat2/metabat2/2.15+galaxy0"
+    },
+    {
+      "name": "Convert Kraken",
+      "id": "Kraken2Tax",
+      "description": "data to Galaxy taxonomy representation",
+      "tool_shed_repository": "kraken2tax",
+      "panel_section_name": "Metagenomic Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/kraken2tax/Kraken2Tax/1.1"
+    },
+    {
+      "name": "Kraken-translate",
+      "id": "kraken-translate",
+      "description": "convert taxonomy IDs to names",
+      "tool_shed_repository": "kraken_translate",
+      "panel_section_name": "Metagenomic Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/kraken_translate/kraken-translate/1.3.1"
+    },
+    {
+      "name": "Kraken-filter",
+      "id": "kraken-filter",
+      "description": "filter classification by confidence score",
+      "tool_shed_repository": "kraken_filter",
+      "panel_section_name": "Metagenomic Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/kraken_filter/kraken-filter/1.3.1"
+    },
+    {
+      "name": "Krona pie chart",
+      "id": "taxonomy_krona_chart",
+      "description": "from taxonomic profile",
+      "tool_shed_repository": "taxonomy_krona_chart",
+      "panel_section_name": "Metagenomic Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/crs4/taxonomy_krona_chart/taxonomy_krona_chart/2.7.1"
+    },
+    {
+      "name": "Kraken taxonomic report",
+      "id": "kraken_taxonomy_report",
+      "description": "view report of classification for multiple samples",
+      "tool_shed_repository": "kraken_taxonomy_report",
+      "panel_section_name": "Metagenomic Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/kraken_taxonomy_report/kraken_taxonomy_report/0.0.2"
+    },
+    {
+      "name": "InStrain Profile",
+      "id": "instrain_profile",
+      "description": "Creates an inStrain profile (microdiversity analysis) from a mapping file",
+      "tool_shed_repository": "instrain_profile",
+      "panel_section_name": "Metagenomic Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/instrain_profile/instrain_profile/1.5.3+galaxy0"
+    },
+    {
+      "name": "dada2: plotQualityProfile",
+      "id": "dada2_plotQualityProfile",
+      "description": "plot a visual summary of the quality scores",
+      "tool_shed_repository": "dada2_plotqualityprofile",
+      "panel_section_name": "Metagenomic Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/dada2_plotqualityprofile/dada2_plotQualityProfile/1.20+galaxy0"
+    },
+    {
+      "name": "dada2: mergePairs",
+      "id": "dada2_mergePairs",
+      "description": "Merge denoised forward and reverse reads",
+      "tool_shed_repository": "dada2_mergepairs",
+      "panel_section_name": "Metagenomic Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/dada2_mergepairs/dada2_mergePairs/1.20+galaxy0"
+    },
+    {
+      "name": "dada2: assignTaxonomy and addSpecies",
+      "id": "dada2_assignTaxonomyAddspecies",
+      "description": "Learn Error rates",
+      "tool_shed_repository": "dada2_assigntaxonomyaddspecies",
+      "panel_section_name": "Metagenomic Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/dada2_assigntaxonomyaddspecies/dada2_assignTaxonomyAddspecies/1.20+galaxy0"
+    },
+    {
+      "name": "dada2: makeSequenceTable",
+      "id": "dada2_makeSequenceTable",
+      "description": "construct a sequence table (analogous to OTU table)",
+      "tool_shed_repository": "dada2_makesequencetable",
+      "panel_section_name": "Metagenomic Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/dada2_makesequencetable/dada2_makeSequenceTable/1.20+galaxy0"
+    },
+    {
+      "name": "dada2: learnErrors",
+      "id": "dada2_learnErrors",
+      "description": "Learn Error rates",
+      "tool_shed_repository": "dada2_learnerrors",
+      "panel_section_name": "Metagenomic Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/dada2_learnerrors/dada2_learnErrors/1.20+galaxy0"
+    },
+    {
+      "name": "dada2: removeBimeraDenovo",
+      "id": "dada2_removeBimeraDenovo",
+      "description": "Remove bimeras from collections of unique sequences",
+      "tool_shed_repository": "dada2_removebimeradenovo",
+      "panel_section_name": "Metagenomic Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/dada2_removebimeradenovo/dada2_removeBimeraDenovo/1.20+galaxy0"
+    },
+    {
+      "name": "dada2: dada",
+      "id": "dada2_dada",
+      "description": "Remove sequencing errors",
+      "tool_shed_repository": "dada2_dada",
+      "panel_section_name": "Metagenomic Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/dada2_dada/dada2_dada/1.20+galaxy0"
+    },
+    {
+      "name": "dada2: filterAndTrim",
+      "id": "dada2_filterAndTrim",
+      "description": "Filter and trim short read data",
+      "tool_shed_repository": "dada2_filterandtrim",
+      "panel_section_name": "Metagenomic Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/dada2_filterandtrim/dada2_filterAndTrim/1.20+galaxy0"
+    },
+    {
+      "name": "Make strain profiles",
+      "id": "humann_strain_profiler",
+      "description": "",
+      "tool_shed_repository": "humann_strain_profiler",
+      "panel_section_name": "Metagenomic Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/humann_strain_profiler/humann_strain_profiler/3.0.0+galaxy1"
+    },
+    {
+      "name": "Split a HUMAnN table",
+      "id": "humann_split_stratified_table",
+      "description": "into 2 tables (one stratified and one unstratified)",
+      "tool_shed_repository": "humann_split_stratified_table",
+      "panel_section_name": "Metagenomic Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/humann_split_stratified_table/humann_split_stratified_table/3.0.0+galaxy1"
+    },
+    {
+      "name": "Rename features",
+      "id": "humann_rename_table",
+      "description": "of a HUMAnN generated table",
+      "tool_shed_repository": "humann_rename_table",
+      "panel_section_name": "Metagenomic Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/humann_rename_table/humann_rename_table/3.0.0+galaxy1"
+    },
+    {
+      "name": "Join (merge)",
+      "id": "humann_join_tables",
+      "description": "gene, pathway, or taxonomy HUMAnN/MetaPhlAn tables into a single table",
+      "tool_shed_repository": "humann_join_tables",
+      "panel_section_name": "Metagenomic Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/humann_join_tables/humann_join_tables/3.0.0+galaxy1"
+    },
+    {
+      "name": "Perform metadata association",
+      "id": "humann_associate",
+      "description": "on HUMAnN generated table",
+      "tool_shed_repository": "humann_associate",
+      "panel_section_name": "Metagenomic Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/humann_associate/humann_associate/3.0.0+galaxy1"
+    },
+    {
+      "name": "Regroup",
+      "id": "humann_regroup_table",
+      "description": "HUMAnN table features",
+      "tool_shed_repository": "humann_regroup_table",
+      "panel_section_name": "Metagenomic Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/humann_regroup_table/humann_regroup_table/3.0.0+galaxy1"
+    },
+    {
+      "name": "HUMAnN",
+      "id": "humann",
+      "description": "to profile presence/absence and abundance of microbial pathways and gene families",
+      "tool_shed_repository": "humann",
+      "panel_section_name": "Metagenomic Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/humann/humann/3.0.0+galaxy1"
+    },
+    {
+      "name": "Split",
+      "id": "humann_split_table",
+      "description": "a merged HUMAnN table",
+      "tool_shed_repository": "humann_split_table",
+      "panel_section_name": "Metagenomic Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/humann_split_table/humann_split_table/3.0.0+galaxy1"
+    },
+    {
+      "name": "Renormalize",
+      "id": "humann_renorm_table",
+      "description": "a HUMAnN generated table",
+      "tool_shed_repository": "humann_renorm_table",
+      "panel_section_name": "Metagenomic Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/humann_renorm_table/humann_renorm_table/3.0.0+galaxy1"
+    },
+    {
+      "name": "Barplot",
+      "id": "humann_barplot",
+      "description": "stratified HUMAnN features",
+      "tool_shed_repository": "humann_barplot",
+      "panel_section_name": "Metagenomic Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/humann_barplot/humann_barplot/3.0.0+galaxy1"
+    },
+    {
+      "name": "Salmonella Subtyping",
+      "id": "bio_hansel",
+      "description": "",
+      "tool_shed_repository": "bio_hansel",
+      "panel_section_name": "Metagenomic Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/bio_hansel/bio_hansel/2.6.1+galaxy0"
+    },
+    {
+      "name": "jellyfish",
+      "id": "jellyfish",
+      "description": "",
+      "tool_shed_repository": "jellyfish",
+      "panel_section_name": "Metagenomic Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/jellyfish/jellyfish/2.3.0+galaxy0"
+    },
+    {
+      "name": "HUMAnN2",
+      "id": "humann2",
+      "description": "to profile presence/absence and abundance of microbial pathways and gene families",
+      "tool_shed_repository": "humann2",
+      "panel_section_name": "Metagenomic Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/humann2/humann2/0.11.1.3"
+    },
+    {
+      "name": "LASTdb",
+      "id": "last_db",
+      "description": "prepares sequences for subsequent comparison and alignment using lastal.",
+      "tool_shed_repository": "last",
+      "panel_section_name": "Metagenomic Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/last/last_db/1205+galaxy0"
+    },
+    {
+      "name": "LAST-split",
+      "id": "last_split",
+      "description": "finds \"split alignments\" (typically for DNA) or \"spliced alignments\" (typically for RNA).",
+      "tool_shed_repository": "last",
+      "panel_section_name": "Metagenomic Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/last/last_split/1205+galaxy0"
+    },
+    {
+      "name": "LAST-train",
+      "id": "last_train",
+      "description": "finds the rates (probabilities) of insertion, deletion, and substitutions between two sets of sequences.",
+      "tool_shed_repository": "last",
+      "panel_section_name": "Metagenomic Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/last/last_train/1205+galaxy0"
+    },
+    {
+      "name": "MAF-convert",
+      "id": "last_maf_convert",
+      "description": "read MAF-format alignments and write them in another format.",
+      "tool_shed_repository": "last",
+      "panel_section_name": "Metagenomic Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/last/last_maf_convert/1205+galaxy0"
+    },
+    {
+      "name": "khmer: Abundance Distribution (all-in-one)",
+      "id": "khmer_abundance_distribution_single",
+      "description": "Calculate abundance distribution of k-mers",
+      "tool_shed_repository": "khmer_abundance_distribution_single",
+      "panel_section_name": "Metagenomic Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/khmer_abundance_distribution_single/khmer_abundance_distribution_single/3.0.0a3+galaxy2"
+    },
+    {
+      "name": "khmer: Sequence partition all-in-one",
+      "id": "khmer_partition",
+      "description": "Load, partition, and annotate sequences",
+      "tool_shed_repository": "khmer_partition",
+      "panel_section_name": "Metagenomic Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/khmer_partition/khmer_partition/3.0.0a3+galaxy2"
+    },
+    {
+      "name": "khmer: Count Median",
+      "id": "khmer_count_median",
+      "description": "Count the median/avg k-mer abundance for each sequence",
+      "tool_shed_repository": "khmer_count_median",
+      "panel_section_name": "Metagenomic Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/khmer_count_median/khmer_count_median/3.0.0a3+galaxy2"
+    },
+    {
+      "name": "khmer: Abundance Distribution",
+      "id": "khmer_abundance_distribution",
+      "description": "Calculate abundance distribution of k-mers using pre-made k-mer countgraphs",
+      "tool_shed_repository": "khmer_abundance_distribution",
+      "panel_section_name": "Metagenomic Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/khmer_abundance_distribution/khmer_abundance_distribution/3.0.0a3+galaxy2"
+    },
+    {
+      "name": "khmer: Filter reads",
+      "id": "khmer_filter_below_abundance_cutoff",
+      "description": "below k-mer abundance of 50",
+      "tool_shed_repository": "khmer_filter_below_abundance_cutoff",
+      "panel_section_name": "Metagenomic Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/khmer_filter_below_abundance_cutoff/khmer_filter_below_abundance_cutoff/3.0.0a3+galaxy2"
+    },
+    {
+      "name": "khmer: Filter reads",
+      "id": "khmer_filter_abundance",
+      "description": "by minimal k-mer abundance",
+      "tool_shed_repository": "khmer_filter_abundance",
+      "panel_section_name": "Metagenomic Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/khmer_filter_abundance/khmer_filter_abundance/3.0.0a3+galaxy2"
+    },
+    {
+      "name": "staramr",
+      "id": "staramr_search",
+      "description": "Scans genome assemblies against the ResFinder, PlasmidFinder, and PointFinder databases searching for AMR genes.",
+      "tool_shed_repository": "staramr",
+      "panel_section_name": "Metagenomic Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/nml/staramr/staramr_search/0.7.2+galaxy0"
+    },
+    {
+      "name": "Scoary",
+      "id": "scoary",
+      "description": "calculates the assocations between all genes in the accessory genome and the traits",
+      "tool_shed_repository": "scoary",
+      "panel_section_name": "Metagenomic Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/scoary/scoary/1.6.16+galaxy0"
+    },
+    {
+      "name": "khmer: Extract partitions",
+      "id": "khmer_extract_partitions",
+      "description": "Separate sequences that are annotated with partitions into grouped files",
+      "tool_shed_repository": "khmer_extract_partitions",
+      "panel_section_name": "Metagenomic Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/khmer_extract_partitions/khmer_extract_partitions/3.0.0a3+galaxy2"
+    },
+    {
+      "name": "khmer: Normalize By Median",
+      "id": "khmer_normalize_by_median",
+      "description": "Filter reads using digital normalization via k-mer abundances",
+      "tool_shed_repository": "khmer_normalize_by_median",
+      "panel_section_name": "Metagenomic Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/khmer_normalize_by_median/khmer_normalize_by_median/3.0.0a3+galaxy2"
+    },
+    {
+      "name": "Reduce",
+      "id": "humann_reduce_table",
+      "description": "a joined HUMAnN table",
+      "tool_shed_repository": "humann_reduce_table",
+      "panel_section_name": "Metagenomic Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/humann_reduce_table/humann_reduce_table/3.0.0+galaxy1"
+    },
+    {
+      "name": "Normalize",
+      "id": "humann_rna_dna_norm",
+      "description": "combined meta'omic sequencing data",
+      "tool_shed_repository": "humann_rna_dna_norm",
+      "panel_section_name": "Metagenomic Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/humann_rna_dna_norm/humann_rna_dna_norm/3.0.0+galaxy1"
+    },
+    {
+      "name": "Unpack pathway abundances",
+      "id": "humann_unpack_pathways",
+      "description": "to show the genes for each",
+      "tool_shed_repository": "humann_unpack_pathways",
+      "panel_section_name": "Metagenomic Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/humann_unpack_pathways/humann_unpack_pathways/3.0.0+galaxy1"
+    },
+    {
+      "name": "mash screen",
+      "id": "mash_screen",
+      "description": "determines how well query sequences are contained within a pool of sequences",
+      "tool_shed_repository": "mash",
+      "panel_section_name": "Metagenomic Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/mash/mash_screen/2.3+galaxy3"
+    },
+    {
+      "name": "dada2: sequence counts",
+      "id": "dada2_seqCounts",
+      "description": "",
+      "tool_shed_repository": "dada2_seqcounts",
+      "panel_section_name": "Metagenomic Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/dada2_seqcounts/dada2_seqCounts/1.20+galaxy0"
+    },
+    {
+      "name": "dada2: plotComplexity",
+      "id": "dada2_plotComplexity",
+      "description": "Plot sequence complexity profile",
+      "tool_shed_repository": "dada2_plotcomplexity",
+      "panel_section_name": "Metagenomic Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/dada2_plotcomplexity/dada2_plotComplexity/1.20+galaxy0"
+    },
+    {
+      "name": "InStrain Compare",
+      "id": "instrain_compare",
+      "description": "Compares multiple inStrain profiles (popANI, coverage_overlap, etc.)",
+      "tool_shed_repository": "instrain_compare",
+      "panel_section_name": "Metagenomic Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/instrain_compare/instrain_compare/1.5.3+galaxy0"
+    },
+    {
+      "name": "MT2MQ",
+      "id": "mt2mq",
+      "description": "Tool to prepare metatranscriptomic outputs from ASaiM for Metaquantome",
+      "tool_shed_repository": "mt2mq",
+      "panel_section_name": "Metagenomic Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/mt2mq/mt2mq/1.0"
+    },
+    {
+      "name": "Join",
+      "id": "humann2_join_tables",
+      "description": "HUMAnN2 generated tables",
+      "tool_shed_repository": "humann2_join_tables",
+      "panel_section_name": "Metagenomic Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/humann2_join_tables/humann2_join_tables/0.11.1.2"
+    },
+    {
+      "name": "VSearch search",
+      "id": "vsearch_search",
+      "description": "",
+      "tool_shed_repository": "vsearch",
+      "panel_section_name": "Metagenomic Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/vsearch/vsearch_search/2.8.3.1"
+    },
+    {
+      "name": "Associate",
+      "id": "humann2_associate",
+      "description": "HUMAnN2 functions with metadata",
+      "tool_shed_repository": "humann2_associate",
+      "panel_section_name": "Metagenomic Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/humann2_associate/humann2_associate/0.11.1.1"
+    },
+    {
+      "name": "Barplot",
+      "id": "humann2_barplot",
+      "description": "stratified HUMAnN2 features",
+      "tool_shed_repository": "humann2_barplot",
+      "panel_section_name": "Metagenomic Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/humann2_barplot/humann2_barplot/0.11.1.1"
+    },
+    {
+      "name": "Create a genus level gene families file",
+      "id": "humann2_genefamilies_genus_level",
+      "description": "",
+      "tool_shed_repository": "humann2_genefamilies_genus_level",
+      "panel_section_name": "Metagenomic Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/humann2_genefamilies_genus_level/humann2_genefamilies_genus_level/0.11.1.1"
+    },
+    {
+      "name": "Reduce",
+      "id": "humann2_reduce_table",
+      "description": "a HUMAnN2 generated table",
+      "tool_shed_repository": "humann2_reduce_table",
+      "panel_section_name": "Metagenomic Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/humann2_reduce_table/humann2_reduce_table/0.11.1.1"
+    },
+    {
+      "name": "Regroup",
+      "id": "humann2_regroup_table",
+      "description": "a HUMAnN2 generated table by features",
+      "tool_shed_repository": "humann2_regroup_table",
+      "panel_section_name": "Metagenomic Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/humann2_regroup_table/humann2_regroup_table/0.11.1.1"
+    },
+    {
+      "name": "Rename",
+      "id": "humann2_rename_table",
+      "description": "features of a HUMAnN2 generated table",
+      "tool_shed_repository": "humann2_rename_table",
+      "panel_section_name": "Metagenomic Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/humann2_rename_table/humann2_rename_table/0.11.1.1"
+    },
+    {
+      "name": "Renormalize",
+      "id": "humann2_renorm_table",
+      "description": "a HUMAnN2 generated table",
+      "tool_shed_repository": "humann2_renorm_table",
+      "panel_section_name": "Metagenomic Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/humann2_renorm_table/humann2_renorm_table/0.11.1.1"
+    },
+    {
+      "name": "Normalize",
+      "id": "humann2_rna_dna_norm",
+      "description": "combined meta'omic sequencing data",
+      "tool_shed_repository": "humann2_rna_dna_norm",
+      "panel_section_name": "Metagenomic Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/humann2_rna_dna_norm/humann2_rna_dna_norm/0.11.1.1"
+    },
+    {
+      "name": "Split stratified table",
+      "id": "humann2_split_stratified_table",
+      "description": "",
+      "tool_shed_repository": "humann2_split_stratified_table",
+      "panel_section_name": "Metagenomic Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/humann2_split_stratified_table/humann2_split_stratified_table/0.11.1.1"
+    },
+    {
+      "name": "Split",
+      "id": "humann2_split_table",
+      "description": "a HUMAnN2 generated table",
+      "tool_shed_repository": "humann2_split_table",
+      "panel_section_name": "Metagenomic Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/humann2_split_table/humann2_split_table/0.11.1.1"
+    },
+    {
+      "name": "Make strain profiles",
+      "id": "humann2_strain_profiler",
+      "description": "",
+      "tool_shed_repository": "humann2_strain_profiler",
+      "panel_section_name": "Metagenomic Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/humann2_strain_profiler/humann2_strain_profiler/0.11.1.1"
+    },
+    {
+      "name": "Unpack pathway abundances to show genes included",
+      "id": "humann2_unpack_pathways",
+      "description": "",
+      "tool_shed_repository": "humann2_unpack_pathways",
+      "panel_section_name": "Metagenomic Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/humann2_unpack_pathways/humann2_unpack_pathways/0.11.1.1"
+    },
+    {
+      "name": "MetaGeneAnnotator",
+      "id": "metagene_annotator",
+      "description": "gene-finding program for prokaryote and phage (used by sixgill)",
+      "tool_shed_repository": "metagene_annotator",
+      "panel_section_name": "Metagenomic Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/metagene_annotator/metagene_annotator/1.0.0"
+    },
+    {
+      "name": "mash sketch",
+      "id": "mash_sketch",
+      "description": "Create a reduced representation of a sequence or set of sequences, based on min-hashes",
+      "tool_shed_repository": "mash_sketch",
+      "panel_section_name": "Metagenomic Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/mash_sketch/mash_sketch/2.1+galaxy0"
+    },
+    {
+      "name": "sixgill merge",
+      "id": "sixgill_merge",
+      "description": "metapeptide databases",
+      "tool_shed_repository": "sixgill",
+      "panel_section_name": "Metagenomic Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/sixgill/sixgill_merge/0.2.4.0"
+    },
+    {
+      "name": "sixgill filter",
+      "id": "sixgill_filter",
+      "description": "a metapeptide database",
+      "tool_shed_repository": "sixgill",
+      "panel_section_name": "Metagenomic Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/sixgill/sixgill_filter/0.2.4.0"
+    },
+    {
+      "name": "sixgill build",
+      "id": "sixgill_build",
+      "description": "a metapeptide database from metagenome fastq files",
+      "tool_shed_repository": "sixgill",
+      "panel_section_name": "Metagenomic Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/sixgill/sixgill_build/0.2.4.0"
+    },
+    {
+      "name": "sixgill makefasta",
+      "id": "sixgill_makefasta",
+      "description": "from a metapeptide database",
+      "tool_shed_repository": "sixgill",
+      "panel_section_name": "Metagenomic Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/sixgill/sixgill_makefasta/0.2.4.0"
+    },
+    {
+      "name": "CAT contigs",
+      "id": "cat_contigs",
+      "description": "annotate with taxonomic classification",
+      "tool_shed_repository": "cat_contigs",
+      "panel_section_name": "Metagenomic Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/cat_contigs/cat_contigs/5.0.3.1"
+    },
+    {
+      "name": "CAT bins",
+      "id": "cat_bins",
+      "description": "annotate with taxonomic classification",
+      "tool_shed_repository": "cat_bins",
+      "panel_section_name": "Metagenomic Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/cat_bins/cat_bins/5.0.3.1"
+    },
+    {
+      "name": "CAT add_names",
+      "id": "cat_add_names",
+      "description": "annotate with taxonomic names",
+      "tool_shed_repository": "cat_add_names",
+      "panel_section_name": "Metagenomic Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/cat_add_names/cat_add_names/5.0.3.0"
+    },
+    {
+      "name": "CAT summarise",
+      "id": "cat_summarise",
+      "description": "the number of contigs or bins assigned to each taxonomic name",
+      "tool_shed_repository": "cat_summarise",
+      "panel_section_name": "Metagenomic Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/cat_summarise/cat_summarise/5.0.3.0"
+    },
+    {
+      "name": "CAT prepare",
+      "id": "cat_prepare",
+      "description": "a database for CAT - Contig Annotation Tool",
+      "tool_shed_repository": "cat_prepare",
+      "panel_section_name": "Metagenomic Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/cat_prepare/cat_prepare/5.0.3.0"
+    },
+    {
+      "name": "MaxBin2",
+      "id": "maxbin2",
+      "description": "clusters metagenomic contigs into bins",
+      "tool_shed_repository": "maxbin2",
+      "panel_section_name": "Metagenomic Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/mbernt/maxbin2/maxbin2/2.2.7+galaxy2"
+    },
+    {
+      "name": "Group abundances",
+      "id": "group_humann2_uniref_abundances_to_go",
+      "description": "of UniRef50 gene families obtained (HUMAnN2 output) to Gene Ontology (GO) slim terms",
+      "tool_shed_repository": "group_humann2_uniref_abundances_to_go",
+      "panel_section_name": "Metagenomic Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bebatut/group_humann2_uniref_abundances_to_go/group_humann2_uniref_abundances_to_go/1.2.3"
+    },
+    {
+      "name": "PlasFlow",
+      "id": "PlasFlow",
+      "description": "Prediction of plasmid sequences in metagenomic contigs",
+      "tool_shed_repository": "plasflow",
+      "panel_section_name": "Metagenomic Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/plasflow/PlasFlow/1.0"
+    },
+    {
+      "name": "Vegan Diversity",
+      "id": "vegan_diversity",
+      "description": "index",
+      "tool_shed_repository": "vegan_diversity",
+      "panel_section_name": "Metagenomic Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/vegan_diversity/vegan_diversity/2.4-3"
+    },
+    {
+      "name": "Vegan Fisher Alpha",
+      "id": "vegan_fisher_alpha",
+      "description": "index",
+      "tool_shed_repository": "vegan_fisher_alpha",
+      "panel_section_name": "Metagenomic Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/vegan_fisher_alpha/vegan_fisher_alpha/2.4-3"
+    },
+    {
+      "name": "Vegan Rarefaction",
+      "id": "vegan_rarefaction",
+      "description": "curve and statistics",
+      "tool_shed_repository": "vegan_rarefaction",
+      "panel_section_name": "Metagenomic Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/vegan_rarefaction/vegan_rarefaction/2.4-3"
+    },
+    {
+      "name": "VSearch sorting",
+      "id": "vsearch_sorting",
+      "description": "",
+      "tool_shed_repository": "vsearch",
+      "panel_section_name": "Metagenomic Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/vsearch/vsearch_sorting/2.8.3.0"
+    },
+    {
+      "name": "VSearch chimera detection",
+      "id": "vsearch_chimera_detection",
+      "description": "",
+      "tool_shed_repository": "vsearch",
+      "panel_section_name": "Metagenomic Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/vsearch/vsearch_chimera_detection/2.8.3.0"
+    },
+    {
+      "name": "VSearch clustering",
+      "id": "vsearch_clustering",
+      "description": "",
+      "tool_shed_repository": "vsearch",
+      "panel_section_name": "Metagenomic Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/vsearch/vsearch_clustering/2.8.3.0"
+    },
+    {
+      "name": "VSearch masking",
+      "id": "vsearch_masking",
+      "description": "",
+      "tool_shed_repository": "vsearch",
+      "panel_section_name": "Metagenomic Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/vsearch/vsearch_masking/2.8.3.0"
+    },
+    {
+      "name": "VSearch alignment",
+      "id": "vsearch_alignment",
+      "description": "",
+      "tool_shed_repository": "vsearch",
+      "panel_section_name": "Metagenomic Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/vsearch/vsearch_alignment/2.8.3.0"
+    },
+    {
+      "name": "VSearch dereplication",
+      "id": "vsearch_dereplication",
+      "description": "",
+      "tool_shed_repository": "vsearch",
+      "panel_section_name": "Metagenomic Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/vsearch/vsearch_dereplication/2.8.3.0"
+    },
+    {
+      "name": "VSearch shuffling",
+      "id": "vsearch_shuffling",
+      "description": "",
+      "tool_shed_repository": "vsearch",
+      "panel_section_name": "Metagenomic Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/vsearch/vsearch_shuffling/2.8.3.0"
+    },
+    {
+      "name": "Compare outputs of HUMAnN2 for several samples",
+      "id": "compare_humann2_output",
+      "description": "and extract similar and specific information",
+      "tool_shed_repository": "compare_humann2_output",
+      "panel_section_name": "Metagenomic Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bebatut/compare_humann2_output/compare_humann2_output/0.1.0"
+    },
+    {
+      "name": "Combine MetaPhlAn2 and HUMAnN2 outputs",
+      "id": "combine_metaphlan2_humann2",
+      "description": "to relate genus/species abundances and gene families/pathways abundances",
+      "tool_shed_repository": "combine_metaphlan2_humann2",
+      "panel_section_name": "Metagenomic Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bebatut/combine_metaphlan2_humann2/combine_metaphlan2_humann2/0.1.0"
+    },
+    {
+      "name": "Format MetaPhlAn2",
+      "id": "format_metaphlan2_output",
+      "description": "output to extract abundance at different taxonomic levels",
+      "tool_shed_repository": "format_metaphlan2_output",
+      "panel_section_name": "Metagenomic Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bebatut/format_metaphlan2_output/format_metaphlan2_output/0.1.0"
+    },
+    {
+      "name": "VALET",
+      "id": "valet",
+      "description": "to detect mis-assemblies in metagenomic assemblies",
+      "tool_shed_repository": "valet",
+      "panel_section_name": "Metagenomic Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/valet/valet/1.0.0"
+    },
+    {
+      "name": "Nonpareil",
+      "id": "nonpareil",
+      "description": "to estimate average coverage and generate Nonpareil curves",
+      "tool_shed_repository": "nonpareil",
+      "panel_section_name": "Metagenomic Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/nonpareil/nonpareil/3.1.1.0"
+    },
+    {
+      "name": "MetaPhlAn2",
+      "id": "metaphlan2",
+      "description": "to profile the composition of microbial communities",
+      "tool_shed_repository": "metaphlan2",
+      "panel_section_name": "Metagenomic Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/metaphlan2/metaphlan2/2.6.0.0"
+    },
+    {
+      "name": "Format MetaPhlAn2",
+      "id": "metaphlan2krona",
+      "description": "output for Krona",
+      "tool_shed_repository": "metaphlan2krona",
+      "panel_section_name": "Metagenomic Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/metaphlan2krona/metaphlan2krona/2.6.0.0"
+    },
+    {
+      "name": "Generate heatmap",
+      "id": "metaphlan_hclust_heatmap",
+      "description": "with hierarchical clustering of both samplesand microbial clades for MetaPhlAn2",
+      "tool_shed_repository": "metaphlan_hclust_heatmap",
+      "panel_section_name": "Metagenomic Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/metaphlan_hclust_heatmap/metaphlan_hclust_heatmap/2.6.0.0"
+    },
+    {
+      "name": "metagenomeSeq Normalization",
+      "id": "metagenomeseq_normalizaton",
+      "description": "Cumulative sum scaling",
+      "tool_shed_repository": "metagenomeseq_normalization",
+      "panel_section_name": "Metagenomic Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/metagenomeseq_normalization/metagenomeseq_normalizaton/1.16.0-0.0.1"
+    },
+    {
+      "name": "Collapse samples",
+      "id": "qiime_collapse_samples",
+      "description": "Collapse samples in a BIOM table and mapping file",
+      "tool_shed_repository": "qiime_collapse_samples",
+      "panel_section_name": "Qiime",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/qiime_collapse_samples/qiime_collapse_samples/1.9.1.0"
+    },
+    {
+      "name": "Make OTU table",
+      "id": "qiime_make_otu_table",
+      "description": "Make an OTU table from an OTU map and a taxonomy assignment file",
+      "tool_shed_repository": "qiime_make_otu_table",
+      "panel_section_name": "Qiime",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/qiime_make_otu_table/qiime_make_otu_table/1.9.1.0"
+    },
+    {
+      "name": "Perform open-reference OTU picking",
+      "id": "qiime_pick_open_reference_otus",
+      "description": "(pick_open_reference_otus)",
+      "tool_shed_repository": "qiime_pick_open_reference_otus",
+      "panel_section_name": "Qiime",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/qiime_pick_open_reference_otus/qiime_pick_open_reference_otus/1.9.1.0"
+    },
+    {
+      "name": "Closed-reference OTU picking",
+      "id": "qiime_pick_closed_reference_otus",
+      "description": "Shotgun UniFrac workflow (pick_closed_reference_otus)",
+      "tool_shed_repository": "qiime_pick_closed_reference_otus",
+      "panel_section_name": "Qiime",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/qiime_pick_closed_reference_otus/qiime_pick_closed_reference_otus/1.9.1.0"
+    },
+    {
+      "name": "Count the sequences",
+      "id": "qiime_count_seqs",
+      "description": "in a fasta file (count_seqs)",
+      "tool_shed_repository": "qiime_count_seqs",
+      "panel_section_name": "Qiime",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/qiime_count_seqs/qiime_count_seqs/1.9.1.0"
+    },
+    {
+      "name": "Format Fastq sequences and barcode data",
+      "id": "qiime_extract_barcodes",
+      "description": "(extract_barcodes)",
+      "tool_shed_repository": "qiime_extract_barcodes",
+      "panel_section_name": "Qiime",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/qiime_extract_barcodes/qiime_extract_barcodes/1.9.1.0"
+    },
+    {
+      "name": "Count sequences",
+      "id": "count_seqs",
+      "description": "Count the sequences in a fasta file",
+      "tool_shed_repository": "count_seqs",
+      "panel_section_name": "Qiime",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/count_seqs/count_seqs/1.9.1.0"
+    },
+    {
+      "name": "Create three-dimensional PCoA plots",
+      "id": "qiime_make_emperor",
+      "description": "to be visualized with Emperor (make_emperor)",
+      "tool_shed_repository": "qiime_make_emperor",
+      "panel_section_name": "Qiime",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/qiime_make_emperor/qiime_make_emperor/1.9.1.0"
+    },
+    {
+      "name": "Plot heatmap of OTU table",
+      "id": "qiime_make_otu_heatmap",
+      "description": "(make_otu_heatmap)",
+      "tool_shed_repository": "qiime_make_otu_heatmap",
+      "panel_section_name": "Qiime",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/qiime_make_otu_heatmap/qiime_make_otu_heatmap/1.9.1.0"
+    },
+    {
+      "name": "Pick representative set of sequences",
+      "id": "qiime_pick_rep_set",
+      "description": "(pick_rep_set)",
+      "tool_shed_repository": "qiime_pick_rep_set",
+      "panel_section_name": "Qiime",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/qiime_pick_rep_set/qiime_pick_rep_set/1.9.1.0"
+    },
+    {
+      "name": "Run join_paired_ends on multiple files",
+      "id": "qiime_multiple_join_paired_ends",
+      "description": "(multiple_join_paired_ends)",
+      "tool_shed_repository": "qiime_multiple_join_paired_ends",
+      "panel_section_name": "Qiime",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/qiime_multiple_join_paired_ends/qiime_multiple_join_paired_ends/1.9.1.0"
+    },
+    {
+      "name": "Align sequences",
+      "id": "qiime_align_seqs",
+      "description": "using a variety of alignment methods (align_seqs)",
+      "tool_shed_repository": "qiime_align_seqs",
+      "panel_section_name": "Qiime",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/qiime_align_seqs/qiime_align_seqs/1.9.1.0"
+    },
+    {
+      "name": "Perform alpha rarefaction",
+      "id": "qiime_alpha_rarefaction",
+      "description": "(alpha_rarefaction)",
+      "tool_shed_repository": "qiime_alpha_rarefaction",
+      "panel_section_name": "Qiime",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/qiime_alpha_rarefaction/qiime_alpha_rarefaction/1.9.1.0"
+    },
+    {
+      "name": "Perform open-reference OTU picking",
+      "id": "pick_open_reference_otus",
+      "description": "",
+      "tool_shed_repository": "pick_open_reference_otus",
+      "panel_section_name": "Qiime",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/pick_open_reference_otus/pick_open_reference_otus/1.9.1.0"
+    },
+    {
+      "name": "Perform closed-reference OTU picking",
+      "id": "pick_closed_reference_otus",
+      "description": "",
+      "tool_shed_repository": "pick_closed_reference_otus",
+      "panel_section_name": "Qiime",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/pick_closed_reference_otus/pick_closed_reference_otus/1.9.1.0"
+    },
+    {
+      "name": "Run a core set of QIIME diversity analyses",
+      "id": "qiime_core_diversity",
+      "description": "(core_diversity_analyses)",
+      "tool_shed_repository": "qiime_core_diversity",
+      "panel_section_name": "Qiime",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/qiime_core_diversity/qiime_core_diversity/1.9.1.0"
+    },
+    {
+      "name": "Calculate alpha diversity",
+      "id": "qiime_alpha_diversity",
+      "description": "on each sample in an otu table, using a variety of alpha diversity metrics (alpha_diversity)",
+      "tool_shed_repository": "qiime_alpha_diversity",
+      "panel_section_name": "Qiime",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/qiime_alpha_diversity/qiime_alpha_diversity/1.9.1.0"
+    },
+    {
+      "name": "Split fastq libraries",
+      "id": "qiime_split_libraries_fastq",
+      "description": "to performs demultiplexing of Fastq sequence data (split_libraries_fastq)",
+      "tool_shed_repository": "qiime_split_libraries_fastq",
+      "panel_section_name": "Qiime",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/qiime_split_libraries_fastq/qiime_split_libraries_fastq/1.9.1.0"
+    },
+    {
+      "name": "Filter OTUs from an OTU table",
+      "id": "qiime_filter_otus_from_otu_table",
+      "description": "based on their observation counts or identifier (filter_otus_from_otu_table)",
+      "tool_shed_repository": "qiime_filter_otus_from_otu_table",
+      "panel_section_name": "Qiime",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/qiime_filter_otus_from_otu_table/qiime_filter_otus_from_otu_table/1.9.1.0"
+    },
+    {
+      "name": "Perform jackknifed UPGMA clustering",
+      "id": "qiime_jackknifed_beta_diversity",
+      "description": "and building jackknifed PCoA plots (jackknifed_beta_diversity)",
+      "tool_shed_repository": "qiime_jackknifed_beta_diversity",
+      "panel_section_name": "Qiime",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/qiime_jackknifed_beta_diversity/qiime_jackknifed_beta_diversity/1.9.1.0"
+    },
+    {
+      "name": "Filter taxa from an OTU table",
+      "id": "qiime_filter_taxa_from_otu_table",
+      "description": "(filter_taxa_from_otu_table)",
+      "tool_shed_repository": "qiime_filter_taxa_from_otu_table",
+      "panel_section_name": "Qiime",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/qiime_filter_taxa_from_otu_table/qiime_filter_taxa_from_otu_table/1.9.1.0"
+    },
+    {
+      "name": "Perform OTU picking",
+      "id": "qiime_pick_otus",
+      "description": "(pick_otus)",
+      "tool_shed_repository": "qiime_pick_otus",
+      "panel_section_name": "Qiime",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/qiime_pick_otus/qiime_pick_otus/1.9.1.0"
+    },
+    {
+      "name": "Analyze statistical significance of sample groupings",
+      "id": "qiime_compare_categories",
+      "description": "using distance matrices (compare_categories)",
+      "tool_shed_repository": "qiime_compare_categories",
+      "panel_section_name": "Qiime",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/qiime_compare_categories/qiime_compare_categories/1.9.1.0"
+    },
+    {
+      "name": "Make taxonomy summary charts",
+      "id": "qiime_plot_taxa_summary",
+      "description": "based on taxonomy assignment (plot_taxa_summary)",
+      "tool_shed_repository": "qiime_plot_taxa_summary",
+      "panel_section_name": "Qiime",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/qiime_plot_taxa_summary/qiime_plot_taxa_summary/1.9.1.0"
+    },
+    {
+      "name": "Build a UPGMA tree",
+      "id": "qiime_upgma_cluster",
+      "description": "comparing samples (upgma_cluster)",
+      "tool_shed_repository": "qiime_upgma_cluster",
+      "panel_section_name": "Qiime",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/qiime_upgma_cluster/qiime_upgma_cluster/1.9.1.0"
+    },
+    {
+      "name": "Filter fasta",
+      "id": "qiime_filter_fasta",
+      "description": "to remove sequences based on input criteria (filter_fasta)",
+      "tool_shed_repository": "qiime_filter_fasta",
+      "panel_section_name": "Qiime",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/qiime_filter_fasta/qiime_filter_fasta/1.9.1.0"
+    },
+    {
+      "name": "Filter sequence alignment",
+      "id": "qiime_filter_alignment",
+      "description": "by removing highly variable regions (filter_alignment)",
+      "tool_shed_repository": "qiime_filter_alignment",
+      "panel_section_name": "Qiime",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/qiime_filter_alignment/qiime_filter_alignment/1.9.1.0"
+    },
+    {
+      "name": "Assign taxonomy",
+      "id": "qiime_assign_taxonomy",
+      "description": "to each sequence (assign_taxonomy)",
+      "tool_shed_repository": "qiime_assign_taxonomy",
+      "panel_section_name": "Qiime",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/qiime_assign_taxonomy/qiime_assign_taxonomy/1.9.1.0"
+    },
+    {
+      "name": "Make phylogeny",
+      "id": "qiime_make_phylogeny",
+      "description": "(make_phylogeny)",
+      "tool_shed_repository": "qiime_make_phylogeny",
+      "panel_section_name": "Qiime",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/qiime_make_phylogeny/qiime_make_phylogeny/1.9.1.0"
+    },
+    {
+      "name": "Summarize taxa",
+      "id": "qiime_summarize_taxa",
+      "description": "and store results in a new table or appended to an existing mapping file (summarize_taxa)",
+      "tool_shed_repository": "qiime_summarize_taxa",
+      "panel_section_name": "Qiime",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/qiime_summarize_taxa/qiime_summarize_taxa/1.9.1.0"
+    },
+    {
+      "name": "Calculate beta diversity",
+      "id": "qiime_beta_diversity",
+      "description": "(pairwise sample dissimilarity) on one or many otu tables (beta_diversity)",
+      "tool_shed_repository": "qiime_beta_diversity",
+      "panel_section_name": "Qiime",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/qiime_beta_diversity/qiime_beta_diversity/1.9.1.0"
+    },
+    {
+      "name": "Split libraries",
+      "id": "qiime_split_libraries",
+      "description": "according to barcodes specified in mapping file (split_libraries)",
+      "tool_shed_repository": "qiime_split_libraries",
+      "panel_section_name": "Qiime",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/qiime_split_libraries/qiime_split_libraries/1.9.1.0"
+    },
+    {
+      "name": "Filters samples from an OTU table",
+      "id": "qiime_filter_samples_from_otu_table",
+      "description": "on the basis of the number of observations in that sample, or on the basis of sample metadata (filter_samples_from_otu_table)",
+      "tool_shed_repository": "qiime_filter_samples_from_otu_table",
+      "panel_section_name": "Qiime",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/qiime_filter_samples_from_otu_table/qiime_filter_samples_from_otu_table/1.9.1.0"
+    },
+    {
+      "name": "Perform taxonomy summaries and plots",
+      "id": "qiime_summarize_taxa_through_plots",
+      "description": "(summarize_taxa_through_plots)",
+      "tool_shed_repository": "qiime_summarize_taxa_through_plots",
+      "panel_section_name": "Qiime",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/qiime_summarize_taxa_through_plots/qiime_summarize_taxa_through_plots/1.9.1.0"
+    },
+    {
+      "name": "Run split_libraries_fastq on multiple files",
+      "id": "qiime_multiple_split_libraries_fastq",
+      "description": "(multiple_split_libraries_fastq)",
+      "tool_shed_repository": "qiime_multiple_split_libraries_fastq",
+      "panel_section_name": "Qiime",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/qiime_multiple_split_libraries_fastq/qiime_multiple_split_libraries_fastq/1.9.1.0"
+    },
+    {
+      "name": "Compute beta diversity distance matrices and generate PCoA plots",
+      "id": "qiime_beta_diversity_through_plots",
+      "description": "(beta_diversity_through_plots)",
+      "tool_shed_repository": "qiime_beta_diversity_through_plots",
+      "panel_section_name": "Qiime",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/qiime_beta_diversity_through_plots/qiime_beta_diversity_through_plots/1.9.1.0"
+    },
+    {
+      "name": "Check user's metadata mapping file",
+      "id": "qiime_validate_mapping_file",
+      "description": "for required data, valid format (validate_mapping_file)",
+      "tool_shed_repository": "qiime_validate_mapping_file",
+      "panel_section_name": "Qiime",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/qiime_validate_mapping_file/qiime_validate_mapping_file/1.9.1.0"
+    },
+    {
+      "name": "Screen.seqs",
+      "id": "mothur_screen_seqs",
+      "description": "Screen sequences",
+      "tool_shed_repository": "mothur_screen_seqs",
+      "panel_section_name": "Mothur",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/mothur_screen_seqs/mothur_screen_seqs/1.39.5.1"
+    },
+    {
+      "name": "Make.contigs",
+      "id": "mothur_make_contigs",
+      "description": "Aligns paired forward and reverse fastq files to contigs as fasta and quality",
+      "tool_shed_repository": "mothur_make_contigs",
+      "panel_section_name": "Mothur",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/mothur_make_contigs/mothur_make_contigs/1.39.5.1"
+    },
+    {
+      "name": "Get.label",
+      "id": "mothur_get_label",
+      "description": "label names from list, sabund, or rabund file",
+      "tool_shed_repository": "mothur_get_label",
+      "panel_section_name": "Mothur",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/mothur_get_label/mothur_get_label/1.39.5.0"
+    },
+    {
+      "name": "Chimera.vsearch",
+      "id": "mothur_chimera_vsearch",
+      "description": "find potential chimeric sequences using vsearch",
+      "tool_shed_repository": "mothur_chimera_vsearch",
+      "panel_section_name": "Mothur",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/mothur_chimera_vsearch/mothur_chimera_vsearch/1.39.5.1"
+    },
+    {
+      "name": "Chimera.pintail",
+      "id": "mothur_chimera_pintail",
+      "description": "Find putative chimeras using pintail",
+      "tool_shed_repository": "mothur_chimera_pintail",
+      "panel_section_name": "Mothur",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/mothur_chimera_pintail/mothur_chimera_pintail/1.39.5.0"
+    },
+    {
+      "name": "Split.abund",
+      "id": "mothur_split_abund",
+      "description": "Separate sequences into rare and abundant groups",
+      "tool_shed_repository": "mothur_split_abund",
+      "panel_section_name": "Mothur",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/mothur_split_abund/mothur_split_abund/1.39.5.0"
+    },
+    {
+      "name": "Mimarks.attributes",
+      "id": "mothur_mimarks_attributes",
+      "description": "Reads bioSample Attributes xml and generates source for get.mimarkspackage command",
+      "tool_shed_repository": "mothur_mimarks_attributes",
+      "panel_section_name": "Mothur",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/mothur_mimarks_attributes/mothur_mimarks_attributes/1.39.5.0"
+    },
+    {
+      "name": "Summary.single",
+      "id": "mothur_summary_single",
+      "description": "Summary of calculator values for OTUs",
+      "tool_shed_repository": "mothur_summary_single",
+      "panel_section_name": "Mothur",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/mothur_summary_single/mothur_summary_single/1.39.5.2"
+    },
+    {
+      "name": "Chop.seqs",
+      "id": "mothur_chop_seqs",
+      "description": "Trim sequences to a specified length",
+      "tool_shed_repository": "mothur_chop_seqs",
+      "panel_section_name": "Mothur",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/mothur_chop_seqs/mothur_chop_seqs/1.39.5.0"
+    },
+    {
+      "name": "Remove.otulabels",
+      "id": "mothur_remove_otulabels",
+      "description": "Removes OTU labels",
+      "tool_shed_repository": "mothur_remove_otulabels",
+      "panel_section_name": "Mothur",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/mothur_remove_otulabels/mothur_remove_otulabels/1.39.5.0"
+    },
+    {
+      "name": "Get.sabund",
+      "id": "mothur_get_sabund",
+      "description": "Get sabund from a otu list or rabund",
+      "tool_shed_repository": "mothur_get_sabund",
+      "panel_section_name": "Mothur",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/mothur_get_sabund/mothur_get_sabund/1.39.5.0"
+    },
+    {
+      "name": "Make.sra",
+      "id": "mothur_make_sra",
+      "description": "creates the necessary files for a NCBI submission",
+      "tool_shed_repository": "mothur_make_sra",
+      "panel_section_name": "Mothur",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/mothur_make_sra/mothur_make_sra/1.39.5.0"
+    },
+    {
+      "name": "Make.group",
+      "id": "mothur_make_group",
+      "description": "Make a group file",
+      "tool_shed_repository": "mothur_make_group",
+      "panel_section_name": "Mothur",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/mothur_make_group/mothur_make_group/1.39.5.0"
+    },
+    {
+      "name": "Trim.seqs",
+      "id": "mothur_trim_seqs",
+      "description": "Trim sequences - primers, barcodes, quality",
+      "tool_shed_repository": "mothur_trim_seqs",
+      "panel_section_name": "Mothur",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/mothur_trim_seqs/mothur_trim_seqs/1.39.5.0"
+    },
+    {
+      "name": "Nmds",
+      "id": "mothur_nmds",
+      "description": "generate non-metric multidimensional scaling data",
+      "tool_shed_repository": "mothur_nmds",
+      "panel_section_name": "Mothur",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/mothur_nmds/mothur_nmds/1.39.5.0"
+    },
+    {
+      "name": "List.otulabels",
+      "id": "mothur_list_otulabels",
+      "description": "Lists otu labels from shared or relabund file",
+      "tool_shed_repository": "mothur_list_otulabels",
+      "panel_section_name": "Mothur",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/mothur_list_otulabels/mothur_list_otulabels/1.39.5.0"
+    },
+    {
+      "name": "Create.database",
+      "id": "mothur_create_database",
+      "description": "creates a database file from a list, repnames, repfasta and contaxonomy file",
+      "tool_shed_repository": "mothur_create_database",
+      "panel_section_name": "Mothur",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/mothur_create_database/mothur_create_database/1.39.5.0"
+    },
+    {
+      "name": "Deunique.tree",
+      "id": "mothur_deunique_tree",
+      "description": "Reinsert the redundant sequence identiers back into a unique tree.",
+      "tool_shed_repository": "mothur_deunique_tree",
+      "panel_section_name": "Mothur",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/mothur_deunique_tree/mothur_deunique_tree/1.39.5.0"
+    },
+    {
+      "name": "Biom.info",
+      "id": "mothur_biom_info",
+      "description": "create shared and taxonomy files from biom",
+      "tool_shed_repository": "mothur_biom_info",
+      "panel_section_name": "Mothur",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/mothur_biom_info/mothur_biom_info/1.39.5.0"
+    },
+    {
+      "name": "Pairwise.seqs",
+      "id": "mothur_pairwise_seqs",
+      "description": "calculate uncorrected pairwise distances between sequences",
+      "tool_shed_repository": "mothur_pairwise_seqs",
+      "panel_section_name": "Mothur",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/mothur_pairwise_seqs/mothur_pairwise_seqs/1.39.5.0"
+    },
+    {
+      "name": "Merge.count",
+      "id": "mothur_merge_count",
+      "description": "Merge count tables",
+      "tool_shed_repository": "mothur_merge_count",
+      "panel_section_name": "Mothur",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/mothur_merge_count/mothur_merge_count/1.39.5.0"
+    },
+    {
+      "name": "Pcr.seqs",
+      "id": "mothur_pcr_seqs",
+      "description": "Trim sequences",
+      "tool_shed_repository": "mothur_pcr_seqs",
+      "panel_section_name": "Mothur",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/mothur_pcr_seqs/mothur_pcr_seqs/1.39.5.0"
+    },
+    {
+      "name": "Taxonomy-to-Krona",
+      "id": "mothur_taxonomy_to_krona",
+      "description": "convert a mothur taxonomy file to Krona input format",
+      "tool_shed_repository": "mothur_taxonomy_to_krona",
+      "panel_section_name": "Mothur",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/mothur_taxonomy_to_krona/mothur_taxonomy_to_krona/1.0"
+    },
+    {
+      "name": "Split.groups",
+      "id": "mothur_split_groups",
+      "description": "Generates a fasta file for each group",
+      "tool_shed_repository": "mothur_split_groups",
+      "panel_section_name": "Mothur",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/mothur_split_groups/mothur_split_groups/1.39.5.0"
+    },
+    {
+      "name": "Classify.tree",
+      "id": "mothur_classify_tree",
+      "description": "Get a consensus taxonomy for each node on a tree",
+      "tool_shed_repository": "mothur_classify_tree",
+      "panel_section_name": "Mothur",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/mothur_classify_tree/mothur_classify_tree/1.39.5.0"
+    },
+    {
+      "name": "Make.fastq",
+      "id": "mothur_make_fastq",
+      "description": "Convert fasta and quality to fastq",
+      "tool_shed_repository": "mothur_make_fastq",
+      "panel_section_name": "Mothur",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/mothur_make_fastq/mothur_make_fastq/1.39.5.0"
+    },
+    {
+      "name": "Pcoa",
+      "id": "mothur_pcoa",
+      "description": "Principal Coordinate Analysis for a distance matrix",
+      "tool_shed_repository": "mothur_pcoa",
+      "panel_section_name": "Mothur",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/mothur_pcoa/mothur_pcoa/1.39.5.0"
+    },
+    {
+      "name": "Summary.shared",
+      "id": "mothur_summary_shared",
+      "description": "Summary of calculator values for OTUs",
+      "tool_shed_repository": "mothur_summary_shared",
+      "panel_section_name": "Mothur",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/mothur_summary_shared/mothur_summary_shared/1.39.5.0"
+    },
+    {
+      "name": "Sort.seqs",
+      "id": "mothur_sort_seqs",
+      "description": "put sequences in different files in the same order",
+      "tool_shed_repository": "mothur_sort_seqs",
+      "panel_section_name": "Mothur",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/mothur_sort_seqs/mothur_sort_seqs/1.39.5.0"
+    },
+    {
+      "name": "Remove.dists",
+      "id": "mothur_remove_dists",
+      "description": "Removes distances from a phylip or column file",
+      "tool_shed_repository": "mothur_remove_dists",
+      "panel_section_name": "Mothur",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/mothur_remove_dists/mothur_remove_dists/1.39.5.0"
+    },
+    {
+      "name": "Make.lefse",
+      "id": "mothur_make_lefse",
+      "description": "create a lefse formatted input file from mothur's output files",
+      "tool_shed_repository": "mothur_make_lefse",
+      "panel_section_name": "Mothur",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/mothur_make_lefse/mothur_make_lefse/1.39.5.0"
+    },
+    {
+      "name": "Cluster.classic",
+      "id": "mothur_cluster_classic",
+      "description": "Assign sequences to OTUs (Dotur implementation)",
+      "tool_shed_repository": "mothur_cluster_classic",
+      "panel_section_name": "Mothur",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/mothur_cluster_classic/mothur_cluster_classic/1.39.5.0"
+    },
+    {
+      "name": "Filter.seqs",
+      "id": "mothur_filter_seqs",
+      "description": "removes columns from alignments",
+      "tool_shed_repository": "mothur_filter_seqs",
+      "panel_section_name": "Mothur",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/mothur_filter_seqs/mothur_filter_seqs/1.39.5.0"
+    },
+    {
+      "name": "Unique.seqs",
+      "id": "mothur_unique_seqs",
+      "description": "Return unique sequences",
+      "tool_shed_repository": "mothur_unique_seqs",
+      "panel_section_name": "Mothur",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/mothur_unique_seqs/mothur_unique_seqs/1.39.5.0"
+    },
+    {
+      "name": "Rename.seqs",
+      "id": "mothur_rename_seqs",
+      "description": "Rename sequences by concatenating the group name",
+      "tool_shed_repository": "mothur_rename_seqs",
+      "panel_section_name": "Mothur",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/mothur_rename_seqs/mothur_rename_seqs/1.39.5.0"
+    },
+    {
+      "name": "Cooccurrence",
+      "id": "mothur_cooccurrence",
+      "description": "tests whether presence-absence patterns differ from chance",
+      "tool_shed_repository": "mothur_cooccurrence",
+      "panel_section_name": "Mothur",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/mothur_cooccurrence/mothur_cooccurrence/1.39.5.0"
+    },
+    {
+      "name": "Parse.list",
+      "id": "mothur_parse_list",
+      "description": "Generate a List file for each group",
+      "tool_shed_repository": "mothur_parse_list",
+      "panel_section_name": "Mothur",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/mothur_parse_list/mothur_parse_list/1.39.5.0"
+    },
+    {
+      "name": "Get.group",
+      "id": "mothur_get_group",
+      "description": "group names from shared or from list and group",
+      "tool_shed_repository": "mothur_get_group",
+      "panel_section_name": "Mothur",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/mothur_get_group/mothur_get_group/1.39.5.0"
+    },
+    {
+      "name": "Make Design",
+      "id": "mothur_make_design",
+      "description": "Assign groups to Sets",
+      "tool_shed_repository": "mothur_make_design",
+      "panel_section_name": "Mothur",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/mothur_make_design/mothur_make_design/1.39.5.0"
+    },
+    {
+      "name": "Get.dists",
+      "id": "mothur_get_dists",
+      "description": "selects distances from a phylip or column file",
+      "tool_shed_repository": "mothur_get_dists",
+      "panel_section_name": "Mothur",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/mothur_get_dists/mothur_get_dists/1.39.5.0"
+    },
+    {
+      "name": "Get.otulist",
+      "id": "mothur_get_otulist",
+      "description": "Get otus for each distance in a otu list",
+      "tool_shed_repository": "mothur_get_otulist",
+      "panel_section_name": "Mothur",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/mothur_get_otulist/mothur_get_otulist/1.39.5.0"
+    },
+    {
+      "name": "Merge.groups",
+      "id": "mothur_merge_groups",
+      "description": "Merge groups in a shared file",
+      "tool_shed_repository": "mothur_merge_groups",
+      "panel_section_name": "Mothur",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/mothur_merge_groups/mothur_merge_groups/1.39.5.0"
+    },
+    {
+      "name": "Otu.association",
+      "id": "mothur_otu_association",
+      "description": "Calculate the correlation coefficient for the otus",
+      "tool_shed_repository": "mothur_otu_association",
+      "panel_section_name": "Mothur",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/mothur_otu_association/mothur_otu_association/1.39.5.0"
+    },
+    {
+      "name": "Merge.files",
+      "id": "mothur_merge_files",
+      "description": "Merge data",
+      "tool_shed_repository": "mothur_merge_files",
+      "panel_section_name": "Mothur",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/mothur_merge_files/mothur_merge_files/1.39.5.0"
+    },
+    {
+      "name": "Filter.shared",
+      "id": "mothur_filter_shared",
+      "description": "remove OTUs based on various critieria",
+      "tool_shed_repository": "mothur_filter_shared",
+      "panel_section_name": "Mothur",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/mothur_filter_shared/mothur_filter_shared/1.39.5.0"
+    },
+    {
+      "name": "Phylo.diversity",
+      "id": "mothur_phylo_diversity",
+      "description": "Alpha Diversity calculates unique branch length",
+      "tool_shed_repository": "mothur_phylo_diversity",
+      "panel_section_name": "Mothur",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/mothur_phylo_diversity/mothur_phylo_diversity/1.39.5.0"
+    },
+    {
+      "name": "Sffinfo",
+      "id": "mothur_sffinfo",
+      "description": "Summarize the quality of sequences",
+      "tool_shed_repository": "mothur_sffinfo",
+      "panel_section_name": "Mothur",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/mothur_sffinfo/mothur_sffinfo/1.39.5.0"
+    },
+    {
+      "name": "Sub.sample",
+      "id": "mothur_sub_sample",
+      "description": "Create a sub sample",
+      "tool_shed_repository": "mothur_sub_sample",
+      "panel_section_name": "Mothur",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/mothur_sub_sample/mothur_sub_sample/1.39.5.0"
+    },
+    {
+      "name": "Deunique.seqs",
+      "id": "mothur_deunique_seqs",
+      "description": "Return all sequences",
+      "tool_shed_repository": "mothur_deunique_seqs",
+      "panel_section_name": "Mothur",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/mothur_deunique_seqs/mothur_deunique_seqs/1.39.5.0"
+    },
+    {
+      "name": "Chimera.perseus",
+      "id": "mothur_chimera_perseus",
+      "description": "Find putative chimeras using chimeraCheck",
+      "tool_shed_repository": "mothur_chimera_perseus",
+      "panel_section_name": "Mothur",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/mothur_chimera_perseus/mothur_chimera_perseus/1.39.5.0"
+    },
+    {
+      "name": "Amova",
+      "id": "mothur_amova",
+      "description": "Analysis of molecular variance",
+      "tool_shed_repository": "mothur_amova",
+      "panel_section_name": "Mothur",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/mothur_amova/mothur_amova/1.39.5.0"
+    },
+    {
+      "name": "Align.check",
+      "id": "mothur_align_check",
+      "description": "Calculate the number of potentially misaligned bases",
+      "tool_shed_repository": "mothur_align_check",
+      "panel_section_name": "Mothur",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/mothur_align_check/mothur_align_check/1.39.5.0"
+    },
+    {
+      "name": "Align.seqs",
+      "id": "mothur_align_seqs",
+      "description": "Align sequences to a template alignment",
+      "tool_shed_repository": "mothur_align_seqs",
+      "panel_section_name": "Mothur",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/mothur_align_seqs/mothur_align_seqs/1.39.5.0"
+    },
+    {
+      "name": "Classify.rf",
+      "id": "mothur_classify_rf",
+      "description": "description",
+      "tool_shed_repository": "mothur_classify_rf",
+      "panel_section_name": "Mothur",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/mothur_classify_rf/mothur_classify_rf/1.36.1.0"
+    },
+    {
+      "name": "Dist.seqs",
+      "id": "mothur_dist_seqs",
+      "description": "calculate uncorrected pairwise distances between aligned sequences",
+      "tool_shed_repository": "mothur_dist_seqs",
+      "panel_section_name": "Mothur",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/mothur_dist_seqs/mothur_dist_seqs/1.39.5.0"
+    },
+    {
+      "name": "Pre.cluster",
+      "id": "mothur_pre_cluster",
+      "description": "Remove sequences due to pyrosequencing errors",
+      "tool_shed_repository": "mothur_pre_cluster",
+      "panel_section_name": "Mothur",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/mothur_pre_cluster/mothur_pre_cluster/1.39.5.0"
+    },
+    {
+      "name": "Libshuff",
+      "id": "mothur_libshuff",
+      "description": "Cramer-von Mises tests communities for the same structure",
+      "tool_shed_repository": "mothur_libshuff",
+      "panel_section_name": "Mothur",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/mothur_libshuff/mothur_libshuff/1.39.5.0"
+    },
+    {
+      "name": "Metastats",
+      "id": "mothur_metastats",
+      "description": "generate principle components plot data",
+      "tool_shed_repository": "mothur_metastats",
+      "panel_section_name": "Mothur",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/mothur_metastats/mothur_metastats/1.39.5.0"
+    },
+    {
+      "name": "Get.rabund",
+      "id": "mothur_get_rabund",
+      "description": "Get rabund from a otu list or sabund",
+      "tool_shed_repository": "mothur_get_rabund",
+      "panel_section_name": "Mothur",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/mothur_get_rabund/mothur_get_rabund/1.39.5.0"
+    },
+    {
+      "name": "Get.otus",
+      "id": "mothur_get_otus",
+      "description": "Get otus containing sequences from specified groups",
+      "tool_shed_repository": "mothur_get_otus",
+      "panel_section_name": "Mothur",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/mothur_get_otus/mothur_get_otus/1.39.5.0"
+    },
+    {
+      "name": "Otu.hierarchy",
+      "id": "mothur_otu_hierarchy",
+      "description": "Relate OTUs at different distances",
+      "tool_shed_repository": "mothur_otu_hierarchy",
+      "panel_section_name": "Mothur",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/mothur_otu_hierarchy/mothur_otu_hierarchy/1.39.5.0"
+    },
+    {
+      "name": "Trim.flows",
+      "id": "mothur_trim_flows",
+      "description": "partition by barcode, trim to length, cull by length and mismatches",
+      "tool_shed_repository": "mothur_trim_flows",
+      "panel_section_name": "Mothur",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/mothur_trim_flows/mothur_trim_flows/1.39.5.0"
+    },
+    {
+      "name": "Cluster.fragments",
+      "id": "mothur_cluster_fragments",
+      "description": "Group sequences that are part of a larger sequence",
+      "tool_shed_repository": "mothur_cluster_fragments",
+      "panel_section_name": "Mothur",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/mothur_cluster_fragments/mothur_cluster_fragments/1.39.5.0"
+    },
+    {
+      "name": "Rarefaction.shared",
+      "id": "mothur_rarefaction_shared",
+      "description": "Generate inter-sample rarefaction curves for OTUs",
+      "tool_shed_repository": "mothur_rarefaction_shared",
+      "panel_section_name": "Mothur",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/mothur_rarefaction_shared/mothur_rarefaction_shared/1.39.5.0"
+    },
+    {
+      "name": "Classify.seqs",
+      "id": "mothur_classify_seqs",
+      "description": "Assign sequences to taxonomy",
+      "tool_shed_repository": "mothur_classify_seqs",
+      "panel_section_name": "Mothur",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/mothur_classify_seqs/mothur_classify_seqs/1.39.5.0"
+    },
+    {
+      "name": "Phylotype",
+      "id": "mothur_phylotype",
+      "description": "Assign sequences to OTUs based on taxonomy",
+      "tool_shed_repository": "mothur_phylotype",
+      "panel_section_name": "Mothur",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/mothur_phylotype/mothur_phylotype/1.39.5.0"
+    },
+    {
+      "name": "unifrac.unweighted",
+      "id": "mothur_unifrac_unweighted",
+      "description": "Describes whether two or more communities have the same structure",
+      "tool_shed_repository": "mothur_unifrac_unweighted",
+      "panel_section_name": "Mothur",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/mothur_unifrac_unweighted/mothur_unifrac_unweighted/1.39.5.0"
+    },
+    {
+      "name": "Tree.shared",
+      "id": "mothur_tree_shared",
+      "description": "Generate a newick tree for dissimilarity among groups",
+      "tool_shed_repository": "mothur_tree_shared",
+      "panel_section_name": "Mothur",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/mothur_tree_shared/mothur_tree_shared/1.39.5.0"
+    },
+    {
+      "name": "Get.otulabels",
+      "id": "mothur_get_otulabels",
+      "description": "Selects OTU labels",
+      "tool_shed_repository": "mothur_get_otulabels",
+      "panel_section_name": "Mothur",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/mothur_get_otulabels/mothur_get_otulabels/1.39.5.0"
+    },
+    {
+      "name": "Count.seqs",
+      "id": "mothur_count_seqs",
+      "description": "(aka make.table) counts the number of sequences represented by the representative",
+      "tool_shed_repository": "mothur_count_seqs",
+      "panel_section_name": "Mothur",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/mothur_count_seqs/mothur_count_seqs/1.39.5.0"
+    },
+    {
+      "name": "Consensus.seqs",
+      "id": "mothur_consensus_seqs",
+      "description": "Find a consensus sequence for each OTU or phylotype",
+      "tool_shed_repository": "mothur_consensus_seqs",
+      "panel_section_name": "Mothur",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/mothur_consensus_seqs/mothur_consensus_seqs/1.39.5.0"
+    },
+    {
+      "name": "Collect.shared",
+      "id": "mothur_collect_shared",
+      "description": "Generate collector's curves for calculators on OTUs",
+      "tool_shed_repository": "mothur_collect_shared",
+      "panel_section_name": "Mothur",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/mothur_collect_shared/mothur_collect_shared/1.39.5.0"
+    },
+    {
+      "name": "Corr.axes",
+      "id": "mothur_corr_axes",
+      "description": "correlation of data to axes",
+      "tool_shed_repository": "mothur_corr_axes",
+      "panel_section_name": "Mothur",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/mothur_corr_axes/mothur_corr_axes/1.39.5.0"
+    },
+    {
+      "name": "Summary.seqs",
+      "id": "mothur_summary_seqs",
+      "description": "Summarize the quality of sequences",
+      "tool_shed_repository": "mothur_summary_seqs",
+      "panel_section_name": "Mothur",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/mothur_summary_seqs/mothur_summary_seqs/1.39.5.0"
+    },
+    {
+      "name": "Anosim",
+      "id": "mothur_anosim",
+      "description": "Non-parametric multivariate analysis of changes in community structure",
+      "tool_shed_repository": "mothur_anosim",
+      "panel_section_name": "Mothur",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/mothur_anosim/mothur_anosim/1.39.5.0"
+    },
+    {
+      "name": "Remove.seqs",
+      "id": "mothur_remove_seqs",
+      "description": "Remove sequences by name",
+      "tool_shed_repository": "mothur_remove_seqs",
+      "panel_section_name": "Mothur",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/mothur_remove_seqs/mothur_remove_seqs/1.39.5.0"
+    },
+    {
+      "name": "Get.communitytype",
+      "id": "mothur_get_communitytype",
+      "description": "description",
+      "tool_shed_repository": "mothur_get_communitytype",
+      "panel_section_name": "Mothur",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/mothur_get_communitytype/mothur_get_communitytype/1.39.5.0"
+    },
+    {
+      "name": "Cluster.split",
+      "id": "mothur_cluster_split",
+      "description": "Assign sequences to OTUs and split large matrices",
+      "tool_shed_repository": "mothur_cluster_split",
+      "panel_section_name": "Mothur",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/mothur_cluster_split/mothur_cluster_split/1.39.5.0"
+    },
+    {
+      "name": "Summary.tax",
+      "id": "mothur_summary_tax",
+      "description": "Assign sequences to taxonomy",
+      "tool_shed_repository": "mothur_summary_tax",
+      "panel_section_name": "Mothur",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/mothur_summary_tax/mothur_summary_tax/1.39.5.0"
+    },
+    {
+      "name": "Fastq.info",
+      "id": "mothur_fastq_info",
+      "description": "Convert fastq to fasta and quality",
+      "tool_shed_repository": "mothur_fastq_info",
+      "panel_section_name": "Mothur",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/mothur_fastq_info/mothur_fastq_info/1.39.5.0"
+    },
+    {
+      "name": "unifrac.weighted",
+      "id": "mothur_unifrac_weighted",
+      "description": "Describes whether two or more communities have the same structure",
+      "tool_shed_repository": "mothur_unifrac_weighted",
+      "panel_section_name": "Mothur",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/mothur_unifrac_weighted/mothur_unifrac_weighted/1.39.5.0"
+    },
+    {
+      "name": "Get.seqs",
+      "id": "mothur_get_seqs",
+      "description": "Picks sequences by name",
+      "tool_shed_repository": "mothur_get_seqs",
+      "panel_section_name": "Mothur",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/mothur_get_seqs/mothur_get_seqs/1.39.5.0"
+    },
+    {
+      "name": "Bin.seqs",
+      "id": "mothur_bin_seqs",
+      "description": "Order Sequences by OTU",
+      "tool_shed_repository": "mothur_bin_seqs",
+      "panel_section_name": "Mothur",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/mothur_bin_seqs/mothur_bin_seqs/1.39.5.0"
+    },
+    {
+      "name": "Degap.seqs",
+      "id": "mothur_degap_seqs",
+      "description": "Remove gap characters from sequences",
+      "tool_shed_repository": "mothur_degap_seqs",
+      "panel_section_name": "Mothur",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/mothur_degap_seqs/mothur_degap_seqs/1.39.5.0"
+    },
+    {
+      "name": "Chimera.ccode",
+      "id": "mothur_chimera_ccode",
+      "description": "Find putative chimeras using ccode",
+      "tool_shed_repository": "mothur_chimera_ccode",
+      "panel_section_name": "Mothur",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/mothur_chimera_ccode/mothur_chimera_ccode/1.39.5.0"
+    },
+    {
+      "name": "Primer.design",
+      "id": "mothur_primer_design",
+      "description": "identify sequence fragments that are specific to particular OTUs",
+      "tool_shed_repository": "mothur_primer_design",
+      "panel_section_name": "Mothur",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/mothur_primer_design/mothur_primer_design/1.39.5.0"
+    },
+    {
+      "name": "Seq.error",
+      "id": "mothur_seq_error",
+      "description": "assess error rates in sequencing data",
+      "tool_shed_repository": "mothur_seq_error",
+      "panel_section_name": "Mothur",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/mothur_seq_error/mothur_seq_error/1.39.5.0"
+    },
+    {
+      "name": "Remove.groups",
+      "id": "mothur_remove_groups",
+      "description": "Remove groups from groups,fasta,names,list,taxonomy",
+      "tool_shed_repository": "mothur_remove_groups",
+      "panel_section_name": "Mothur",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/mothur_remove_groups/mothur_remove_groups/1.39.5.0"
+    },
+    {
+      "name": "Mantel",
+      "id": "mothur_mantel",
+      "description": "Mantel correlation coefficient between two matrices.",
+      "tool_shed_repository": "mothur_mantel",
+      "panel_section_name": "Mothur",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/mothur_mantel/mothur_mantel/1.39.5.0"
+    },
+    {
+      "name": "Lefse",
+      "id": "mothur_lefse",
+      "description": "description",
+      "tool_shed_repository": "mothur_lefse",
+      "panel_section_name": "Mothur",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/mothur_lefse/mothur_lefse/1.39.5.0"
+    },
+    {
+      "name": "Heatmap.bin",
+      "id": "mothur_heatmap_bin",
+      "description": "Generate a heatmap for OTUs",
+      "tool_shed_repository": "mothur_heatmap_bin",
+      "panel_section_name": "Mothur",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/mothur_heatmap_bin/mothur_heatmap_bin/1.39.5.0"
+    },
+    {
+      "name": "Clearcut",
+      "id": "mothur_clearcut",
+      "description": "Generate a tree using relaxed neighbor joining",
+      "tool_shed_repository": "mothur_clearcut",
+      "panel_section_name": "Mothur",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/mothur_clearcut/mothur_clearcut/1.39.5.0"
+    },
+    {
+      "name": "Get.sharedseqs",
+      "id": "mothur_get_sharedseqs",
+      "description": "Get shared sequences at each distance from list and group",
+      "tool_shed_repository": "mothur_get_sharedseqs",
+      "panel_section_name": "Mothur",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/mothur_get_sharedseqs/mothur_get_sharedseqs/1.39.5.0"
+    },
+    {
+      "name": "Chimera.bellerophon",
+      "id": "mothur_chimera_bellerophon",
+      "description": "Find putative chimeras using bellerophon",
+      "tool_shed_repository": "mothur_chimera_bellerophon",
+      "panel_section_name": "Mothur",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/mothur_chimera_bellerophon/mothur_chimera_bellerophon/1.39.5.0"
+    },
+    {
+      "name": "Cluster",
+      "id": "mothur_cluster",
+      "description": "Assign sequences to OTUs (Operational Taxonomic Unit)",
+      "tool_shed_repository": "mothur_cluster",
+      "panel_section_name": "Mothur",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/mothur_cluster/mothur_cluster/1.39.5.0"
+    },
+    {
+      "name": "Sens.spec",
+      "id": "mothur_sens_spec",
+      "description": "Determine the quality of OTU assignment",
+      "tool_shed_repository": "mothur_sens_spec",
+      "panel_section_name": "Mothur",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/mothur_sens_spec/mothur_sens_spec/1.39.5.0"
+    },
+    {
+      "name": "Make.shared",
+      "id": "mothur_make_shared",
+      "description": "Make a shared file from a list and a group",
+      "tool_shed_repository": "mothur_make_shared",
+      "panel_section_name": "Mothur",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/mothur_make_shared/mothur_make_shared/1.39.5.0"
+    },
+    {
+      "name": "Chimera.slayer",
+      "id": "mothur_chimera_slayer",
+      "description": "Find putative chimeras using slayer",
+      "tool_shed_repository": "mothur_chimera_slayer",
+      "panel_section_name": "Mothur",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/mothur_chimera_slayer/mothur_chimera_slayer/1.39.5.0"
+    },
+    {
+      "name": "Remove.lineage",
+      "id": "mothur_remove_lineage",
+      "description": "Picks by taxon",
+      "tool_shed_repository": "mothur_remove_lineage",
+      "panel_section_name": "Mothur",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/mothur_remove_lineage/mothur_remove_lineage/1.39.5.0"
+    },
+    {
+      "name": "Reverse.seqs",
+      "id": "mothur_reverse_seqs",
+      "description": "Reverse complement the sequences",
+      "tool_shed_repository": "mothur_reverse_seqs",
+      "panel_section_name": "Mothur",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/mothur_reverse_seqs/mothur_reverse_seqs/1.39.5.0"
+    },
+    {
+      "name": "Dist.shared",
+      "id": "mothur_dist_shared",
+      "description": "Generate a phylip-formatted dissimilarity distance matrix among multiple groups",
+      "tool_shed_repository": "mothur_dist_shared",
+      "panel_section_name": "Mothur",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/mothur_dist_shared/mothur_dist_shared/1.39.5.0"
+    },
+    {
+      "name": "Shhh.flows",
+      "id": "mothur_shhh_flows",
+      "description": "Denoise flowgrams (PyroNoise algorithm)",
+      "tool_shed_repository": "mothur_shhh_flows",
+      "panel_section_name": "Mothur",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/mothur_shhh_flows/mothur_shhh_flows/1.39.5.0"
+    },
+    {
+      "name": "Get.lineage",
+      "id": "mothur_get_lineage",
+      "description": "Picks by taxon",
+      "tool_shed_repository": "mothur_get_lineage",
+      "panel_section_name": "Mothur",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/mothur_get_lineage/mothur_get_lineage/1.39.5.0"
+    },
+    {
+      "name": "Merge.taxsummary",
+      "id": "mothur_merge_taxsummary",
+      "description": "Merge tax.summary files",
+      "tool_shed_repository": "mothur_merge_taxsummary",
+      "panel_section_name": "Mothur",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/mothur_merge_taxsummary/mothur_merge_taxsummary/1.39.5.0"
+    },
+    {
+      "name": "Hcluster",
+      "id": "mothur_hcluster",
+      "description": "Assign sequences to OTUs (Operational Taxonomic Unit)",
+      "tool_shed_repository": "mothur_hcluster",
+      "panel_section_name": "Mothur",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/mothur_hcluster/mothur_hcluster/1.36.1.0"
+    },
+    {
+      "name": "Make.lookup",
+      "id": "mothur_make_lookup",
+      "description": "allows you to create custom lookup files for use with shhh.flows",
+      "tool_shed_repository": "mothur_make_lookup",
+      "panel_section_name": "Mothur",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/mothur_make_lookup/mothur_make_lookup/1.39.5.0"
+    },
+    {
+      "name": "Remove.rare",
+      "id": "mothur_remove_rare",
+      "description": "Remove rare OTUs",
+      "tool_shed_repository": "mothur_remove_rare",
+      "panel_section_name": "Mothur",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/mothur_remove_rare/mothur_remove_rare/1.39.5.0"
+    },
+    {
+      "name": "Collect.single",
+      "id": "mothur_collect_single",
+      "description": "Generate collector's curves for OTUs",
+      "tool_shed_repository": "mothur_collect_single",
+      "panel_section_name": "Mothur",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/mothur_collect_single/mothur_collect_single/1.39.5.0"
+    },
+    {
+      "name": "Rarefaction.single",
+      "id": "mothur_rarefaction_single",
+      "description": "Generate intra-sample rarefaction curves for OTUs",
+      "tool_shed_repository": "mothur_rarefaction_single",
+      "panel_section_name": "Mothur",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/mothur_rarefaction_single/mothur_rarefaction_single/1.39.5.0"
+    },
+    {
+      "name": "Get.groups",
+      "id": "mothur_get_groups",
+      "description": "Select groups",
+      "tool_shed_repository": "mothur_get_groups",
+      "panel_section_name": "Mothur",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/mothur_get_groups/mothur_get_groups/1.39.5.0"
+    },
+    {
+      "name": "Chimera.check",
+      "id": "mothur_chimera_check",
+      "description": "Find putative chimeras using chimeraCheck",
+      "tool_shed_repository": "mothur_chimera_check",
+      "panel_section_name": "Mothur",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/mothur_chimera_check/mothur_chimera_check/1.39.5.0"
+    },
+    {
+      "name": "Heatmap.sim",
+      "id": "mothur_heatmap_sim",
+      "description": "Generate a heatmap for pariwise similarity",
+      "tool_shed_repository": "mothur_heatmap_sim",
+      "panel_section_name": "Mothur",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/mothur_heatmap_sim/mothur_heatmap_sim/1.39.5.0"
+    },
+    {
+      "name": "Get.relabund",
+      "id": "mothur_get_relabund",
+      "description": "Calculate the relative abundance of each otu",
+      "tool_shed_repository": "mothur_get_relabund",
+      "panel_section_name": "Mothur",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/mothur_get_relabund/mothur_get_relabund/1.39.5.0"
+    },
+    {
+      "name": "Make.biom",
+      "id": "mothur_make_biom",
+      "description": "Make biom files from a shared file",
+      "tool_shed_repository": "mothur_make_biom",
+      "panel_section_name": "Mothur",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/mothur_make_biom/mothur_make_biom/1.39.5.0"
+    },
+    {
+      "name": "Classify.otu",
+      "id": "mothur_classify_otu",
+      "description": "Assign sequences to taxonomy",
+      "tool_shed_repository": "mothur_classify_otu",
+      "panel_section_name": "Mothur",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/mothur_classify_otu/mothur_classify_otu/1.39.5.0"
+    },
+    {
+      "name": "Merge.sfffiles",
+      "id": "mothur_merge_sfffiles",
+      "description": "Merge SFF files",
+      "tool_shed_repository": "mothur_merge_sfffiles",
+      "panel_section_name": "Mothur",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/mothur_merge_sfffiles/mothur_merge_sfffiles/1.39.5.0"
+    },
+    {
+      "name": "Summary.qual",
+      "id": "mothur_summary_qual",
+      "description": "Summarize the quality scores",
+      "tool_shed_repository": "mothur_summary_qual",
+      "panel_section_name": "Mothur",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/mothur_summary_qual/mothur_summary_qual/1.39.5.0"
+    },
+    {
+      "name": "Venn",
+      "id": "mothur_venn",
+      "description": "Generate Venn diagrams for groups",
+      "tool_shed_repository": "mothur_venn",
+      "panel_section_name": "Mothur",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/mothur_venn/mothur_venn/1.39.5.0"
+    },
+    {
+      "name": "List.seqs",
+      "id": "mothur_list_seqs",
+      "description": "Lists the names (accnos) of the sequences",
+      "tool_shed_repository": "mothur_list_seqs",
+      "panel_section_name": "Mothur",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/mothur_list_seqs/mothur_list_seqs/1.39.5.0"
+    },
+    {
+      "name": "Homova",
+      "id": "mothur_homova",
+      "description": "Homogeneity of molecular variance",
+      "tool_shed_repository": "mothur_homova",
+      "panel_section_name": "Mothur",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/mothur_homova/mothur_homova/1.39.5.0"
+    },
+    {
+      "name": "Pca",
+      "id": "mothur_pca",
+      "description": "Principal Coordinate Analysis for a shared file",
+      "tool_shed_repository": "mothur_pca",
+      "panel_section_name": "Mothur",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/mothur_pca/mothur_pca/1.39.5.0"
+    },
+    {
+      "name": "Remove.otus",
+      "id": "mothur_remove_otus",
+      "description": "Removes OTUs from various file formats",
+      "tool_shed_repository": "mothur_remove_otus",
+      "panel_section_name": "Mothur",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/mothur_remove_otus/mothur_remove_otus/1.39.5.0"
+    },
+    {
+      "name": "Parsimony",
+      "id": "mothur_parsimony",
+      "description": "Describes whether two or more communities have the same structure",
+      "tool_shed_repository": "mothur_parsimony",
+      "panel_section_name": "Mothur",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/mothur_parsimony/mothur_parsimony/1.39.5.0"
+    },
+    {
+      "name": "Shhh.seqs",
+      "id": "mothur_shhh_seqs",
+      "description": "Denoise program (Quince SeqNoise)",
+      "tool_shed_repository": "mothur_shhh_seqs",
+      "panel_section_name": "Mothur",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/mothur_shhh_seqs/mothur_shhh_seqs/1.39.5.0"
+    },
+    {
+      "name": "Get.oturep",
+      "id": "mothur_get_oturep",
+      "description": "Generate a fasta with a representative sequence for each OTU",
+      "tool_shed_repository": "mothur_get_oturep",
+      "panel_section_name": "Mothur",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/mothur_get_oturep/mothur_get_oturep/1.39.5.0"
+    },
+    {
+      "name": "Count.groups",
+      "id": "mothur_count_groups",
+      "description": "counts the number of sequences represented by a specific group or set of groups",
+      "tool_shed_repository": "mothur_count_groups",
+      "panel_section_name": "Mothur",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/mothur_count_groups/mothur_count_groups/1.39.5.0"
+    },
+    {
+      "name": "Get.mimarkspackage",
+      "id": "mothur_get_mimarkspackage",
+      "description": "creates a mimarks package form with your groups",
+      "tool_shed_repository": "mothur_get_mimarkspackage",
+      "panel_section_name": "Mothur",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/mothur_get_mimarkspackage/mothur_get_mimarkspackage/1.39.5.0"
+    },
+    {
+      "name": "Normalize.shared",
+      "id": "mothur_normalize_shared",
+      "description": "Normalize the number of sequences per group to a specified level",
+      "tool_shed_repository": "mothur_normalize_shared",
+      "panel_section_name": "Mothur",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/mothur_normalize_shared/mothur_normalize_shared/1.39.5.0"
+    },
+    {
+      "name": "Indicator",
+      "id": "mothur_indicator",
+      "description": "Identify indicator \"species\" for nodes on a tree",
+      "tool_shed_repository": "mothur_indicator",
+      "panel_section_name": "Mothur",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/mothur_indicator/mothur_indicator/1.39.5.0"
+    },
+    {
+      "name": "Get.coremicrobiome",
+      "id": "mothur_get_coremicrobiome",
+      "description": "fraction of OTUs for samples or abundances",
+      "tool_shed_repository": "mothur_get_coremicrobiome",
+      "panel_section_name": "Mothur",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/mothur_get_coremicrobiome/mothur_get_coremicrobiome/1.39.5.0"
+    },
+    {
+      "name": "Chimera.uchime",
+      "id": "mothur_chimera_uchime",
+      "description": "Find putative chimeras using uchime",
+      "tool_shed_repository": "mothur_chimera_uchime",
+      "panel_section_name": "Mothur",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/mothur_chimera_uchime/mothur_chimera_uchime/1.39.5.0"
+    },
+    {
+      "name": "obistat",
+      "id": "obi_stat",
+      "description": "computes basic statistics for attribute values",
+      "tool_shed_repository": "obi_stat",
+      "panel_section_name": "DNA Metabarcoding",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/obi_stat/obi_stat/1.2.13"
+    },
+    {
+      "name": "obisort",
+      "id": "obi_sort",
+      "description": "sorts sequence records according to the value of a given attribute",
+      "tool_shed_repository": "obi_sort",
+      "panel_section_name": "DNA Metabarcoding",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/obi_sort/obi_sort/1.2.13"
+    },
+    {
+      "name": "obiconvert",
+      "id": "obi_convert",
+      "description": "converts sequence files to different output formats",
+      "tool_shed_repository": "obi_convert",
+      "panel_section_name": "DNA Metabarcoding",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/obi_convert/obi_convert/1.2.13"
+    },
+    {
+      "name": "obiclean",
+      "id": "obi_clean",
+      "description": "tags a set of sequences for PCR/sequencing errors identification",
+      "tool_shed_repository": "obi_clean",
+      "panel_section_name": "DNA Metabarcoding",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/obi_clean/obi_clean/1.2.13"
+    },
+    {
+      "name": "obiuniq",
+      "id": "obi_uniq",
+      "description": "",
+      "tool_shed_repository": "obi_uniq",
+      "panel_section_name": "DNA Metabarcoding",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/obi_uniq/obi_uniq/1.2.13"
+    },
+    {
+      "name": "obigrep",
+      "id": "obi_grep",
+      "description": "Filters sequence file",
+      "tool_shed_repository": "obi_grep",
+      "panel_section_name": "DNA Metabarcoding",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/obi_grep/obi_grep/1.2.13"
+    },
+    {
+      "name": "obiannotate",
+      "id": "obi_annotate",
+      "description": "Adds/Edits sequence record annotations",
+      "tool_shed_repository": "obi_annotate",
+      "panel_section_name": "DNA Metabarcoding",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/obi_annotate/obi_annotate/1.2.13"
+    },
+    {
+      "name": "Illuminapairedend",
+      "id": "obi_illumina_pairend",
+      "description": "Construct consensus reads from Illumina pair-end reads",
+      "tool_shed_repository": "obi_illumina_pairend",
+      "panel_section_name": "DNA Metabarcoding",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/obi_illumina_pairend/obi_illumina_pairend/1.2.13"
+    },
+    {
+      "name": "NGSfilter",
+      "id": "obi_ngsfilter",
+      "description": "Assigns sequence records to the corresponding experiment/sample based on DNA tags and primers",
+      "tool_shed_repository": "obi_ngsfilter",
+      "panel_section_name": "DNA Metabarcoding",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/obi_ngsfilter/obi_ngsfilter/1.2.13"
+    },
+    {
+      "name": "obitab",
+      "id": "obi_tab",
+      "description": "converts sequence file to a tabular file",
+      "tool_shed_repository": "obi_tab",
+      "panel_section_name": "DNA Metabarcoding",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/obi_tab/obi_tab/1.2.13"
+    },
+    {
+      "name": "ivar trim",
+      "id": "ivar_trim",
+      "description": "Trim reads in aligned BAM",
+      "tool_shed_repository": "ivar_trim",
+      "panel_section_name": "Virology",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/ivar_trim/ivar_trim/1.3.1+galaxy3"
+    },
+    {
+      "name": "Read It and Keep",
+      "id": "read_it_and_keep",
+      "description": "",
+      "tool_shed_repository": "read_it_and_keep",
+      "panel_section_name": "Virology",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/read_it_and_keep/read_it_and_keep/0.2.2+galaxy0"
+    },
+    {
+      "name": "ivar removereads",
+      "id": "ivar_removereads",
+      "description": "Remove reads from trimmed BAM file",
+      "tool_shed_repository": "ivar_removereads",
+      "panel_section_name": "Virology",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/ivar_removereads/ivar_removereads/1.3.1+galaxy2"
+    },
+    {
+      "name": "ivar variants",
+      "id": "ivar_variants",
+      "description": "Call variants from aligned BAM file",
+      "tool_shed_repository": "ivar_variants",
+      "panel_section_name": "Virology",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/ivar_variants/ivar_variants/1.3.1+galaxy2"
+    },
+    {
+      "name": "ivar filtervariants",
+      "id": "ivar_filtervariants",
+      "description": "Filter variants across replicates or multiple samples aligned using the same reference",
+      "tool_shed_repository": "ivar_filtervariants",
+      "panel_section_name": "Virology",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/ivar_filtervariants/ivar_filtervariants/1.3.1+galaxy0"
+    },
+    {
+      "name": "ivar consensus",
+      "id": "ivar_consensus",
+      "description": "Call consensus from aligned BAM file",
+      "tool_shed_repository": "ivar_consensus",
+      "panel_section_name": "Virology",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/ivar_consensus/ivar_consensus/1.3.1+galaxy0"
+    },
+    {
+      "name": "ivar getmasked",
+      "id": "ivar_getmasked",
+      "description": "Detect primer mismatches and get primer indices for the amplicon to be masked",
+      "tool_shed_repository": "ivar_getmasked",
+      "panel_section_name": "Virology",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/ivar_getmasked/ivar_getmasked/1.2.2+galaxy0"
+    },
+    {
+      "name": "MetaNovo",
+      "id": "metanovo",
+      "description": "Produce targeted databases for mass spectrometry analysis.",
+      "tool_shed_repository": "metanovo",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/metanovo/metanovo/1.9.4+galaxy3"
+    },
+    {
+      "name": "MSI colocalization",
+      "id": "cardinal_colocalization",
+      "description": "mass spectrometry imaging colocalization",
+      "tool_shed_repository": "cardinal_colocalization",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/cardinal_colocalization/cardinal_colocalization/2.10.0.0"
+    },
+    {
+      "name": "eggNOG Mapper",
+      "id": "eggnog_mapper",
+      "description": "functional sequence annotation by orthology",
+      "tool_shed_repository": "eggnog_mapper",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/eggnog_mapper/eggnog_mapper/2.1.6+galaxy1"
+    },
+    {
+      "name": "Proteinortho summary",
+      "id": "proteinortho_summary",
+      "description": "summaries the orthology-pairs/RBH files",
+      "tool_shed_repository": "proteinortho_summary",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/proteinortho_summary/proteinortho_summary/6.0.32+galaxy0"
+    },
+    {
+      "name": "OpenPepXL",
+      "id": "OpenPepXL",
+      "description": "Tool for protein-protein cross-linking identification using labeled linkers.",
+      "tool_shed_repository": "openms_openpepxl",
+      "panel_section_name": "ChemicalToolBox",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/openms_openpepxl/OpenPepXL/2.6+galaxy0"
+    },
+    {
+      "name": "XFDR",
+      "id": "XFDR",
+      "description": "Calculates false discovery rate estimates on crosslink identifications",
+      "tool_shed_repository": "openms_xfdr",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/openms_xfdr/XFDR/2.6+galaxy0"
+    },
+    {
+      "name": "PercolatorAdapter",
+      "id": "PercolatorAdapter",
+      "description": "Facilitate input to Percolator and reintegrate.",
+      "tool_shed_repository": "openms_percolatoradapter",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/openms_percolatoradapter/PercolatorAdapter/2.6+galaxy0"
+    },
+    {
+      "name": "metaQuantome: create samples file",
+      "id": "metaquantome_sample",
+      "description": "by specifying the experiment's groups and associated column names",
+      "tool_shed_repository": "metaquantome_sample",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/metaquantome_sample/metaquantome_sample/2.0.2+galaxy0"
+    },
+    {
+      "name": "FastaCLI",
+      "id": "fasta_cli",
+      "description": "Appends decoy sequences to FASTA files",
+      "tool_shed_repository": "peptideshaker",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/peptideshaker/fasta_cli/4.0.41+galaxy1"
+    },
+    {
+      "name": "Identification Parameters",
+      "id": "ident_params",
+      "description": "Sets the identification parameters to be used in SearchGUI and PeptideShaker apps",
+      "tool_shed_repository": "peptideshaker",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/peptideshaker/ident_params/4.0.41+galaxy1"
+    },
+    {
+      "name": "MaxQuant (using mqpar.xml)",
+      "id": "maxquant_mqpar",
+      "description": "",
+      "tool_shed_repository": "maxquant_mqpar",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/maxquant_mqpar/maxquant_mqpar/1.6.10.43"
+    },
+    {
+      "name": "Search GUI",
+      "id": "search_gui",
+      "description": "Perform protein identification using various search engines and prepare results for input to Peptide Shaker",
+      "tool_shed_repository": "peptideshaker",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/peptideshaker/search_gui/4.0.41+galaxy1"
+    },
+    {
+      "name": "Proteinortho",
+      "id": "proteinortho",
+      "description": "detects orthologous proteins/genes within different species",
+      "tool_shed_repository": "proteinortho",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/proteinortho/proteinortho/6.0.32+galaxy0"
+    },
+    {
+      "name": "Proteomiqon LabeledProteinQuantification",
+      "id": "proteomiqon_labeledproteinquantification",
+      "description": "estimates protein abundances using quantified peptide ions.",
+      "tool_shed_repository": "proteomiqon_labeledproteinquantification",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/proteomiqon_labeledproteinquantification/proteomiqon_labeledproteinquantification/0.0.1"
+    },
+    {
+      "name": "Proteomiqon JoinQuantPepIonsWithProteins",
+      "id": "proteomiqon_joinquantpepionswithproteins",
+      "description": "combines the results from ProteinInference and PSMBasedQuantification.",
+      "tool_shed_repository": "proteomiqon_joinquantpepionswithproteins",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/proteomiqon_joinquantpepionswithproteins/proteomiqon_joinquantpepionswithproteins/0.0.1"
+    },
+    {
+      "name": "Proteomiqon PSMBasedQuantification",
+      "id": "proteomiqon_psmbasedquantification",
+      "description": "allows label-free quantification as well as quantification of full metabolic labeled samples.",
+      "tool_shed_repository": "proteomiqon_psmbasedquantification",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/proteomiqon_psmbasedquantification/proteomiqon_psmbasedquantification/0.0.7"
+    },
+    {
+      "name": "MSI combine",
+      "id": "cardinal_combine",
+      "description": "combine several mass spectrometry imaging datasets into one",
+      "tool_shed_repository": "cardinal_combine",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/cardinal_combine/cardinal_combine/2.10.0.0"
+    },
+    {
+      "name": "MSI plot spectra",
+      "id": "cardinal_spectra_plots",
+      "description": "mass spectrometry imaging mass spectra plots",
+      "tool_shed_repository": "cardinal_spectra_plots",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/cardinal_spectra_plots/cardinal_spectra_plots/2.10.0.0"
+    },
+    {
+      "name": "MSI preprocessing",
+      "id": "cardinal_preprocessing",
+      "description": "mass spectrometry imaging preprocessing",
+      "tool_shed_repository": "cardinal_preprocessing",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/cardinal_preprocessing/cardinal_preprocessing/2.10.0.0"
+    },
+    {
+      "name": "MSI Qualitycontrol",
+      "id": "cardinal_quality_report",
+      "description": "mass spectrometry imaging QC",
+      "tool_shed_repository": "cardinal_quality_report",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/cardinal_quality_report/cardinal_quality_report/2.10.0.0"
+    },
+    {
+      "name": "MSI mz images",
+      "id": "cardinal_mz_images",
+      "description": "mass spectrometry imaging m/z heatmaps",
+      "tool_shed_repository": "cardinal_mz_images",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/cardinal_mz_images/cardinal_mz_images/2.10.0.0"
+    },
+    {
+      "name": "MSI data exporter",
+      "id": "cardinal_data_exporter",
+      "description": "exports imzML and Analyze7.5 to tabular files",
+      "tool_shed_repository": "cardinal_data_exporter",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/cardinal_data_exporter/cardinal_data_exporter/2.10.0.0"
+    },
+    {
+      "name": "MSI segmentation",
+      "id": "cardinal_segmentations",
+      "description": "mass spectrometry imaging spatial clustering",
+      "tool_shed_repository": "cardinal_segmentations",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/cardinal_segmentations/cardinal_segmentations/2.10.0.0"
+    },
+    {
+      "name": "MSI filtering",
+      "id": "cardinal_filtering",
+      "description": "tool for filtering mass spectrometry imaging data",
+      "tool_shed_repository": "cardinal_filtering",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/cardinal_filtering/cardinal_filtering/2.10.0.0"
+    },
+    {
+      "name": "ProteomIQon PSMStatistics",
+      "id": "proteomiqon_psmstatistics",
+      "description": "utilizes semi supervised machine learning techniques to integrate search engine scores as well as the mentioned quality scores into one single consensus score.",
+      "tool_shed_repository": "proteomiqon_psmstatistics",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/proteomiqon_psmstatistics/proteomiqon_psmstatistics/0.0.7"
+    },
+    {
+      "name": "MSstats",
+      "id": "msstats",
+      "description": "statistical relative protein significance analysis in DDA, SRM and DIA Mass Spectrometry",
+      "tool_shed_repository": "msstats",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/msstats/msstats/4.0.0.0"
+    },
+    {
+      "name": "ProteomIQon ProteinInference",
+      "id": "proteomiqon_proteininference",
+      "description": "uses identified peptides to infere proteins explaining their presence in the sample.",
+      "tool_shed_repository": "proteomiqon_proteininference",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/proteomiqon_proteininference/proteomiqon_proteininference/0.0.7"
+    },
+    {
+      "name": "MSstatsTMT",
+      "id": "msstatstmt",
+      "description": "protein significance analysis in shotgun mass spectrometry-based proteomic experiments with tandem mass tag (TMT) labeling",
+      "tool_shed_repository": "msstatstmt",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/msstatstmt/msstatstmt/2.0.0+galaxy0"
+    },
+    {
+      "name": "Peptide Shaker",
+      "id": "peptide_shaker",
+      "description": "Perform protein identification using various search engines based on results from SearchGUI",
+      "tool_shed_repository": "peptideshaker",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/peptideshaker/peptide_shaker/2.0.33+galaxy1"
+    },
+    {
+      "name": "ProteomIQon PeptideDB",
+      "id": "proteomiqon_peptidedb",
+      "description": "creates a peptide database in the SQLite format.",
+      "tool_shed_repository": "proteomiqon_peptidedb",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/proteomiqon_peptidedb/proteomiqon_peptidedb/0.0.7"
+    },
+    {
+      "name": "MaxQuant",
+      "id": "maxquant",
+      "description": "",
+      "tool_shed_repository": "maxquant",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/maxquant/maxquant/1.6.17.0+galaxy3"
+    },
+    {
+      "name": "ProteomIQon MzMLToMzLite",
+      "id": "proteomiqon_mzmltomzlite",
+      "description": "converts mzML files to mzLite files.",
+      "tool_shed_repository": "proteomiqon_mzmltomzlite",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/proteomiqon_mzmltomzlite/proteomiqon_mzmltomzlite/0.0.5"
+    },
+    {
+      "name": "Diffacto",
+      "id": "diffacto",
+      "description": "Comparative Protein Abundance from Covariation of Peptide Abundances",
+      "tool_shed_repository": "diffacto",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/diffacto/diffacto/1.0.6+galaxy0"
+    },
+    {
+      "name": "MSI classification",
+      "id": "cardinal_classification",
+      "description": "spatial classification of mass spectrometry imaging data",
+      "tool_shed_repository": "cardinal_classification",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/cardinal_classification/cardinal_classification/2.10.0.0"
+    },
+    {
+      "name": "metaQuantome: visualize",
+      "id": "metaquantome_viz",
+      "description": "taxonomic analysis, functional analysis, and function-taxonomy analysis results",
+      "tool_shed_repository": "metaquantome_viz",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/metaquantome_viz/metaquantome_viz/2.0.2+galaxy0"
+    },
+    {
+      "name": "metaQuantome: stat",
+      "id": "metaquantome_stat",
+      "description": "differential analysis of functional expression and taxonomic abundance",
+      "tool_shed_repository": "metaquantome_stat",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/metaquantome_stat/metaquantome_stat/2.0.2+galaxy0"
+    },
+    {
+      "name": "metaQuantome: expand",
+      "id": "metaquantome_expand",
+      "description": "a set of functional or taxonomy annotations",
+      "tool_shed_repository": "metaquantome_expand",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/metaquantome_expand/metaquantome_expand/2.0.2+galaxy0"
+    },
+    {
+      "name": "idpAssemble",
+      "id": "idpassemble",
+      "description": "Merge IDPicker databases from single files into a merged database, and filters the result at PSM/spectrum/peptide/protein/gene levels.",
+      "tool_shed_repository": "idpassemble",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/idpassemble/idpassemble/3.0.21142.0"
+    },
+    {
+      "name": "idpEmbedder",
+      "id": "idpqonvertEmbedder",
+      "description": "Embed human/mouse gene metadata into IDPicker files",
+      "tool_shed_repository": "idpqonvert",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/idpqonvert/idpqonvertEmbedder/3.0.21142.1"
+    },
+    {
+      "name": "idpQonvert",
+      "id": "idpqonvert",
+      "description": "Prepare identification results for IDPicker",
+      "tool_shed_repository": "idpqonvert",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/idpqonvert/idpqonvert/3.0.21142.0"
+    },
+    {
+      "name": "ConvertFastaToPrositCSV",
+      "id": "encyclopedia_fasta_to_prosit_csv",
+      "description": "Create Prosit CSV Input From a Protein FASTA",
+      "tool_shed_repository": "encyclopedia_fasta_to_prosit_csv",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/encyclopedia_fasta_to_prosit_csv/encyclopedia_fasta_to_prosit_csv/1.2.2+galaxy0"
+    },
+    {
+      "name": "EncyclopeDIA Quantify",
+      "id": "encyclopedia_quantify",
+      "description": "samples from Data-Independent Acquisition (DIA) MS/MS Data",
+      "tool_shed_repository": "encyclopedia_quantify",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/encyclopedia_quantify/encyclopedia_quantify/1.2.2+galaxy0"
+    },
+    {
+      "name": "Walnut",
+      "id": "encyclopedia_walnut",
+      "description": "PeCAn-based Peptide Detection Directly from Data-Independent Acquisition (DIA) MS/MS Data",
+      "tool_shed_repository": "encyclopedia_walnut",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/encyclopedia_walnut/encyclopedia_walnut/1.2.2+galaxy0"
+    },
+    {
+      "name": "SearchToLib",
+      "id": "encyclopedia_searchtolib",
+      "description": "Build a Chromatogram Library from Data-Independent Acquisition (DIA) MS/MS Data",
+      "tool_shed_repository": "encyclopedia_searchtolib",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/encyclopedia_searchtolib/encyclopedia_searchtolib/1.2.2+galaxy0"
+    },
+    {
+      "name": "ConvertLibraryToBlib",
+      "id": "encyclopedia_library_to_blib",
+      "description": "Convert EncyclopeDIA Library to BLIB for Skyline",
+      "tool_shed_repository": "encyclopedia_library_to_blib",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/encyclopedia_library_to_blib/encyclopedia_library_to_blib/1.2.2+galaxy0"
+    },
+    {
+      "name": "PepQuery",
+      "id": "pepquery",
+      "description": "Peptide-centric search engine for novel peptide identification and validation.",
+      "tool_shed_repository": "pepquery",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/pepquery/pepquery/1.6.2+galaxy1"
+    },
+    {
+      "name": "Peptide Genomic Coordinate",
+      "id": "peptide_genomic_coordinate",
+      "description": "Get Peptide's genomic coordinate using mzsqlite DB and genomic mapping sqlite DB",
+      "tool_shed_repository": "peptide_genomic_coordinate",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/peptide_genomic_coordinate/peptide_genomic_coordinate/1.0.0"
+    },
+    {
+      "name": "ConsensusID",
+      "id": "ConsensusID",
+      "description": "Computes a consensus of peptide identifications of several identification engines.",
+      "tool_shed_repository": "openms_consensusid",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/openms_consensusid/ConsensusID/2.6+galaxy1"
+    },
+    {
+      "name": "ConvertPrositCSVToLibrary",
+      "id": "encyclopedia_prosit_csv_to_library",
+      "description": "Convert Prosit/Spectronaut CSV to EncyclopeDIA DLIB library",
+      "tool_shed_repository": "encyclopedia_prosit_csv_to_library",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/encyclopedia_prosit_csv_to_library/encyclopedia_prosit_csv_to_library/1.2.2+galaxy0"
+    },
+    {
+      "name": "MyriMatch",
+      "id": "myrimatch",
+      "description": "Identify peptides in tandem mass spectra.",
+      "tool_shed_repository": "myrimatch",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/myrimatch/myrimatch/3.0.21142.0"
+    },
+    {
+      "name": "EncyclopeDIA",
+      "id": "encyclopedia_encyclopedia",
+      "description": "Library Searching Directly from Data-Independent Acquisition (DIA) MS/MS Data",
+      "tool_shed_repository": "encyclopedia_encyclopedia",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/encyclopedia_encyclopedia/encyclopedia_encyclopedia/1.2.2+galaxy0"
+    },
+    {
+      "name": "metaQuantome: database",
+      "id": "metaquantome_db",
+      "description": "download the GO, EC, and NCBI databases",
+      "tool_shed_repository": "metaquantome_db",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/metaquantome_db/metaquantome_db/2.0.2+galaxy0"
+    },
+    {
+      "name": "MaxQuant (using mqpar.xml)",
+      "id": "maxquant_mqpar",
+      "description": "",
+      "tool_shed_repository": "maxquant",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/maxquant/maxquant_mqpar/1.6.17.0+galaxy0"
+    },
+    {
+      "name": "metaQuantome: filter",
+      "id": "metaquantome_filter",
+      "description": "for quality, redundancy, and sample coverage",
+      "tool_shed_repository": "metaquantome_filter",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/metaquantome_filter/metaquantome_filter/2.0.2+galaxy0"
+    },
+    {
+      "name": "ProteomIQon PeptideSpectrumMatching",
+      "id": "proteomiqon_peptidespectrummatching",
+      "description": "iterates across all MS/MS scans in an MS run, determines precursor charge states and possible peptide spectrum matches.",
+      "tool_shed_repository": "proteomiqon_peptidespectrummatching",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/proteomiqon_peptidespectrummatching/proteomiqon_peptidespectrummatching/0.0.7"
+    },
+    {
+      "name": "Proteinortho grab proteins",
+      "id": "proteinortho_grab_proteins",
+      "description": "finds genes/proteins in a given fasta file",
+      "tool_shed_repository": "proteinortho_grab_proteins",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/proteinortho_grab_proteins/proteinortho_grab_proteins/6.0.32+galaxy0"
+    },
+    {
+      "name": "MSI single ion segmentation",
+      "id": "cardinal_single_ion_segmentation",
+      "description": "mass spectrometry imaging spatial DGMM",
+      "tool_shed_repository": "cardinal_single_ion_segmentation",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/cardinal_single_ion_segmentation/cardinal_single_ion_segmentation/2.10.0.0"
+    },
+    {
+      "name": "Validate FASTA Database",
+      "id": "validate_fasta_database",
+      "description": "",
+      "tool_shed_repository": "validate_fasta_database",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/validate_fasta_database/validate_fasta_database/0.1.5"
+    },
+    {
+      "name": "Proteomiqon LabelFreeProteinQuantification",
+      "id": "proteomiqon_labelfreeproteinquantification",
+      "description": "estimates protein abundances using quantified peptide ions.",
+      "tool_shed_repository": "proteomiqon_labelfreeproteinquantification",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/proteomiqon_labelfreeproteinquantification/proteomiqon_labelfreeproteinquantification/0.0.1"
+    },
+    {
+      "name": "TRIC",
+      "id": "feature_alignment",
+      "description": "integrates information from all available runs via a graph-based alignment strategy",
+      "tool_shed_repository": "feature_alignment",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/feature_alignment/feature_alignment/0.11.0+galaxy0"
+    },
+    {
+      "name": "PSMFeatureExtractor",
+      "id": "PSMFeatureExtractor",
+      "description": "Computes extra features for each input PSM.",
+      "tool_shed_repository": "openms_psmfeatureextractor",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/openms_psmfeatureextractor/PSMFeatureExtractor/2.6+galaxy2"
+    },
+    {
+      "name": "MetaProteomeAnalyzer",
+      "id": "meta_proteome_analyzer",
+      "description": "functional and taxonomic characterization of proteins",
+      "tool_shed_repository": "meta_proteome_analyzer",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/meta_proteome_analyzer/meta_proteome_analyzer/2.0.0+galaxy1"
+    },
+    {
+      "name": "DIAlignR",
+      "id": "dialignr",
+      "description": "for retention time alignment of targeted mass spectrometric data",
+      "tool_shed_repository": "dialignr",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/dialignr/dialignr/1.2.0+galaxy0"
+    },
+    {
+      "name": "FASTG2Protlib-Peptides",
+      "id": "fastg2protlib-peptides",
+      "description": "Generate FASTA from FASTG",
+      "tool_shed_repository": "fastg2protlib",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/fastg2protlib/fastg2protlib-peptides/1.0.2"
+    },
+    {
+      "name": "FASTG2Protlib-Validate",
+      "id": "fastg2protlib-validate",
+      "description": "Validate a candidate protein library",
+      "tool_shed_repository": "fastg2protlib",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/fastg2protlib/fastg2protlib-validate/1.0.2"
+    },
+    {
+      "name": "NovorAdapter",
+      "id": "NovorAdapter",
+      "description": "Template for Tool creation",
+      "tool_shed_repository": "openms_novoradapter",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/openms_novoradapter/NovorAdapter/2.6+galaxy1"
+    },
+    {
+      "name": "LuciphorAdapter",
+      "id": "LuciphorAdapter",
+      "description": "Modification site localisation using LuciPHOr2.",
+      "tool_shed_repository": "openms_luciphoradapter",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/openms_luciphoradapter/LuciphorAdapter/2.6+galaxy1"
+    },
+    {
+      "name": "AssayGeneratorMetabo",
+      "id": "AssayGeneratorMetabo",
+      "description": "Assay library generation from DDA data (Metabolomics)",
+      "tool_shed_repository": "openms_assaygeneratormetabo",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/openms_assaygeneratormetabo/AssayGeneratorMetabo/2.6+galaxy1"
+    },
+    {
+      "name": "SiriusAdapter",
+      "id": "SiriusAdapter",
+      "description": "Tool for metabolite identification using single and tandem mass spectrometry",
+      "tool_shed_repository": "openms_siriusadapter",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/openms_siriusadapter/SiriusAdapter/2.6+galaxy1"
+    },
+    {
+      "name": "MSFraggerAdapter",
+      "id": "MSFraggerAdapter",
+      "description": "Peptide Identification with MSFragger",
+      "tool_shed_repository": "openms_msfraggeradapter",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/openms_msfraggeradapter/MSFraggerAdapter/2.6+galaxy1"
+    },
+    {
+      "name": "MSGFPlusAdapter",
+      "id": "MSGFPlusAdapter",
+      "description": "MS/MS database search using MS-GF+.",
+      "tool_shed_repository": "openms_msgfplusadapter",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/openms_msgfplusadapter/MSGFPlusAdapter/2.6+galaxy1"
+    },
+    {
+      "name": "PeakPickerHiRes",
+      "id": "PeakPickerHiRes",
+      "description": "Finds mass spectrometric peaks in profile mass spectra.",
+      "tool_shed_repository": "openms_peakpickerhires",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/openms_peakpickerhires/PeakPickerHiRes/2.6+galaxy0"
+    },
+    {
+      "name": "RNAMassCalculator",
+      "id": "RNAMassCalculator",
+      "description": "Calculates masses, mass-to-charge ratios and sum formulas of RNA sequences",
+      "tool_shed_repository": "openms_rnamasscalculator",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/openms_rnamasscalculator/RNAMassCalculator/2.6+galaxy0"
+    },
+    {
+      "name": "QualityControl",
+      "id": "QualityControl",
+      "description": "Computes various QC metrics from many possible input files (only the consensusXML is required). The more optional files you provide, the more metrics you get.",
+      "tool_shed_repository": "openms_qualitycontrol",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/openms_qualitycontrol/QualityControl/2.6+galaxy0"
+    },
+    {
+      "name": "RNPxlXICFilter",
+      "id": "RNPxlXICFilter",
+      "description": "Remove MS2 spectra from treatment based on the fold change between control and treatment.",
+      "tool_shed_repository": "openms_rnpxlxicfilter",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/openms_rnpxlxicfilter/RNPxlXICFilter/2.6+galaxy0"
+    },
+    {
+      "name": "OpenSwathConfidenceScoring",
+      "id": "OpenSwathConfidenceScoring",
+      "description": "Compute confidence scores for OpenSwath results",
+      "tool_shed_repository": "openms_openswathconfidencescoring",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/openms_openswathconfidencescoring/OpenSwathConfidenceScoring/2.6+galaxy0"
+    },
+    {
+      "name": "MultiplexResolver",
+      "id": "MultiplexResolver",
+      "description": "Completes peptide multiplets and resolves conflicts within them.",
+      "tool_shed_repository": "openms_multiplexresolver",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/openms_multiplexresolver/MultiplexResolver/2.6+galaxy0"
+    },
+    {
+      "name": "PSM-Fragment Validator",
+      "id": "psmvalidator",
+      "description": "Validate PSMs against Ion Fragmentation",
+      "tool_shed_repository": "psm_validation",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/psm_validation/psmvalidator/1.0.3+galaxy1"
+    },
+    {
+      "name": "Remove protonation state",
+      "id": "openbabel_remove_protonation_state",
+      "description": "of every atom",
+      "tool_shed_repository": "openbabel_remove_protonation_state",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/openbabel_remove_protonation_state/openbabel_remove_protonation_state/3.1.1+galaxy0"
+    },
+    {
+      "name": "idpQuery",
+      "id": "idpquery",
+      "description": "Creates text reports from idpDB files.",
+      "tool_shed_repository": "idpquery",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/idpquery/idpquery/3.0.20163.0"
+    },
+    {
+      "name": "OpenSwathFeatureXMLToTSV",
+      "id": "OpenSwathFeatureXMLToTSV",
+      "description": "Converts a featureXML to a mProphet tsv.",
+      "tool_shed_repository": "openms_openswathfeaturexmltotsv",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/openms_openswathfeaturexmltotsv/OpenSwathFeatureXMLToTSV/2.6+galaxy0"
+    },
+    {
+      "name": "OpenSwathDIAPreScoring",
+      "id": "OpenSwathDIAPreScoring",
+      "description": "Scoring spectra using the DIA scores.",
+      "tool_shed_repository": "openms_openswathdiaprescoring",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/openms_openswathdiaprescoring/OpenSwathDIAPreScoring/2.6+galaxy0"
+    },
+    {
+      "name": "MapStatistics",
+      "id": "MapStatistics",
+      "description": "Extract extended statistics on the features of a map for quality control.",
+      "tool_shed_repository": "openms_mapstatistics",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/openms_mapstatistics/MapStatistics/2.6+galaxy0"
+    },
+    {
+      "name": "DigestorMotif",
+      "id": "DigestorMotif",
+      "description": "digests a protein database in-silico",
+      "tool_shed_repository": "openms_digestormotif",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/openms_digestormotif/DigestorMotif/2.6+galaxy0"
+    },
+    {
+      "name": "FeatureLinkerLabeled",
+      "id": "FeatureLinkerLabeled",
+      "description": "Groups corresponding isotope-labeled features in a feature map.",
+      "tool_shed_repository": "openms_featurelinkerlabeled",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/openms_featurelinkerlabeled/FeatureLinkerLabeled/2.6+galaxy0"
+    },
+    {
+      "name": "XTandemAdapter",
+      "id": "XTandemAdapter",
+      "description": "Annotates MS/MS spectra using X! Tandem.",
+      "tool_shed_repository": "openms_xtandemadapter",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/openms_xtandemadapter/XTandemAdapter/2.6+galaxy0"
+    },
+    {
+      "name": "SpectraFilterWindowMower",
+      "id": "SpectraFilterWindowMower",
+      "description": "Applies thresholdfilter to peak spectra.",
+      "tool_shed_repository": "openms_spectrafilterwindowmower",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/openms_spectrafilterwindowmower/SpectraFilterWindowMower/2.6+galaxy0"
+    },
+    {
+      "name": "OpenSwathWorkflow",
+      "id": "OpenSwathWorkflow",
+      "description": "Complete workflow to run OpenSWATH",
+      "tool_shed_repository": "openms_openswathworkflow",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/openms_openswathworkflow/OpenSwathWorkflow/2.6+galaxy0"
+    },
+    {
+      "name": "QCMerger",
+      "id": "QCMerger",
+      "description": "Merges two qcml files together.",
+      "tool_shed_repository": "openms_qcmerger",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/openms_qcmerger/QCMerger/2.6+galaxy0"
+    },
+    {
+      "name": "IDMapper",
+      "id": "IDMapper",
+      "description": "Assigns protein/peptide identifications to features or consensus features.",
+      "tool_shed_repository": "openms_idmapper",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/openms_idmapper/IDMapper/2.6+galaxy0"
+    },
+    {
+      "name": "IDMassAccuracy",
+      "id": "IDMassAccuracy",
+      "description": "Calculates a distribution of the mass error from given mass spectra and IDs.",
+      "tool_shed_repository": "openms_idmassaccuracy",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/openms_idmassaccuracy/IDMassAccuracy/2.6+galaxy0"
+    },
+    {
+      "name": "IDRTCalibration",
+      "id": "IDRTCalibration",
+      "description": "Can be used to calibrate RTs of peptide hits linearly to standards.",
+      "tool_shed_repository": "openms_idrtcalibration",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/openms_idrtcalibration/IDRTCalibration/2.6+galaxy0"
+    },
+    {
+      "name": "IDSplitter",
+      "id": "IDSplitter",
+      "description": "Splits protein/peptide identifications off of annotated data files",
+      "tool_shed_repository": "openms_idsplitter",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/openms_idsplitter/IDSplitter/2.6+galaxy0"
+    },
+    {
+      "name": "MRMTransitionGroupPicker",
+      "id": "MRMTransitionGroupPicker",
+      "description": "Picks peaks in SRM/MRM chromatograms.",
+      "tool_shed_repository": "openms_mrmtransitiongrouppicker",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/openms_mrmtransitiongrouppicker/MRMTransitionGroupPicker/2.6+galaxy0"
+    },
+    {
+      "name": "MapAlignerIdentification",
+      "id": "MapAlignerIdentification",
+      "description": "Corrects retention time distortions between maps based on common peptide identifications.",
+      "tool_shed_repository": "openms_mapaligneridentification",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/openms_mapaligneridentification/MapAlignerIdentification/2.6+galaxy0"
+    },
+    {
+      "name": "IsobaricAnalyzer",
+      "id": "IsobaricAnalyzer",
+      "description": "Calculates isobaric quantitative values for peptides",
+      "tool_shed_repository": "openms_isobaricanalyzer",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/openms_isobaricanalyzer/IsobaricAnalyzer/2.6+galaxy0"
+    },
+    {
+      "name": "ERPairFinder",
+      "id": "ERPairFinder",
+      "description": "Util which can be used to evaluate pair ratios on enhanced resolution (zoom) scans.",
+      "tool_shed_repository": "openms_erpairfinder",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/openms_erpairfinder/ERPairFinder/2.6+galaxy0"
+    },
+    {
+      "name": "ClusterMassTraces",
+      "id": "ClusterMassTraces",
+      "description": "Creates pseudo spectra.",
+      "tool_shed_repository": "openms_clustermasstraces",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/openms_clustermasstraces/ClusterMassTraces/2.6+galaxy0"
+    },
+    {
+      "name": "ClusterMassTracesByPrecursor",
+      "id": "ClusterMassTracesByPrecursor",
+      "description": "Correlate precursor masstraces with fragment ion masstraces in SWATH maps based on their elution profile.",
+      "tool_shed_repository": "openms_clustermasstracesbyprecursor",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/openms_clustermasstracesbyprecursor/ClusterMassTracesByPrecursor/2.6+galaxy0"
+    },
+    {
+      "name": "CometAdapter",
+      "id": "CometAdapter",
+      "description": "Annotates MS/MS spectra using Comet.",
+      "tool_shed_repository": "openms_cometadapter",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/openms_cometadapter/CometAdapter/2.6+galaxy0"
+    },
+    {
+      "name": "CompNovo",
+      "id": "CompNovo",
+      "description": "Performs a de novo peptide identification using the CompNovo engine.",
+      "tool_shed_repository": "openms_compnovo",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/openms_compnovo/CompNovo/2.6+galaxy0"
+    },
+    {
+      "name": "CompNovoCID",
+      "id": "CompNovoCID",
+      "description": "Performs a de novo peptide identification using the CompNovo engine.",
+      "tool_shed_repository": "openms_compnovocid",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/openms_compnovocid/CompNovoCID/2.6+galaxy0"
+    },
+    {
+      "name": "IDMerger",
+      "id": "IDMerger",
+      "description": "Merges several protein/peptide identification files into one file.",
+      "tool_shed_repository": "openms_idmerger",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/openms_idmerger/IDMerger/2.6+galaxy0"
+    },
+    {
+      "name": "MetaboliteSpectralMatcher",
+      "id": "MetaboliteSpectralMatcher",
+      "description": "Perform a spectral library search.",
+      "tool_shed_repository": "openms_metabolitespectralmatcher",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/openms_metabolitespectralmatcher/MetaboliteSpectralMatcher/2.6+galaxy0"
+    },
+    {
+      "name": "RTEvaluation",
+      "id": "RTEvaluation",
+      "description": "Application that evaluates TPs (true positives), TNs, FPs, and FNs for an idXML file with predicted RTs.",
+      "tool_shed_repository": "openms_rtevaluation",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/openms_rtevaluation/RTEvaluation/2.6+galaxy0"
+    },
+    {
+      "name": "QCExporter",
+      "id": "QCExporter",
+      "description": "Will extract several qp from several run/sets in a tabular format.",
+      "tool_shed_repository": "openms_qcexporter",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/openms_qcexporter/QCExporter/2.6+galaxy0"
+    },
+    {
+      "name": "SpectraFilterNormalizer",
+      "id": "SpectraFilterNormalizer",
+      "description": "Normalizes intensity of peak spectra.",
+      "tool_shed_repository": "openms_spectrafilternormalizer",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/openms_spectrafilternormalizer/SpectraFilterNormalizer/2.6+galaxy0"
+    },
+    {
+      "name": "InternalCalibration",
+      "id": "InternalCalibration",
+      "description": "Applies an internal mass recalibration.",
+      "tool_shed_repository": "openms_internalcalibration",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/openms_internalcalibration/InternalCalibration/2.6+galaxy0"
+    },
+    {
+      "name": "MassTraceExtractor",
+      "id": "MassTraceExtractor",
+      "description": "Detects mass traces in centroided LC-MS data.",
+      "tool_shed_repository": "openms_masstraceextractor",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/openms_masstraceextractor/MassTraceExtractor/2.6+galaxy0"
+    },
+    {
+      "name": "PepNovoAdapter",
+      "id": "PepNovoAdapter",
+      "description": "Adapter to PepNovo supporting all PepNovo command line parameters. The results are converted from the PepNovo text outfile format into the idXML format.",
+      "tool_shed_repository": "openms_pepnovoadapter",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/openms_pepnovoadapter/PepNovoAdapter/2.6+galaxy0"
+    },
+    {
+      "name": "Digestor",
+      "id": "Digestor",
+      "description": "Digests a protein database in-silico.",
+      "tool_shed_repository": "openms_digestor",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/openms_digestor/Digestor/2.6+galaxy0"
+    },
+    {
+      "name": "PeptideIndexer",
+      "id": "PeptideIndexer",
+      "description": "Refreshes the protein references for all peptide hits.",
+      "tool_shed_repository": "openms_peptideindexer",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/openms_peptideindexer/PeptideIndexer/2.6+galaxy0"
+    },
+    {
+      "name": "MapRTTransformer",
+      "id": "MapRTTransformer",
+      "description": "Applies retention time transformations to maps.",
+      "tool_shed_repository": "openms_maprttransformer",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/openms_maprttransformer/MapRTTransformer/2.6+galaxy0"
+    },
+    {
+      "name": "OpenSwathAssayGenerator",
+      "id": "OpenSwathAssayGenerator",
+      "description": "Generates assays according to different models for a specific TraML",
+      "tool_shed_repository": "openms_openswathassaygenerator",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/openms_openswathassaygenerator/OpenSwathAssayGenerator/2.6+galaxy0"
+    },
+    {
+      "name": "DTAExtractor",
+      "id": "DTAExtractor",
+      "description": "Extracts spectra of an MS run file to several files in DTA format.",
+      "tool_shed_repository": "openms_dtaextractor",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/openms_dtaextractor/DTAExtractor/2.6+galaxy0"
+    },
+    {
+      "name": "SequenceCoverageCalculator",
+      "id": "SequenceCoverageCalculator",
+      "description": "Prints information about idXML files.",
+      "tool_shed_repository": "openms_sequencecoveragecalculator",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/openms_sequencecoveragecalculator/SequenceCoverageCalculator/2.6+galaxy0"
+    },
+    {
+      "name": "MetaProSIP",
+      "id": "MetaProSIP",
+      "description": "Performs proteinSIP on peptide features for elemental flux analysis.",
+      "tool_shed_repository": "openms_metaprosip",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/openms_metaprosip/MetaProSIP/2.6+galaxy0"
+    },
+    {
+      "name": "IDConflictResolver",
+      "id": "IDConflictResolver",
+      "description": "Resolves ambiguous annotations of features with peptide identifications",
+      "tool_shed_repository": "openms_idconflictresolver",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/openms_idconflictresolver/IDConflictResolver/2.6+galaxy0"
+    },
+    {
+      "name": "PeakPickerWavelet",
+      "id": "PeakPickerWavelet",
+      "description": "Finds mass spectrometric peaks in profile mass spectra.",
+      "tool_shed_repository": "openms_peakpickerwavelet",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/openms_peakpickerwavelet/PeakPickerWavelet/2.6+galaxy0"
+    },
+    {
+      "name": "ProteinQuantifier",
+      "id": "ProteinQuantifier",
+      "description": "Compute peptide and protein abundances",
+      "tool_shed_repository": "openms_proteinquantifier",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/openms_proteinquantifier/ProteinQuantifier/2.6+galaxy0"
+    },
+    {
+      "name": "PeakPickerIterative",
+      "id": "PeakPickerIterative",
+      "description": "Finds mass spectrometric peaks in profile mass spectra.",
+      "tool_shed_repository": "openms_peakpickeriterative",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/openms_peakpickeriterative/PeakPickerIterative/2.6+galaxy0"
+    },
+    {
+      "name": "Decharger",
+      "id": "Decharger",
+      "description": "Decharges and merges different feature charge variants of the same peptide.",
+      "tool_shed_repository": "openms_decharger",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/openms_decharger/Decharger/2.6+galaxy0"
+    },
+    {
+      "name": "FuzzyDiff",
+      "id": "FuzzyDiff",
+      "description": "Compares two files, tolerating numeric differences.",
+      "tool_shed_repository": "openms_fuzzydiff",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/openms_fuzzydiff/FuzzyDiff/2.6+galaxy0"
+    },
+    {
+      "name": "MzMLSplitter",
+      "id": "MzMLSplitter",
+      "description": "Splits an mzML file into multiple parts",
+      "tool_shed_repository": "openms_mzmlsplitter",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/openms_mzmlsplitter/MzMLSplitter/2.6+galaxy0"
+    },
+    {
+      "name": "FileConverter",
+      "id": "FileConverter",
+      "description": "Converts between different MS file formats.",
+      "tool_shed_repository": "openms_fileconverter",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/openms_fileconverter/FileConverter/2.6+galaxy0"
+    },
+    {
+      "name": "MassCalculator",
+      "id": "MassCalculator",
+      "description": "Calculates masses and mass-to-charge ratios of peptide sequences",
+      "tool_shed_repository": "openms_masscalculator",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/openms_masscalculator/MassCalculator/2.6+galaxy0"
+    },
+    {
+      "name": "SpectraFilterNLargest",
+      "id": "SpectraFilterNLargest",
+      "description": "Applies thresholdfilter to peak spectra.",
+      "tool_shed_repository": "openms_spectrafilternlargest",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/openms_spectrafilternlargest/SpectraFilterNLargest/2.6+galaxy0"
+    },
+    {
+      "name": "MapAlignerPoseClustering",
+      "id": "MapAlignerPoseClustering",
+      "description": "Corrects retention time distortions between maps using a pose clustering approach.",
+      "tool_shed_repository": "openms_mapalignerposeclustering",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/openms_mapalignerposeclustering/MapAlignerPoseClustering/2.6+galaxy0"
+    },
+    {
+      "name": "QCEmbedder",
+      "id": "QCEmbedder",
+      "description": "Attaches a table or an image to a given qc parameter.",
+      "tool_shed_repository": "openms_qcembedder",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/openms_qcembedder/QCEmbedder/2.6+galaxy0"
+    },
+    {
+      "name": "Epifany",
+      "id": "Epifany",
+      "description": "Runs a Bayesian protein inference.",
+      "tool_shed_repository": "openms_epifany",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/openms_epifany/Epifany/2.6+galaxy0"
+    },
+    {
+      "name": "SpectraFilterThresholdMower",
+      "id": "SpectraFilterThresholdMower",
+      "description": "Applies thresholdfilter to peak spectra.",
+      "tool_shed_repository": "openms_spectrafilterthresholdmower",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/openms_spectrafilterthresholdmower/SpectraFilterThresholdMower/2.6+galaxy0"
+    },
+    {
+      "name": "SpectraMerger",
+      "id": "SpectraMerger",
+      "description": "Merges spectra (each MS level separately), increasing S/N ratios.",
+      "tool_shed_repository": "openms_spectramerger",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/openms_spectramerger/SpectraMerger/2.6+galaxy0"
+    },
+    {
+      "name": "OpenSwathDecoyGenerator",
+      "id": "OpenSwathDecoyGenerator",
+      "description": "Generates decoys according to different models for a specific TraML",
+      "tool_shed_repository": "openms_openswathdecoygenerator",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/openms_openswathdecoygenerator/OpenSwathDecoyGenerator/2.6+galaxy0"
+    },
+    {
+      "name": "PTModel",
+      "id": "PTModel",
+      "description": "Trains a model for the prediction of proteotypic peptides from a training set.",
+      "tool_shed_repository": "openms_ptmodel",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/openms_ptmodel/PTModel/2.6+galaxy0"
+    },
+    {
+      "name": "TargetedFileConverter",
+      "id": "TargetedFileConverter",
+      "description": "Converts different transition files for targeted proteomics / metabolomics analysis.",
+      "tool_shed_repository": "openms_targetedfileconverter",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/openms_targetedfileconverter/TargetedFileConverter/2.6+galaxy0"
+    },
+    {
+      "name": "TextExporter",
+      "id": "TextExporter",
+      "description": "Exports various XML formats to a text file.",
+      "tool_shed_repository": "openms_textexporter",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/openms_textexporter/TextExporter/2.6+galaxy0"
+    },
+    {
+      "name": "TOFCalibration",
+      "id": "TOFCalibration",
+      "description": "Applies time of flight calibration.",
+      "tool_shed_repository": "openms_tofcalibration",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/openms_tofcalibration/TOFCalibration/2.6+galaxy0"
+    },
+    {
+      "name": "TransformationEvaluation",
+      "id": "TransformationEvaluation",
+      "description": "Applies a transformation to a range of values",
+      "tool_shed_repository": "openms_transformationevaluation",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/openms_transformationevaluation/TransformationEvaluation/2.6+galaxy0"
+    },
+    {
+      "name": "XMLValidator",
+      "id": "XMLValidator",
+      "description": "Validates XML files against an XSD schema.",
+      "tool_shed_repository": "openms_xmlvalidator",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/openms_xmlvalidator/XMLValidator/2.6+galaxy0"
+    },
+    {
+      "name": "ProteinInference",
+      "id": "ProteinInference",
+      "description": "Protein inference based on an aggregation of the scores of the identified peptides.",
+      "tool_shed_repository": "openms_proteininference",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/openms_proteininference/ProteinInference/2.6+galaxy0"
+    },
+    {
+      "name": "SvmTheoreticalSpectrumGeneratorTrainer",
+      "id": "SvmTheoreticalSpectrumGeneratorTrainer",
+      "description": "Trainer for SVM models as input for SvmTheoreticalSpectrumGenerator",
+      "tool_shed_repository": "openms_svmtheoreticalspectrumgeneratortrainer",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/openms_svmtheoreticalspectrumgeneratortrainer/SvmTheoreticalSpectrumGeneratorTrainer/2.6+galaxy0"
+    },
+    {
+      "name": "IDRipper",
+      "id": "IDRipper",
+      "description": "Split protein/peptide identification file into several files according to annotated file origin.",
+      "tool_shed_repository": "openms_idripper",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/openms_idripper/IDRipper/2.6+galaxy0"
+    },
+    {
+      "name": "SpectraSTSearchAdapter",
+      "id": "SpectraSTSearchAdapter",
+      "description": "Interface to the SEARCH Mode of the SpectraST executable",
+      "tool_shed_repository": "openms_spectrastsearchadapter",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/openms_spectrastsearchadapter/SpectraSTSearchAdapter/2.6+galaxy0"
+    },
+    {
+      "name": "SpectraFilterSqrtMower",
+      "id": "SpectraFilterSqrtMower",
+      "description": "Applies thresholdfilter to peak spectra.",
+      "tool_shed_repository": "openms_spectrafiltersqrtmower",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/openms_spectrafiltersqrtmower/SpectraFilterSqrtMower/2.6+galaxy0"
+    },
+    {
+      "name": "SpectraFilterMarkerMower",
+      "id": "SpectraFilterMarkerMower",
+      "description": "Applies thresholdfilter to peak spectra.",
+      "tool_shed_repository": "openms_spectrafiltermarkermower",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/openms_spectrafiltermarkermower/SpectraFilterMarkerMower/2.6+galaxy0"
+    },
+    {
+      "name": "SpecLibSearcher",
+      "id": "SpecLibSearcher",
+      "description": "Identifies peptide MS/MS spectra by spectral matching with a searchable spectral library.",
+      "tool_shed_repository": "openms_speclibsearcher",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/openms_speclibsearcher/SpecLibSearcher/2.6+galaxy0"
+    },
+    {
+      "name": "MascotAdapterOnline",
+      "id": "MascotAdapterOnline",
+      "description": "Annotates MS/MS spectra using Mascot.",
+      "tool_shed_repository": "openms_mascotadapteronline",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/openms_mascotadapteronline/MascotAdapterOnline/2.6+galaxy0"
+    },
+    {
+      "name": "MapAlignerSpectrum",
+      "id": "MapAlignerSpectrum",
+      "description": "Corrects retention time distortions between maps by spectrum alignment.",
+      "tool_shed_repository": "openms_mapalignerspectrum",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/openms_mapalignerspectrum/MapAlignerSpectrum/2.6+galaxy0"
+    },
+    {
+      "name": "SpecLibCreator",
+      "id": "SpecLibCreator",
+      "description": "Creates an MSP formatted spectral library.",
+      "tool_shed_repository": "openms_speclibcreator",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/openms_speclibcreator/SpecLibCreator/2.6+galaxy0"
+    },
+    {
+      "name": "SemanticValidator",
+      "id": "SemanticValidator",
+      "description": "SemanticValidator for semantically validating certain XML files.",
+      "tool_shed_repository": "openms_semanticvalidator",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/openms_semanticvalidator/SemanticValidator/2.6+galaxy0"
+    },
+    {
+      "name": "SimpleSearchEngine",
+      "id": "SimpleSearchEngine",
+      "description": "Annotates MS/MS spectra using SimpleSearchEngine.",
+      "tool_shed_repository": "openms_simplesearchengine",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/openms_simplesearchengine/SimpleSearchEngine/2.6+galaxy0"
+    },
+    {
+      "name": "LabeledEval",
+      "id": "LabeledEval",
+      "description": "Evaluation tool for isotope-labeled quantitation experiments.",
+      "tool_shed_repository": "openms_labeledeval",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/openms_labeledeval/LabeledEval/2.6+galaxy0"
+    },
+    {
+      "name": "SeedListGenerator",
+      "id": "SeedListGenerator",
+      "description": "Generates seed lists for feature detection.",
+      "tool_shed_repository": "openms_seedlistgenerator",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/openms_seedlistgenerator/SeedListGenerator/2.6+galaxy0"
+    },
+    {
+      "name": "RTModel",
+      "id": "RTModel",
+      "description": "Trains a model for the retention time prediction of peptides from a training set.",
+      "tool_shed_repository": "openms_rtmodel",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/openms_rtmodel/RTModel/2.6+galaxy0"
+    },
+    {
+      "name": "MaRaClusterAdapter",
+      "id": "MaRaClusterAdapter",
+      "description": "Facilitate input to MaRaCluster and reintegrate.",
+      "tool_shed_repository": "openms_maraclusteradapter",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/openms_maraclusteradapter/MaRaClusterAdapter/2.6+galaxy0"
+    },
+    {
+      "name": "RNPxlSearch",
+      "id": "RNPxlSearch",
+      "description": "Annotate RNA/DNA-peptide cross-links in MS/MS spectra.",
+      "tool_shed_repository": "openms_rnpxlsearch",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/openms_rnpxlsearch/RNPxlSearch/2.6+galaxy0"
+    },
+    {
+      "name": "PrecursorIonSelector",
+      "id": "PrecursorIonSelector",
+      "description": "PrecursorIonSelector",
+      "tool_shed_repository": "openms_precursorionselector",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/openms_precursorionselector/PrecursorIonSelector/2.6+galaxy0"
+    },
+    {
+      "name": "FeatureFinderCentroided",
+      "id": "FeatureFinderCentroided",
+      "description": "Detects two-dimensional features in LC-MS data.",
+      "tool_shed_repository": "openms_featurefindercentroided",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/openms_featurefindercentroided/FeatureFinderCentroided/2.6+galaxy0"
+    },
+    {
+      "name": "SpectraFilterParentPeakMower",
+      "id": "SpectraFilterParentPeakMower",
+      "description": "Applies thresholdfilter to peak spectra.",
+      "tool_shed_repository": "openms_spectrafilterparentpeakmower",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/openms_spectrafilterparentpeakmower/SpectraFilterParentPeakMower/2.6+galaxy0"
+    },
+    {
+      "name": "TICCalculator",
+      "id": "TICCalculator",
+      "description": "Calculates the TIC from a mass spectrometric raw file (useful for benchmarking).",
+      "tool_shed_repository": "openms_ticcalculator",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/openms_ticcalculator/TICCalculator/2.6+galaxy0"
+    },
+    {
+      "name": "MRMMapper",
+      "id": "MRMMapper",
+      "description": "MRMMapper maps measured chromatograms (mzML) and the transitions used (TraML)",
+      "tool_shed_repository": "openms_mrmmapper",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/openms_mrmmapper/MRMMapper/2.6+galaxy0"
+    },
+    {
+      "name": "OMSSAAdapter",
+      "id": "OMSSAAdapter",
+      "description": "Annotates MS/MS spectra using OMSSA.",
+      "tool_shed_repository": "openms_omssaadapter",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/openms_omssaadapter/OMSSAAdapter/2.6+galaxy0"
+    },
+    {
+      "name": "EICExtractor",
+      "id": "EICExtractor",
+      "description": "Extracts intensities from dedicates positions in a LC/MS map",
+      "tool_shed_repository": "openms_eicextractor",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/openms_eicextractor/EICExtractor/2.6+galaxy0"
+    },
+    {
+      "name": "MyriMatchAdapter",
+      "id": "MyriMatchAdapter",
+      "description": "Annotates MS/MS spectra using MyriMatch.",
+      "tool_shed_repository": "openms_myrimatchadapter",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/openms_myrimatchadapter/MyriMatchAdapter/2.6+galaxy0"
+    },
+    {
+      "name": "IDFilter",
+      "id": "IDFilter",
+      "description": "Filters results from protein or peptide identification engines based on different criteria.",
+      "tool_shed_repository": "openms_idfilter",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/openms_idfilter/IDFilter/2.6+galaxy0"
+    },
+    {
+      "name": "MSSimulator",
+      "id": "MSSimulator",
+      "description": "A highly configurable simulator for mass spectrometry experiments.",
+      "tool_shed_repository": "openms_mssimulator",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/openms_mssimulator/MSSimulator/2.6+galaxy0"
+    },
+    {
+      "name": "BaselineFilter",
+      "id": "BaselineFilter",
+      "description": "Removes the baseline from profile spectra using a top-hat filter.",
+      "tool_shed_repository": "openms_baselinefilter",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/openms_baselinefilter/BaselineFilter/2.6+galaxy0"
+    },
+    {
+      "name": "NucleicAcidSearchEngine",
+      "id": "NucleicAcidSearchEngine",
+      "description": "Annotate nucleic acid identifications to MS/MS spectra.",
+      "tool_shed_repository": "openms_nucleicacidsearchengine",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/openms_nucleicacidsearchengine/NucleicAcidSearchEngine/2.6+galaxy0"
+    },
+    {
+      "name": "SpectraFilterBernNorm",
+      "id": "SpectraFilterBernNorm",
+      "description": "Applies thresholdfilter to peak spectra.",
+      "tool_shed_repository": "openms_spectrafilterbernnorm",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/openms_spectrafilterbernnorm/SpectraFilterBernNorm/2.6+galaxy0"
+    },
+    {
+      "name": "CVInspector",
+      "id": "CVInspector",
+      "description": "A tool for visualization and validation of PSI mapping and CV files.",
+      "tool_shed_repository": "openms_cvinspector",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/openms_cvinspector/CVInspector/2.6+galaxy0"
+    },
+    {
+      "name": "RNADigestor",
+      "id": "RNADigestor",
+      "description": "Digests an RNA sequence database in-silico.",
+      "tool_shed_repository": "openms_rnadigestor",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/openms_rnadigestor/RNADigestor/2.6+galaxy0"
+    },
+    {
+      "name": "DecoyDatabase",
+      "id": "DecoyDatabase",
+      "description": "Create decoy sequence database from forward sequence database.",
+      "tool_shed_repository": "openms_decoydatabase",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/openms_decoydatabase/DecoyDatabase/2.6+galaxy0"
+    },
+    {
+      "name": "ExternalCalibration",
+      "id": "ExternalCalibration",
+      "description": "Applies an external mass recalibration.",
+      "tool_shed_repository": "openms_externalcalibration",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/openms_externalcalibration/ExternalCalibration/2.6+galaxy0"
+    },
+    {
+      "name": "FalseDiscoveryRate",
+      "id": "FalseDiscoveryRate",
+      "description": "Estimates the false discovery rate on peptide and protein level using decoy searches.",
+      "tool_shed_repository": "openms_falsediscoveryrate",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/openms_falsediscoveryrate/FalseDiscoveryRate/2.6+galaxy0"
+    },
+    {
+      "name": "FeatureFinderIdentification",
+      "id": "FeatureFinderIdentification",
+      "description": "Detects features in MS1 data based on peptide identifications.",
+      "tool_shed_repository": "openms_featurefinderidentification",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/openms_featurefinderidentification/FeatureFinderIdentification/2.6+galaxy0"
+    },
+    {
+      "name": "FeatureFinderIsotopeWavelet",
+      "id": "FeatureFinderIsotopeWavelet",
+      "description": "Detects two-dimensional features in LC-MS data.",
+      "tool_shed_repository": "openms_featurefinderisotopewavelet",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/openms_featurefinderisotopewavelet/FeatureFinderIsotopeWavelet/2.6+galaxy0"
+    },
+    {
+      "name": "FeatureFinderMetabo",
+      "id": "FeatureFinderMetabo",
+      "description": "Assembles metabolite features from centroided (LC-)MS data using the mass trace approach.",
+      "tool_shed_repository": "openms_featurefindermetabo",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/openms_featurefindermetabo/FeatureFinderMetabo/2.6+galaxy0"
+    },
+    {
+      "name": "FeatureFinderMetaboIdent",
+      "id": "FeatureFinderMetaboIdent",
+      "description": "Detects features in MS1 data based on metabolite identifications.",
+      "tool_shed_repository": "openms_featurefindermetaboident",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/openms_featurefindermetaboident/FeatureFinderMetaboIdent/2.6+galaxy0"
+    },
+    {
+      "name": "FeatureFinderMRM",
+      "id": "FeatureFinderMRM",
+      "description": "Detects two-dimensional features in LC-MS data.",
+      "tool_shed_repository": "openms_featurefindermrm",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/openms_featurefindermrm/FeatureFinderMRM/2.6+galaxy0"
+    },
+    {
+      "name": "FeatureFinderMultiplex",
+      "id": "FeatureFinderMultiplex",
+      "description": "Determination of peak ratios in LC-MS data",
+      "tool_shed_repository": "openms_featurefindermultiplex",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/openms_featurefindermultiplex/FeatureFinderMultiplex/2.6+galaxy0"
+    },
+    {
+      "name": "FeatureLinkerUnlabeled",
+      "id": "FeatureLinkerUnlabeled",
+      "description": "Groups corresponding features from multiple maps.",
+      "tool_shed_repository": "openms_featurelinkerunlabeled",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/openms_featurelinkerunlabeled/FeatureLinkerUnlabeled/2.6+galaxy0"
+    },
+    {
+      "name": "FeatureLinkerUnlabeledKD",
+      "id": "FeatureLinkerUnlabeledKD",
+      "description": "Groups corresponding features from multiple maps.",
+      "tool_shed_repository": "openms_featurelinkerunlabeledkd",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/openms_featurelinkerunlabeledkd/FeatureLinkerUnlabeledKD/2.6+galaxy0"
+    },
+    {
+      "name": "FeatureLinkerUnlabeledQT",
+      "id": "FeatureLinkerUnlabeledQT",
+      "description": "Groups corresponding features from multiple maps.",
+      "tool_shed_repository": "openms_featurelinkerunlabeledqt",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/openms_featurelinkerunlabeledqt/FeatureLinkerUnlabeledQT/2.6+galaxy0"
+    },
+    {
+      "name": "FFEval",
+      "id": "FFEval",
+      "description": "Evaluation tool for feature detection algorithms.",
+      "tool_shed_repository": "openms_ffeval",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/openms_ffeval/FFEval/2.6+galaxy0"
+    },
+    {
+      "name": "FidoAdapter",
+      "id": "FidoAdapter",
+      "description": "Runs the protein inference engine Fido.",
+      "tool_shed_repository": "openms_fidoadapter",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/openms_fidoadapter/FidoAdapter/2.6+galaxy0"
+    },
+    {
+      "name": "FileFilter",
+      "id": "FileFilter",
+      "description": "Extracts or manipulates portions of data from peak, feature or consensus-feature files.",
+      "tool_shed_repository": "openms_filefilter",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/openms_filefilter/FileFilter/2.6+galaxy0"
+    },
+    {
+      "name": "FileInfo",
+      "id": "FileInfo",
+      "description": "Shows basic information about the file, such as data ranges and file type.",
+      "tool_shed_repository": "openms_fileinfo",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/openms_fileinfo/FileInfo/2.6+galaxy0"
+    },
+    {
+      "name": "FileMerger",
+      "id": "FileMerger",
+      "description": "Merges several MS files into one file.",
+      "tool_shed_repository": "openms_filemerger",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/openms_filemerger/FileMerger/2.6+galaxy0"
+    },
+    {
+      "name": "GNPSExport",
+      "id": "GNPSExport",
+      "description": "Tool to export consensus features into MGF format",
+      "tool_shed_repository": "openms_gnpsexport",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/openms_gnpsexport/GNPSExport/2.6+galaxy0"
+    },
+    {
+      "name": "AccurateMassSearch",
+      "id": "AccurateMassSearch",
+      "description": "Match MS signals to molecules from a database by mass.",
+      "tool_shed_repository": "openms_accuratemasssearch",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/openms_accuratemasssearch/AccurateMassSearch/2.6+galaxy0"
+    },
+    {
+      "name": "DatabaseFilter",
+      "id": "DatabaseFilter",
+      "description": "Filters a protein database (FASTA format) based on identified proteins",
+      "tool_shed_repository": "openms_databasefilter",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/openms_databasefilter/DatabaseFilter/2.6+galaxy0"
+    },
+    {
+      "name": "DeMeanderize",
+      "id": "DeMeanderize",
+      "description": "Orders the spectra of MALDI spotting plates correctly.",
+      "tool_shed_repository": "openms_demeanderize",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/openms_demeanderize/DeMeanderize/2.6+galaxy0"
+    },
+    {
+      "name": "FeatureFinderSuperHirn",
+      "id": "FeatureFinderSuperHirn",
+      "description": "Finds mass spectrometric features in mass spectra.",
+      "tool_shed_repository": "openms_featurefindersuperhirn",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/openms_featurefindersuperhirn/FeatureFinderSuperHirn/2.6+galaxy0"
+    },
+    {
+      "name": "OpenSwathMzMLFileCacher",
+      "id": "OpenSwathMzMLFileCacher",
+      "description": "This tool caches the spectra and chromatogram data of an mzML to disk.",
+      "tool_shed_repository": "openms_openswathmzmlfilecacher",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/openms_openswathmzmlfilecacher/OpenSwathMzMLFileCacher/2.6+galaxy0"
+    },
+    {
+      "name": "OpenSwathRewriteToFeatureXML",
+      "id": "OpenSwathRewriteToFeatureXML",
+      "description": "Combines featureXML and mProphet tsv to FDR filtered featureXML.",
+      "tool_shed_repository": "openms_openswathrewritetofeaturexml",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/openms_openswathrewritetofeaturexml/OpenSwathRewriteToFeatureXML/2.6+galaxy0"
+    },
+    {
+      "name": "IDPosteriorErrorProbability",
+      "id": "IDPosteriorErrorProbability",
+      "description": "Estimates probabilities for incorrectly assigned peptide sequences and a set of search engine scores using a mixture model.",
+      "tool_shed_repository": "openms_idposteriorerrorprobability",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/openms_idposteriorerrorprobability/IDPosteriorErrorProbability/2.6+galaxy0"
+    },
+    {
+      "name": "IDFileConverter",
+      "id": "IDFileConverter",
+      "description": "Converts identification engine file formats.",
+      "tool_shed_repository": "openms_idfileconverter",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/openms_idfileconverter/IDFileConverter/2.6+galaxy0"
+    },
+    {
+      "name": "IDScoreSwitcher",
+      "id": "IDScoreSwitcher",
+      "description": "Switches between different scores of peptide or protein hits in identification data",
+      "tool_shed_repository": "openms_idscoreswitcher",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/openms_idscoreswitcher/IDScoreSwitcher/2.6+galaxy0"
+    },
+    {
+      "name": "MapAlignerTreeGuided",
+      "id": "MapAlignerTreeGuided",
+      "description": "Tree guided correction of retention time distortions between maps.",
+      "tool_shed_repository": "openms_mapalignertreeguided",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/openms_mapalignertreeguided/MapAlignerTreeGuided/2.6+galaxy0"
+    },
+    {
+      "name": "MapNormalizer",
+      "id": "MapNormalizer",
+      "description": "Normalizes peak intensities in an MS run.",
+      "tool_shed_repository": "openms_mapnormalizer",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/openms_mapnormalizer/MapNormalizer/2.6+galaxy0"
+    },
+    {
+      "name": "MascotAdapter",
+      "id": "MascotAdapter",
+      "description": "Annotates MS/MS spectra using Mascot.",
+      "tool_shed_repository": "openms_mascotadapter",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/openms_mascotadapter/MascotAdapter/2.6+galaxy0"
+    },
+    {
+      "name": "MetaboliteAdductDecharger",
+      "id": "MetaboliteAdductDecharger",
+      "description": "Decharges and merges different feature charge variants of the same metabolite.",
+      "tool_shed_repository": "openms_metaboliteadductdecharger",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/openms_metaboliteadductdecharger/MetaboliteAdductDecharger/2.6+galaxy0"
+    },
+    {
+      "name": "MRMPairFinder",
+      "id": "MRMPairFinder",
+      "description": "Util which can be used to evaluate labeled pair ratios on MRM features.",
+      "tool_shed_repository": "openms_mrmpairfinder",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/openms_mrmpairfinder/MRMPairFinder/2.6+galaxy0"
+    },
+    {
+      "name": "MSstatsConverter",
+      "id": "MSstatsConverter",
+      "description": "Converter to input for MSstats",
+      "tool_shed_repository": "openms_msstatsconverter",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/openms_msstatsconverter/MSstatsConverter/2.6+galaxy0"
+    },
+    {
+      "name": "MzTabExporter",
+      "id": "MzTabExporter",
+      "description": "Exports various XML formats to an mzTab file.",
+      "tool_shed_repository": "openms_mztabexporter",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/openms_mztabexporter/MzTabExporter/2.6+galaxy0"
+    },
+    {
+      "name": "NoiseFilterGaussian",
+      "id": "NoiseFilterGaussian",
+      "description": "Removes noise from profile spectra by using Gaussian filter (on uniform as well as non-uniform data).",
+      "tool_shed_repository": "openms_noisefiltergaussian",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/openms_noisefiltergaussian/NoiseFilterGaussian/2.6+galaxy0"
+    },
+    {
+      "name": "NoiseFilterSGolay",
+      "id": "NoiseFilterSGolay",
+      "description": "Removes noise from profile spectra by using a Savitzky Golay filter. Requires uniform (equidistant) data.",
+      "tool_shed_repository": "openms_noisefiltersgolay",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/openms_noisefiltersgolay/NoiseFilterSGolay/2.6+galaxy0"
+    },
+    {
+      "name": "OpenPepXLLF",
+      "id": "OpenPepXLLF",
+      "description": "Tool for protein-protein cross linking with label-free linkers.",
+      "tool_shed_repository": "openms_openpepxllf",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/openms_openpepxllf/OpenPepXLLF/2.6+galaxy0"
+    },
+    {
+      "name": "OpenSwathChromatogramExtractor",
+      "id": "OpenSwathChromatogramExtractor",
+      "description": "Extract chromatograms (XIC) from a MS2 map file.",
+      "tool_shed_repository": "openms_openswathchromatogramextractor",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/openms_openswathchromatogramextractor/OpenSwathChromatogramExtractor/2.6+galaxy0"
+    },
+    {
+      "name": "OpenSwathAnalyzer",
+      "id": "OpenSwathAnalyzer",
+      "description": "Picks peaks and finds features in an SWATH-MS or SRM experiment.",
+      "tool_shed_repository": "openms_openswathanalyzer",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/openms_openswathanalyzer/OpenSwathAnalyzer/2.6+galaxy0"
+    },
+    {
+      "name": "OpenSwathFileSplitter",
+      "id": "OpenSwathFileSplitter",
+      "description": "Splits SWATH files into n files, each containing one window.",
+      "tool_shed_repository": "openms_openswathfilesplitter",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/openms_openswathfilesplitter/OpenSwathFileSplitter/2.6+galaxy0"
+    },
+    {
+      "name": "OpenSwathRTNormalizer",
+      "id": "OpenSwathRTNormalizer",
+      "description": "This tool will take a description of RT peptides and their normalized retention time to write out a transformation file on how to transform the RT space into the normalized space.",
+      "tool_shed_repository": "openms_openswathrtnormalizer",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/openms_openswathrtnormalizer/OpenSwathRTNormalizer/2.6+galaxy0"
+    },
+    {
+      "name": "PhosphoScoring",
+      "id": "PhosphoScoring",
+      "description": "Scores potential phosphorylation sites in order to localize the most probable sites.",
+      "tool_shed_repository": "openms_phosphoscoring",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/openms_phosphoscoring/PhosphoScoring/2.6+galaxy0"
+    },
+    {
+      "name": "HighResPrecursorMassCorrector",
+      "id": "HighResPrecursorMassCorrector",
+      "description": "Corrects the precursor mass and charge determined by the instrument software.",
+      "tool_shed_repository": "openms_highresprecursormasscorrector",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/openms_highresprecursormasscorrector/HighResPrecursorMassCorrector/2.6+galaxy0"
+    },
+    {
+      "name": "PrecursorMassCorrector",
+      "id": "PrecursorMassCorrector",
+      "description": "Corrects the precursor entries of MS/MS spectra, by using MS1 information.",
+      "tool_shed_repository": "openms_precursormasscorrector",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/openms_precursormasscorrector/PrecursorMassCorrector/2.6+galaxy0"
+    },
+    {
+      "name": "QCCalculator",
+      "id": "QCCalculator",
+      "description": "Calculates basic quality parameters from MS experiments and subsequent analysis data as identification or feature detection.",
+      "tool_shed_repository": "openms_qccalculator",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/openms_qccalculator/QCCalculator/2.6+galaxy0"
+    },
+    {
+      "name": "CruxAdapter",
+      "id": "CruxAdapter",
+      "description": "Identifies MS/MS spectra using Crux.",
+      "tool_shed_repository": "openms_cruxadapter",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/openms_cruxadapter/CruxAdapter/2.6+galaxy0"
+    },
+    {
+      "name": "ConsensusMapNormalizer",
+      "id": "ConsensusMapNormalizer",
+      "description": "Normalizes maps of one consensusXML file",
+      "tool_shed_repository": "openms_consensusmapnormalizer",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/openms_consensusmapnormalizer/ConsensusMapNormalizer/2.6+galaxy0"
+    },
+    {
+      "name": "QCImporter",
+      "id": "QCImporter",
+      "description": "Imports tables with quality control parameters into qcml files.",
+      "tool_shed_repository": "openms_qcimporter",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/openms_qcimporter/QCImporter/2.6+galaxy0"
+    },
+    {
+      "name": "SpectraFilterScaler",
+      "id": "SpectraFilterScaler",
+      "description": "Applies thresholdfilter to peak spectra.",
+      "tool_shed_repository": "openms_spectrafilterscaler",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/openms_spectrafilterscaler/SpectraFilterScaler/2.6+galaxy0"
+    },
+    {
+      "name": "QCShrinker",
+      "id": "QCShrinker",
+      "description": "This application is used to remove the verbose table attachments from a qcml file that are not needed anymore, e.g. for a final report.",
+      "tool_shed_repository": "openms_qcshrinker",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/openms_qcshrinker/QCShrinker/2.6+galaxy0"
+    },
+    {
+      "name": "QCExtractor",
+      "id": "QCExtractor",
+      "description": "Extracts a table attachment to a given qc parameter.",
+      "tool_shed_repository": "openms_qcextractor",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/openms_qcextractor/QCExtractor/2.6+galaxy0"
+    },
+    {
+      "name": "ProteinResolver",
+      "id": "ProteinResolver",
+      "description": "protein inference",
+      "tool_shed_repository": "openms_proteinresolver",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/openms_proteinresolver/ProteinResolver/2.6+galaxy0"
+    },
+    {
+      "name": "IDExtractor",
+      "id": "IDExtractor",
+      "description": "Extracts 'n' peptides randomly or best 'n' from idXML files.",
+      "tool_shed_repository": "openms_idextractor",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/openms_idextractor/IDExtractor/2.5+galaxy0"
+    },
+    {
+      "name": "LowMemPeakPickerHiRes",
+      "id": "LowMemPeakPickerHiRes",
+      "description": "Finds mass spectrometric peaks in profile mass spectra.",
+      "tool_shed_repository": "openms_lowmempeakpickerhires",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/openms_lowmempeakpickerhires/LowMemPeakPickerHiRes/2.5+galaxy0"
+    },
+    {
+      "name": "LowMemPeakPickerHiResRandomAccess",
+      "id": "LowMemPeakPickerHiResRandomAccess",
+      "description": "Finds mass spectrometric peaks in profile mass spectra.",
+      "tool_shed_repository": "openms_lowmempeakpickerhiresrandomaccess",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/openms_lowmempeakpickerhiresrandomaccess/LowMemPeakPickerHiResRandomAccess/2.5+galaxy0"
+    },
+    {
+      "name": "MT2MQ",
+      "id": "mt2mq",
+      "description": "Tool to prepare metatranscriptomic outputs from ASaiM for Metaquantome",
+      "tool_shed_repository": "mt2mq",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/mt2mq/mt2mq/1.1.0"
+    },
+    {
+      "name": "PyProphet export",
+      "id": "pyprophet_export",
+      "description": "Export tabular files, optional swath2stats export",
+      "tool_shed_repository": "pyprophet_export",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/pyprophet_export/pyprophet_export/2.1.4.1"
+    },
+    {
+      "name": "moFF",
+      "id": "proteomics_moff",
+      "description": "extracts MS1 intensities from spectrum files",
+      "tool_shed_repository": "proteomics_moff",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/proteomics_moff/proteomics_moff/2.0.3.0"
+    },
+    {
+      "name": "Unipept",
+      "id": "unipept",
+      "description": "retrieve taxonomy for peptides",
+      "tool_shed_repository": "unipept",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/unipept/unipept/4.3.0"
+    },
+    {
+      "name": "MALDIquant peak detection",
+      "id": "maldi_quant_peak_detection",
+      "description": "Peak detection, binning and filtering for mass-spectrometry imaging data",
+      "tool_shed_repository": "maldi_quant_peak_detection",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/maldi_quant_peak_detection/maldi_quant_peak_detection/1.18.0.6"
+    },
+    {
+      "name": "PyProphet score",
+      "id": "pyprophet_score",
+      "description": "Error-rate estimation for MS1, MS2 and transition-level data",
+      "tool_shed_repository": "pyprophet_score",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/pyprophet_score/pyprophet_score/2.1.4.2"
+    },
+    {
+      "name": "Kronik",
+      "id": "kronik",
+      "description": "processes Hardklor features to find peptides by chromatographic profiling",
+      "tool_shed_repository": "hardklor",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/hardklor/kronik/2.20+galaxy1"
+    },
+    {
+      "name": "Hardklor",
+      "id": "hardklor",
+      "description": "identification of features from mass spectra",
+      "tool_shed_repository": "hardklor",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/hardklor/hardklor/2.30.1+galaxy1"
+    },
+    {
+      "name": "diapysef library generation",
+      "id": "diapysef",
+      "description": "generates spectral library for DIA analysis",
+      "tool_shed_repository": "diapysef",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/diapysef/diapysef/0.3.5.0"
+    },
+    {
+      "name": "PyProphet merge",
+      "id": "pyprophet_merge",
+      "description": "Merge multiple osw files",
+      "tool_shed_repository": "pyprophet_merge",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/pyprophet_merge/pyprophet_merge/2.1.4.0"
+    },
+    {
+      "name": "PyProphet peptide",
+      "id": "pyprophet_peptide",
+      "description": "Peptide error-rate estimation",
+      "tool_shed_repository": "pyprophet_peptide",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/pyprophet_peptide/pyprophet_peptide/2.1.4.0"
+    },
+    {
+      "name": "PyProphet protein",
+      "id": "pyprophet_protein",
+      "description": "Protein error-rate estimation",
+      "tool_shed_repository": "pyprophet_protein",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/pyprophet_protein/pyprophet_protein/2.1.4.0"
+    },
+    {
+      "name": "PyProphet subsample",
+      "id": "pyprophet_subsample",
+      "description": "Subsample OpenSWATH file",
+      "tool_shed_repository": "pyprophet_subsample",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/pyprophet_subsample/pyprophet_subsample/2.1.4.0"
+    },
+    {
+      "name": "FlashLFQ",
+      "id": "flashlfq",
+      "description": "ultrafast label-free quantification for mass-spectrometry proteomics",
+      "tool_shed_repository": "flashlfq",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/flashlfq/flashlfq/1.0.3.0"
+    },
+    {
+      "name": "QuantWiz-IQ",
+      "id": "quantwiz_iq",
+      "description": "Isobaric Quantitation using QuantWiz-IQ",
+      "tool_shed_repository": "quantwiz_iq",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/quantwiz_iq/quantwiz_iq/2.0"
+    },
+    {
+      "name": "Pathway Matcher",
+      "id": "reactome_pathwaymatcher",
+      "description": "PathwayMatcher is a software tool to search for pathways related to a list of proteins in Reactome.",
+      "tool_shed_repository": "reactome_pathwaymatcher",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/reactome_pathwaymatcher/reactome_pathwaymatcher/1.9.1.3"
+    },
+    {
+      "name": "Raw Tools",
+      "id": "rawtools",
+      "description": "Perform scan data parsing, quantification and quality control analysis of Thermo Orbitrap raw mass spectrometer files.",
+      "tool_shed_repository": "rawtools",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/rawtools/rawtools/1.4.2.0"
+    },
+    {
+      "name": "DIA_Umpire_SE",
+      "id": "dia_umpire_se",
+      "description": "DIA signal extraction",
+      "tool_shed_repository": "dia_umpire",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/dia_umpire/dia_umpire_se/2.1.3.0"
+    },
+    {
+      "name": "CustomProDB",
+      "id": "custom_pro_db",
+      "description": "Generate protein FASTAs from exosome or transcriptome data",
+      "tool_shed_repository": "custom_pro_db",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/custom_pro_db/custom_pro_db/1.22.0"
+    },
+    {
+      "name": "QuanTP",
+      "id": "quantp",
+      "description": "Correlation between protein and transcript abundances",
+      "tool_shed_repository": "quantp",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/quantp/quantp/1.1.2"
+    },
+    {
+      "name": "MALDIquant preprocessing",
+      "id": "maldi_quant_preprocessing",
+      "description": "Preprocessing of mass-spectrometry imaging data",
+      "tool_shed_repository": "maldi_quant_preprocessing",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/maldi_quant_preprocessing/maldi_quant_preprocessing/1.18.0.3"
+    },
+    {
+      "name": "PepPointer",
+      "id": "pep_pointer",
+      "description": "classify genomic location of peptides",
+      "tool_shed_repository": "pep_pointer",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/pep_pointer/pep_pointer/0.1.3"
+    },
+    {
+      "name": "megahit contig2fastg",
+      "id": "megahit_contig2fastg",
+      "description": "for converting MEGAHIT's contigs (.fa) to assembly graphs (.fastg)",
+      "tool_shed_repository": "megahit_contig2fastg",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/megahit_contig2fastg/megahit_contig2fastg/1.1.3+galaxy1"
+    },
+    {
+      "name": "Search engine output to Pin converter",
+      "id": "percolator_input_converters",
+      "description": "to create Percolator input files",
+      "tool_shed_repository": "percolator",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/percolator/percolator_input_converters/3.1"
+    },
+    {
+      "name": "Percolator",
+      "id": "percolator",
+      "description": "accurate peptide identification",
+      "tool_shed_repository": "percolator",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/percolator/percolator/3.1.0"
+    },
+    {
+      "name": "Pout2mzid",
+      "id": "pout2mzid",
+      "description": "add Percolator scoring to mzIdentML",
+      "tool_shed_repository": "percolator",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/percolator/pout2mzid/0.3.03"
+    },
+    {
+      "name": "Create nested list",
+      "id": "batched_set_list_creator",
+      "description": "based on filenames and batch sizes",
+      "tool_shed_repository": "percolator",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/percolator/batched_set_list_creator/3.3"
+    },
+    {
+      "name": "Label free protein",
+      "id": "lfq_protein_quant",
+      "description": "summarisation and quantitation",
+      "tool_shed_repository": "lfq_protein_quant",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/lfq_protein_quant/lfq_protein_quant/1.0"
+    },
+    {
+      "name": "MS-GF+",
+      "id": "msgfplus",
+      "description": "Identifies peptides in tandem mass spectra using the MS-GF+ search engine.",
+      "tool_shed_repository": "msgfplus",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/msgfplus/msgfplus/0.5"
+    },
+    {
+      "name": "Protease prediction",
+      "id": "eden_protease_prediction",
+      "description": "based on cleavage sites",
+      "tool_shed_repository": "protease_prediction",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/protease_prediction/eden_protease_prediction/0.9"
+    },
+    {
+      "name": "Calculate protein properties",
+      "id": "bg_protein_properties",
+      "description": "",
+      "tool_shed_repository": "protein_properties",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/protein_properties/bg_protein_properties/0.1.0"
+    },
+    {
+      "name": "RTPredict",
+      "id": "RTPredict",
+      "description": "Predicts retention times for peptides using a model trained by RTModel.",
+      "tool_shed_repository": "openms_rtpredict",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/openms_rtpredict/RTPredict/2.3.0"
+    },
+    {
+      "name": "PTPredict",
+      "id": "PTPredict",
+      "description": "predicts the likelihood of peptides to be proteotypic via svm_model which is trained by PTModel",
+      "tool_shed_repository": "openms_ptpredict",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/openms_ptpredict/PTPredict/2.3.0"
+    },
+    {
+      "name": "InspectAdapter",
+      "id": "InspectAdapter",
+      "description": "Annotates MS/MS spectra using Inspect.",
+      "tool_shed_repository": "openms_inspectadapter",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/openms_inspectadapter/InspectAdapter/2.3.0"
+    },
+    {
+      "name": "InclusionExclusionListCreator",
+      "id": "InclusionExclusionListCreator",
+      "description": "Creates inclusion and/or exclusion lists.",
+      "tool_shed_repository": "openms_inclusionexclusionlistcreator",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/openms_inclusionexclusionlistcreator/InclusionExclusionListCreator/2.3.0"
+    },
+    {
+      "name": "LowMemPeakPickerHiResRandomAccess",
+      "id": "LowMemPeakPickerHiRes_RandomAccess",
+      "description": "Finds mass spectrometric peaks in profile mass spectra.",
+      "tool_shed_repository": "openms_lowmempeakpickerhires_randomaccess",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/openms_lowmempeakpickerhires_randomaccess/LowMemPeakPickerHiRes_RandomAccess/2.3.0"
+    },
+    {
+      "name": "IDDecoyProbability",
+      "id": "IDDecoyProbability",
+      "description": "Estimates peptide probabilities using a decoy search strategy.WARNING: This util is deprecated.",
+      "tool_shed_repository": "openms_iddecoyprobability",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/openms_iddecoyprobability/IDDecoyProbability/2.3.0"
+    },
+    {
+      "name": "RNPxl",
+      "id": "RNPxl",
+      "description": "Tool for RNP cross linking experiment analysis.",
+      "tool_shed_repository": "openms_rnpxl",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/openms_rnpxl/RNPxl/2.3.0"
+    },
+    {
+      "name": "AdditiveSeries",
+      "id": "AdditiveSeries",
+      "description": "Computes an additive series to quantify a peptide in a set of samples.",
+      "tool_shed_repository": "openms_additiveseries",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/openms_additiveseries/AdditiveSeries/2.3.0"
+    },
+    {
+      "name": "TopPerc",
+      "id": "TopPerc",
+      "description": "Facilitate input to Percolator and reintegrate.",
+      "tool_shed_repository": "openms_topperc",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/openms_topperc/TopPerc/2.2.0.1"
+    },
+    {
+      "name": "Protease prediction",
+      "id": "eden_protease_prediction",
+      "description": "based on cleavage sites",
+      "tool_shed_repository": "protease_prediction",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "testtoolshed.g2.bx.psu.edu/repos/bgruening/protease_prediction/eden_protease_prediction/0.9"
+    },
+    {
+      "name": "Create Decoy Database (reverse)",
+      "id": "decoyfasta",
+      "description": "Creates a decoy search database by adding reverse    sequences to an existing database",
+      "tool_shed_repository": "decoyfasta",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/decoyfasta/decoyfasta/0.2.0"
+    },
+    {
+      "name": "Morpheus",
+      "id": "morpheus",
+      "description": "database search algorithm for high-resolution tandem mass spectra",
+      "tool_shed_repository": "morpheus",
+      "panel_section_name": "Proteomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/morpheus/morpheus/2.255.0"
+    },
+    {
+      "name": "metaMS.runGC",
+      "id": "metams_runGC",
+      "description": "GC-MS data preprocessing using metaMS package",
+      "tool_shed_repository": "metams_rungc",
+      "panel_section_name": "Metabolomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/yguitton/metams_rungc/metams_runGC/3.0.0+metaMS1.24.0-galaxy0"
+    },
+    {
+      "name": "Isoplot: Generate plots from isocor output",
+      "id": "isoplot",
+      "description": "",
+      "tool_shed_repository": "isoplot",
+      "panel_section_name": "Metabolomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/workflow4metabolomics/isoplot/isoplot/1.3.0+galaxy1"
+    },
+    {
+      "name": "xcms refineChromPeaks (refine)",
+      "id": "abims_xcms_refine",
+      "description": "Remove or merge chromatographic peaks based on specific criteria.",
+      "tool_shed_repository": "xcms_refine",
+      "panel_section_name": "Metabolomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/workflow4metabolomics/xcms_refine/abims_xcms_refine/3.12.0+galaxy0"
+    },
+    {
+      "name": "W4m Data Subset",
+      "id": "w4mclassfilter",
+      "description": "Filter W4M data by values or metadata",
+      "tool_shed_repository": "w4mclassfilter",
+      "panel_section_name": "Metabolomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/eschen42/w4mclassfilter/w4mclassfilter/0.98.19"
+    },
+    {
+      "name": "Align Samples",
+      "id": "dimspy_align_samples",
+      "description": "- Align peaks across Peaklists",
+      "tool_shed_repository": "dimspy_align_samples",
+      "panel_section_name": "Metabolomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/computational-metabolomics/dimspy_align_samples/dimspy_align_samples/2.0.0+galaxy1"
+    },
+    {
+      "name": "Replicate Filter",
+      "id": "dimspy_replicate_filter",
+      "description": "- Remove peaks that fail to appear in at least x-out-of-n (technical) replicates",
+      "tool_shed_repository": "dimspy_replicate_filter",
+      "panel_section_name": "Metabolomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/computational-metabolomics/dimspy_replicate_filter/dimspy_replicate_filter/2.0.0+galaxy1"
+    },
+    {
+      "name": "Process Scans (and SIM-Stitch)",
+      "id": "dimspy_process_scans",
+      "description": "- Read, filter and average MS scans",
+      "tool_shed_repository": "dimspy_process_scans",
+      "panel_section_name": "Metabolomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/computational-metabolomics/dimspy_process_scans/dimspy_process_scans/2.0.0+galaxy1"
+    },
+    {
+      "name": "MetFrag Vis",
+      "id": "metfrag_vis",
+      "description": "Visualisation for MetFrag results",
+      "tool_shed_repository": "metfrag_vis",
+      "panel_section_name": "Metabolomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/computational-metabolomics/metfrag_vis/metfrag_vis/2.4.5+galaxy0"
+    },
+    {
+      "name": "OPLS-DA_Contrasts",
+      "id": "w4mcorcov",
+      "description": "OPLS-DA Contrasts of Univariate Results",
+      "tool_shed_repository": "w4mcorcov",
+      "panel_section_name": "Metabolomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/eschen42/w4mcorcov/w4mcorcov/0.98.18"
+    },
+    {
+      "name": "Get peaklists",
+      "id": "dimspy_get_peaklists",
+      "description": "or an average peaklist from a Peak Intensity Matrix",
+      "tool_shed_repository": "dimspy_get_peaklists",
+      "panel_section_name": "Metabolomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/computational-metabolomics/dimspy_get_peaklists/dimspy_get_peaklists/2.0.0+galaxy0"
+    },
+    {
+      "name": "Convert DIMSpy-based HDF5 to tsv",
+      "id": "dimspy_hdf5_to_txt",
+      "description": "",
+      "tool_shed_repository": "dimspy_hdf5_to_txt",
+      "panel_section_name": "Metabolomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/computational-metabolomics/dimspy_hdf5_to_txt/dimspy_hdf5_to_txt/2.0.0+galaxy0"
+    },
+    {
+      "name": "Missing Values Sample Filter",
+      "id": "dimspy_missing_values_sample_filter",
+      "description": "- Remove samples with a high percentage of missing values",
+      "tool_shed_repository": "dimspy_missing_values_sample_filter",
+      "panel_section_name": "Metabolomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/computational-metabolomics/dimspy_missing_values_sample_filter/dimspy_missing_values_sample_filter/2.0.0+galaxy0"
+    },
+    {
+      "name": "Sample Filter",
+      "id": "dimspy_sample_filter",
+      "description": "Remove peaks that fail to appear in x-out-of-n (biological) samples",
+      "tool_shed_repository": "dimspy_sample_filter",
+      "panel_section_name": "Metabolomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/computational-metabolomics/dimspy_sample_filter/dimspy_sample_filter/2.0.0+galaxy0"
+    },
+    {
+      "name": "Blank Filter",
+      "id": "dimspy_blank_filter",
+      "description": "- Remove 'blank' peaks from the biological mass spectra",
+      "tool_shed_repository": "dimspy_blank_filter",
+      "panel_section_name": "Metabolomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/computational-metabolomics/dimspy_blank_filter/dimspy_blank_filter/2.0.0+galaxy0"
+    },
+    {
+      "name": "SIRIUS-CSI:FingerID",
+      "id": "sirius_csifingerid",
+      "description": "is used to identify metabolites using single and        tandem mass spectrometry",
+      "tool_shed_repository": "sirius_csifingerid",
+      "panel_section_name": "Metabolomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/computational-metabolomics/sirius_csifingerid/sirius_csifingerid/4.0.1+galaxy2"
+    },
+    {
+      "name": "MetFrag",
+      "id": "metfrag",
+      "description": "in silico fragmentor for compound annotation of mass spectrometry fragmentation spectra",
+      "tool_shed_repository": "metfrag",
+      "panel_section_name": "Metabolomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/computational-metabolomics/metfrag/metfrag/2.4.5+galaxy1"
+    },
+    {
+      "name": "msPurity.spectralMatching",
+      "id": "mspurity_spectralmatching",
+      "description": "Perform spectral matching to MS/MS spectral libraries",
+      "tool_shed_repository": "mspurity_spectralmatching",
+      "panel_section_name": "Metabolomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/computational-metabolomics/mspurity_spectralmatching/mspurity_spectralmatching/1.12.0+galaxy1"
+    },
+    {
+      "name": "msPurity.purityX",
+      "id": "mspurity_purityx",
+      "description": "Calculate the anticipated precursor ion purity from a LC-MS XCMS dataset.",
+      "tool_shed_repository": "mspurity_purityx",
+      "panel_section_name": "Metabolomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/computational-metabolomics/mspurity_purityx/mspurity_purityx/1.12.0+galaxy1"
+    },
+    {
+      "name": "msPurity.dimsPredictPuritySingle",
+      "id": "mspurity_dimspredictpuritysingle",
+      "description": "Calculate the anticipated precursor ion purity from a DIMS dataset.",
+      "tool_shed_repository": "mspurity_dimspredictpuritysingle",
+      "panel_section_name": "Metabolomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/computational-metabolomics/mspurity_dimspredictpuritysingle/mspurity_dimspredictpuritysingle/1.12.0+galaxy1"
+    },
+    {
+      "name": "Merge peaklists",
+      "id": "dimspy_merge_peaklists",
+      "description": "produced by the tools 'Process scans (and SIM-Stitch)' or 'Replicate filter'",
+      "tool_shed_repository": "dimspy_merge_peaklists",
+      "panel_section_name": "Metabolomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/computational-metabolomics/dimspy_merge_peaklists/dimspy_merge_peaklists/2.0.0+galaxy0"
+    },
+    {
+      "name": "msPurity.createMSP",
+      "id": "mspurity_createmsp",
+      "description": "Create MSP files from msPurity processed data",
+      "tool_shed_repository": "mspurity_createmsp",
+      "panel_section_name": "Metabolomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/computational-metabolomics/mspurity_createmsp/mspurity_createmsp/1.12.0+galaxy1"
+    },
+    {
+      "name": "msPurity.createDatabase",
+      "id": "mspurity_createdatabase",
+      "description": "Create and SQLite database of an LC-MS(/MS) experiment",
+      "tool_shed_repository": "mspurity_createdatabase",
+      "panel_section_name": "Metabolomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/computational-metabolomics/mspurity_createdatabase/mspurity_createdatabase/1.12.0+galaxy1"
+    },
+    {
+      "name": "msPurity.averageFragSpectra",
+      "id": "mspurity_averagefragspectra",
+      "description": "Average and filter LC-MS/MS fragmentation spectra (Inter, Intra or All)",
+      "tool_shed_repository": "mspurity_averagefragspectra",
+      "panel_section_name": "Metabolomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/computational-metabolomics/mspurity_averagefragspectra/mspurity_averagefragspectra/1.12.0+galaxy1"
+    },
+    {
+      "name": "msPurity.filterFragSpectra",
+      "id": "mspurity_filterfragspectra",
+      "description": "Filter fragmentations spectra associated with an XCMS feature",
+      "tool_shed_repository": "mspurity_filterfragspectra",
+      "panel_section_name": "Metabolomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/computational-metabolomics/mspurity_filterfragspectra/mspurity_filterfragspectra/1.12.0+galaxy1"
+    },
+    {
+      "name": "msPurity.frag4feature",
+      "id": "mspurity_frag4feature",
+      "description": "Assign fragmentation spectra to XCMS features using msPurity",
+      "tool_shed_repository": "mspurity_frag4feature",
+      "panel_section_name": "Metabolomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/computational-metabolomics/mspurity_frag4feature/mspurity_frag4feature/1.12.0+galaxy1"
+    },
+    {
+      "name": "msPurity.purityA",
+      "id": "mspurity_puritya",
+      "description": "Assess acquired precursor ion purity of MS/MS spectra",
+      "tool_shed_repository": "mspurity_puritya",
+      "panel_section_name": "Metabolomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/computational-metabolomics/mspurity_puritya/mspurity_puritya/1.12.0+galaxy1"
+    },
+    {
+      "name": "msPurity.flagRemove",
+      "id": "mspurity_flagremove",
+      "description": "Tool to flag and remove XCMS grouped peaks from the xcmsSet object based on various thresholds        (e.g. RSD of intensity and retention time).",
+      "tool_shed_repository": "mspurity_flagremove",
+      "panel_section_name": "Metabolomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/computational-metabolomics/mspurity_flagremove/mspurity_flagremove/1.12.0+galaxy1"
+    },
+    {
+      "name": "Heatmap",
+      "id": "Heatmap",
+      "description": "Heatmap of the dataMatrix",
+      "tool_shed_repository": "heatmap",
+      "panel_section_name": "Statistics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/ethevenot/heatmap/Heatmap/2.2.2"
+    },
+    {
+      "name": "genform",
+      "id": "genform",
+      "description": "Generation of molecular formulas by high-resolution MS and MS/MS data",
+      "tool_shed_repository": "genform",
+      "panel_section_name": "Metabolomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/workflow4metabolomics/genform/genform/8"
+    },
+    {
+      "name": "NMR_Annotation",
+      "id": "NmrAnnotation",
+      "description": "Annotation of complex mixture NMR spectra and metabolite proportion estimation",
+      "tool_shed_repository": "nmr_annotation",
+      "panel_section_name": "Metabolomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/marie-tremblay-metatoul/nmr_annotation/NmrAnnotation/3.0.0"
+    },
+    {
+      "name": "xcms get a sampleMetadata file",
+      "id": "xcms_export_samplemetadata",
+      "description": "which need to be filled with extra information",
+      "tool_shed_repository": "xcms_export_samplemetadata",
+      "panel_section_name": "Metabolomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/lecorguille/xcms_export_samplemetadata/xcms_export_samplemetadata/3.4.4.0"
+    },
+    {
+      "name": "Table Merge",
+      "id": "tablemerge",
+      "description": "Merging dataMatrix with a metadata table",
+      "tool_shed_repository": "tablemerge",
+      "panel_section_name": "Metabolomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/melpetera/tablemerge/tablemerge/1.0.1"
+    },
+    {
+      "name": "Intensity Check",
+      "id": "intens_check",
+      "description": "Statistical measures, number of missing values and mean fold change",
+      "tool_shed_repository": "intensity_checks",
+      "panel_section_name": "Metabolomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/melpetera/intensity_checks/intens_check/1.2.1"
+    },
+    {
+      "name": "ID choice",
+      "id": "idchoice",
+      "description": "Choosing a particular column in your metadata to be considered as Identifiers",
+      "tool_shed_repository": "idchoice",
+      "panel_section_name": "Metabolomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/melpetera/idchoice/idchoice/18.01"
+    },
+    {
+      "name": "Normalization",
+      "id": "normalization",
+      "description": "Normalization of (preprocessed) spectra",
+      "tool_shed_repository": "normalization",
+      "panel_section_name": "Metabolomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/marie-tremblay-metatoul/normalization/normalization/2.0.1"
+    },
+    {
+      "name": "mixmodel",
+      "id": "mixmodel",
+      "description": "ANOVA for repeated measures statistics",
+      "tool_shed_repository": "mixmodel4repeated_measures",
+      "panel_section_name": "Metabolomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/jfrancoismartin/mixmodel4repeated_measures/mixmodel/1.0.0"
+    },
+    {
+      "name": "ASCA",
+      "id": "asca",
+      "description": "Splitting of the total variance into independent blocks according to the experimental factors and multivariate analysis (SCA) of each block",
+      "tool_shed_repository": "asca",
+      "panel_section_name": "Metabolomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/marie-tremblay-metatoul/asca/asca/1.0.0"
+    },
+    {
+      "name": "Between-table Correlation",
+      "id": "corrtable",
+      "description": "Correlation table between two tables and graphic representation",
+      "tool_shed_repository": "corr_table",
+      "panel_section_name": "Metabolomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/melpetera/corr_table/corrtable/0.0.0"
+    },
+    {
+      "name": "HMDB MS search",
+      "id": "wsdl_hmdb",
+      "description": "search by masses on HMDB online LCMS bank",
+      "tool_shed_repository": "hmdb_ms_search",
+      "panel_section_name": "Metabolomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/fgiacomoni/hmdb_ms_search/wsdl_hmdb/1.6.1"
+    },
+    {
+      "name": "bank_inhouse",
+      "id": "bank_inhouse",
+      "description": "search by accurate mass (and by Retention time) on a local bank",
+      "tool_shed_repository": "bank_inhouse",
+      "panel_section_name": "Metabolomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/fgiacomoni/bank_inhouse/bank_inhouse/1.2.1"
+    },
+    {
+      "name": "LCMS matching",
+      "id": "lcmsmatching",
+      "description": "Annotation of LCMS peaks using matching on a in-house spectra database or on PeakForest spectra database.",
+      "tool_shed_repository": "lcmsmatching",
+      "panel_section_name": "Metabolomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/prog/lcmsmatching/lcmsmatching/4.0.2"
+    },
+    {
+      "name": "Golm Metabolome Database search spectrum",
+      "id": "golm_ws_lib_search",
+      "description": ": GC-MS Mass Spectral Database.",
+      "tool_shed_repository": "golm_ws_lib_search",
+      "panel_section_name": "Metabolomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/fgiacomoni/golm_ws_lib_search/golm_ws_lib_search/2018-10-01"
+    },
+    {
+      "name": "NMR_Preprocessing",
+      "id": "NMR_Preprocessing",
+      "description": "Preprocessing of 1D NMR spectra",
+      "tool_shed_repository": "nmr_preprocessing",
+      "panel_section_name": "Metabolomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/marie-tremblay-metatoul/nmr_preprocessing/NMR_Preprocessing/3.3.0"
+    },
+    {
+      "name": "NMR_Read",
+      "id": "NMR_Read",
+      "description": "Read Bruker NMR raw files",
+      "tool_shed_repository": "nmr_preprocessing",
+      "panel_section_name": "Metabolomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/marie-tremblay-metatoul/nmr_preprocessing/NMR_Read/3.3.0"
+    },
+    {
+      "name": "xcms process history",
+      "id": "abims_xcms_summary",
+      "description": "Create a summary of XCMS analysis",
+      "tool_shed_repository": "xcms_summary",
+      "panel_section_name": "Metabolomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/lecorguille/xcms_summary/abims_xcms_summary/3.4.4.0"
+    },
+    {
+      "name": "CAMERA.annotate",
+      "id": "abims_CAMERA_annotateDiffreport",
+      "description": "CAMERA annotate function. Returns annotation results (isotope peaks, adducts and fragments) and a diffreport if more than one condition.",
+      "tool_shed_repository": "camera_annotate",
+      "panel_section_name": "Metabolomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/lecorguille/camera_annotate/abims_CAMERA_annotateDiffreport/2.2.4"
+    },
+    {
+      "name": "xcms fillChromPeaks (fillPeaks)",
+      "id": "abims_xcms_fillPeaks",
+      "description": "Integrate areas of missing peaks",
+      "tool_shed_repository": "xcms_fillpeaks",
+      "panel_section_name": "Metabolomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/lecorguille/xcms_fillpeaks/abims_xcms_fillPeaks/3.4.4.0"
+    },
+    {
+      "name": "xcms adjustRtime (retcor)",
+      "id": "abims_xcms_retcor",
+      "description": "Retention Time Correction",
+      "tool_shed_repository": "xcms_retcor",
+      "panel_section_name": "Metabolomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/lecorguille/xcms_retcor/abims_xcms_retcor/3.4.4.1"
+    },
+    {
+      "name": "xcms groupChromPeaks (group)",
+      "id": "abims_xcms_group",
+      "description": "Perform the correspondence, the grouping of chromatographic peaks within and between samples.",
+      "tool_shed_repository": "xcms_group",
+      "panel_section_name": "Metabolomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/lecorguille/xcms_group/abims_xcms_group/3.4.4.0"
+    },
+    {
+      "name": "xcms findChromPeaks Merger",
+      "id": "xcms_merge",
+      "description": "Merge xcms findChromPeaks RData into a unique file to be used by group",
+      "tool_shed_repository": "xcms_merge",
+      "panel_section_name": "Metabolomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/lecorguille/xcms_merge/xcms_merge/3.4.4.0"
+    },
+    {
+      "name": "xcms plot chromatogram",
+      "id": "xcms_plot_chromatogram",
+      "description": "Plots base peak intensity chromatogram (BPI) and total ion current chromatogram (TIC) from MSnbase or xcms experiment(s)",
+      "tool_shed_repository": "xcms_plot_chromatogram",
+      "panel_section_name": "Metabolomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/lecorguille/xcms_plot_chromatogram/xcms_plot_chromatogram/3.4.4.0"
+    },
+    {
+      "name": "xcms findChromPeaks (xcmsSet)",
+      "id": "abims_xcms_xcmsSet",
+      "description": "Chromatographic peak detection",
+      "tool_shed_repository": "xcms_xcmsset",
+      "panel_section_name": "Metabolomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/lecorguille/xcms_xcmsset/abims_xcms_xcmsSet/3.4.4.1"
+    },
+    {
+      "name": "MSnbase readMSData",
+      "id": "msnbase_readmsdata",
+      "description": "Imports mass-spectrometry data files",
+      "tool_shed_repository": "msnbase_readmsdata",
+      "panel_section_name": "Metabolomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/lecorguille/msnbase_readmsdata/msnbase_readmsdata/2.8.2.1"
+    },
+    {
+      "name": "Lipidmaps ",
+      "id": "lipidmaps",
+      "description": ": search on LIPID MAPS Structure Database (LMSD) online with masses and its Text/Ontology-based search engine.",
+      "tool_shed_repository": "lipidmaps_textsearch",
+      "panel_section_name": "Metabolomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/fgiacomoni/lipidmaps_textsearch/lipidmaps/2018-10-02"
+    },
+    {
+      "name": "Join +/- Ions",
+      "id": "w4mjoinpn",
+      "description": "Join positive and negative ionization-mode W4M datasets for the same samples",
+      "tool_shed_repository": "w4mjoinpn",
+      "panel_section_name": "Metabolomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/eschen42/w4mjoinpn/w4mjoinpn/0.98.2"
+    },
+    {
+      "name": "Generic_Filter",
+      "id": "generic_filter",
+      "description": "Removes elements according to numerical or qualitative values",
+      "tool_shed_repository": "generic_filter",
+      "panel_section_name": "Metabolomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/melpetera/generic_filter/generic_filter/2017.06"
+    },
+    {
+      "name": "Quality Metrics",
+      "id": "quality_metrics",
+      "description": "Metrics and graphics to check the quality of the data",
+      "tool_shed_repository": "qualitymetrics",
+      "panel_section_name": "Metabolomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/ethevenot/qualitymetrics/quality_metrics/2.2.8"
+    },
+    {
+      "name": "Multilevel",
+      "id": "mixomics_multilevel",
+      "description": "Data transformation: Within matrix decomposition for repeated measurements (cross-over design) with mixOmics package",
+      "tool_shed_repository": "withinvariation",
+      "panel_section_name": "Metabolomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/yguitton/withinvariation/mixomics_multilevel/0.5.0"
+    },
+    {
+      "name": "Check Format",
+      "id": "checkFormat",
+      "description": "Checking/formatting the sample and variable names of the dataMatrix, sampleMetadata, and variableMetadata files",
+      "tool_shed_repository": "checkformat",
+      "panel_section_name": "Metabolomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/ethevenot/checkformat/checkFormat/3.0.0"
+    },
+    {
+      "name": "Determine_batch_correction",
+      "id": "Determine_BC",
+      "description": "to choose between linear, lowess and loess methods",
+      "tool_shed_repository": "batchcorrection",
+      "panel_section_name": "Metabolomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/melpetera/batchcorrection/Determine_BC/2.1.2"
+    },
+    {
+      "name": "Batch_correction",
+      "id": "Batch_correction",
+      "description": "Corrects intensities for signal drift and batch-effects",
+      "tool_shed_repository": "batchcorrection",
+      "panel_section_name": "Metabolomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/melpetera/batchcorrection/Batch_correction/2.1.2"
+    },
+    {
+      "name": "MassBank spectrum searches",
+      "id": "massbank_ws_searchspectrum",
+      "description": ": Search by pseudo-spectra on a High Quality Mass Spectral Database.",
+      "tool_shed_repository": "massbank_ws_searchspectrum",
+      "panel_section_name": "Metabolomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/fgiacomoni/massbank_ws_searchspectrum/massbank_ws_searchspectrum/2017-02-06"
+    },
+    {
+      "name": "ProbMetab Tool",
+      "id": "Probmetab",
+      "description": "Wrapper function for ProbMetab R package.",
+      "tool_shed_repository": "probmetab",
+      "panel_section_name": "Metabolomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/mmonsoor/probmetab/Probmetab/1.1.0"
+    },
+    {
+      "name": "CAMERA.combinexsAnnos",
+      "id": "abims_CAMERA_combinexsAnnos",
+      "description": "Wrapper function for the combinexsAnnos CAMERA function. Returns a dataframe with recalculated annotations.",
+      "tool_shed_repository": "camera_combinexsannos",
+      "panel_section_name": "Metabolomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/mmonsoor/camera_combinexsannos/abims_CAMERA_combinexsAnnos/2.2.2"
+    },
+    {
+      "name": "proFIA",
+      "id": "profia",
+      "description": "Preprocessing of FIA-HRMS data",
+      "tool_shed_repository": "profia",
+      "panel_section_name": "Metabolomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/ethevenot/profia/profia/3.1.0"
+    },
+    {
+      "name": "NMR_Bucketing",
+      "id": "NmrBucketing",
+      "description": "Bucketing and integration of NMR Bruker raw data",
+      "tool_shed_repository": "nmr_bucketing",
+      "panel_section_name": "Metabolomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/marie-tremblay-metatoul/nmr_bucketing/NmrBucketing/2.0.3"
+    },
+    {
+      "name": "NMR_Normalization",
+      "id": "NmrNormalization",
+      "description": "Normalization of NMR bucketed and integrated spectra",
+      "tool_shed_repository": "nmr_normalization",
+      "panel_section_name": "Metabolomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/marie-tremblay-metatoul/nmr_normalization/NmrNormalization/1.0.1"
+    },
+    {
+      "name": "NMR spectra alignment",
+      "id": "NmrAlignment",
+      "description": "based on the Cluster-based Peak Alignment (CluPA) algorithm",
+      "tool_shed_repository": "nmr_alignment",
+      "panel_section_name": "Metabolomics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/marie-tremblay-metatoul/nmr_alignment/NmrAlignment/2.0.4"
+    },
+    {
+      "name": "Extract energy components with GROMACS",
+      "id": "gmx_energy",
+      "description": "",
+      "tool_shed_repository": "gmx_energy",
+      "panel_section_name": "ChemicalToolBox",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/chemteam/gmx_energy/gmx_energy/2022+galaxy1"
+    },
+    {
+      "name": "GROMACS copy file",
+      "id": "gmx_get_builtin_file",
+      "description": "from built-in datasets",
+      "tool_shed_repository": "gmx_get_builtin_file",
+      "panel_section_name": "ChemicalToolBox",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/chemteam/gmx_get_builtin_file/gmx_get_builtin_file/2022+galaxy0"
+    },
+    {
+      "name": "GROMACS Radius of Gyration",
+      "id": "gmx_rg",
+      "description": "of a molecular structure",
+      "tool_shed_repository": "gmx_rg",
+      "panel_section_name": "ChemicalToolBox",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/chemteam/gmx_rg/gmx_rg/2022+galaxy0"
+    },
+    {
+      "name": "Create GROMACS index files",
+      "id": "gmx_makendx",
+      "description": "using make_ndx",
+      "tool_shed_repository": "gmx_makendx",
+      "panel_section_name": "ChemicalToolBox",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/chemteam/gmx_makendx/gmx_makendx/2022+galaxy0"
+    },
+    {
+      "name": "Create GROMACS position restraints files",
+      "id": "gmx_restraints",
+      "description": "using genrestr",
+      "tool_shed_repository": "gmx_restraints",
+      "panel_section_name": "ChemicalToolBox",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/chemteam/gmx_restraints/gmx_restraints/2022+galaxy0"
+    },
+    {
+      "name": "Modify/convert GROMACS trajectories",
+      "id": "gmx_trj",
+      "description": "using trjconv and trjcat",
+      "tool_shed_repository": "gmx_trj",
+      "panel_section_name": "ChemicalToolBox",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/chemteam/gmx_trj/gmx_trj/2022+galaxy0"
+    },
+    {
+      "name": "GROMACS simulation",
+      "id": "gmx_sim",
+      "description": "for system equilibration or data collection",
+      "tool_shed_repository": "gmx_sim",
+      "panel_section_name": "ChemicalToolBox",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/chemteam/gmx_sim/gmx_sim/2022+galaxy0"
+    },
+    {
+      "name": "GROMACS solvation and adding ions",
+      "id": "gmx_solvate",
+      "description": "to structure and topology files",
+      "tool_shed_repository": "gmx_solvate",
+      "panel_section_name": "ChemicalToolBox",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/chemteam/gmx_solvate/gmx_solvate/2022+galaxy0"
+    },
+    {
+      "name": "GROMACS energy minimization",
+      "id": "gmx_em",
+      "description": "of the system prior to equilibration and production MD",
+      "tool_shed_repository": "gmx_em",
+      "panel_section_name": "ChemicalToolBox",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/chemteam/gmx_em/gmx_em/2022+galaxy0"
+    },
+    {
+      "name": "GROMACS initial setup",
+      "id": "gmx_setup",
+      "description": "of topology and GRO structure file",
+      "tool_shed_repository": "gmx_setup",
+      "panel_section_name": "ChemicalToolBox",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/chemteam/gmx_setup/gmx_setup/2022+galaxy0"
+    },
+    {
+      "name": "Extracting Topology Information",
+      "id": "gromacs_extract_topology",
+      "description": "from a GROMACS topology file",
+      "tool_shed_repository": "gromacs_extract_topology",
+      "panel_section_name": "ChemicalToolBox",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/chemteam/gromacs_extract_topology/gromacs_extract_topology/0+galaxy0"
+    },
+    {
+      "name": "Build tLEaP",
+      "id": "tleap",
+      "description": "interactively build and run tLEaP files to set up systems with AmberTools",
+      "tool_shed_repository": "tleap",
+      "panel_section_name": "ChemicalToolBox",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/chemteam/tleap/tleap/21.10+galaxy0"
+    },
+    {
+      "name": "RDConf: Low-energy ligand conformer search",
+      "id": "rdconf",
+      "description": "using RDKit",
+      "tool_shed_repository": "rdconf",
+      "panel_section_name": "ChemicalToolBox",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/rdconf/rdconf/2020.03.4+galaxy0"
+    },
+    {
+      "name": "Trajectory select and merge",
+      "id": "traj_selections_and_merge",
+      "description": "- select specific molecules and merge multiple trajectories.",
+      "tool_shed_repository": "traj_selections_and_merge",
+      "panel_section_name": "ChemicalToolBox",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/chemteam/traj_selections_and_merge/traj_selections_and_merge/1.9.7+galaxy0"
+    },
+    {
+      "name": "VINA Docking",
+      "id": "docking",
+      "description": "tool to perform protein-ligand docking with Autodock Vina",
+      "tool_shed_repository": "autodock_vina",
+      "panel_section_name": "ChemicalToolBox",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/autodock_vina/docking/1.2.3+galaxy0"
+    },
+    {
+      "name": "Descriptors",
+      "id": "ctb_rdkit_descriptors",
+      "description": "calculated with RDKit",
+      "tool_shed_repository": "ctb_rdkit_descriptors",
+      "panel_section_name": "ChemicalToolBox",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/ctb_rdkit_descriptors/ctb_rdkit_descriptors/2020.03.4+galaxy1"
+    },
+    {
+      "name": "Convert Amber topology and coordinate files to GROMACS format",
+      "id": "acpype_Amber2Gromacs",
+      "description": "using acpype",
+      "tool_shed_repository": "acpype_amber2gromacs",
+      "panel_section_name": "ChemicalToolBox",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/chemteam/acpype_amber2gromacs/acpype_Amber2Gromacs/21.10+galaxy0"
+    },
+    {
+      "name": "Convert Parameters",
+      "id": "parmconv",
+      "description": "to AMBER prmtop in preparation for MMGBSA/MMPBSA",
+      "tool_shed_repository": "parmconv",
+      "panel_section_name": "ChemicalToolBox",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/chemteam/parmconv/parmconv/21.10+galaxy0"
+    },
+    {
+      "name": "Generate MD topologies for small molecules",
+      "id": "ambertools_acpype",
+      "description": "using acpype",
+      "tool_shed_repository": "ambertools_acpype",
+      "panel_section_name": "ChemicalToolBox",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/chemteam/ambertools_acpype/ambertools_acpype/21.10+galaxy0"
+    },
+    {
+      "name": "Merge GROMACS topologies",
+      "id": "gmx_merge_topology_files",
+      "description": "and GRO files",
+      "tool_shed_repository": "gmx_merge_topology_files",
+      "panel_section_name": "ChemicalToolBox",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/chemteam/gmx_merge_topology_files/gmx_merge_topology_files/3.4.3+galaxy0"
+    },
+    {
+      "name": "ParmChk2",
+      "id": "ambertools_parmchk2",
+      "description": "- Amber's parameter checker",
+      "tool_shed_repository": "ambertools_parmchk2",
+      "panel_section_name": "ChemicalToolBox",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/chemteam/ambertools_parmchk2/ambertools_parmchk2/21.10+galaxy0"
+    },
+    {
+      "name": "AnteChamber",
+      "id": "ambertools_antechamber",
+      "description": "- Amber's molecular input file processor",
+      "tool_shed_repository": "ambertools_antechamber",
+      "panel_section_name": "ChemicalToolBox",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/chemteam/ambertools_antechamber/ambertools_antechamber/21.10+galaxy0"
+    },
+    {
+      "name": "MMPBSA/MMGBSA",
+      "id": "mmpbsa_mmgbsa",
+      "description": "tool for estimating ligand binding affinities",
+      "tool_shed_repository": "mmpbsa_mmgbsa",
+      "panel_section_name": "ChemicalToolBox",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/chemteam/mmpbsa_mmgbsa/mmpbsa_mmgbsa/21.10+galaxy0"
+    },
+    {
+      "name": "dpocket",
+      "id": "dpocket",
+      "description": "to calculate descriptors for protein pockets",
+      "tool_shed_repository": "fpocket",
+      "panel_section_name": "ChemicalToolBox",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/fpocket/dpocket/4.0.0+galaxy0"
+    },
+    {
+      "name": "OpenPepXL",
+      "id": "OpenPepXL",
+      "description": "Tool for protein-protein cross-linking identification using labeled linkers.",
+      "tool_shed_repository": "openms_openpepxl",
+      "panel_section_name": "ChemicalToolBox",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/galaxyp/openms_openpepxl/OpenPepXL/2.6+galaxy0"
+    },
+    {
+      "name": "fpocket",
+      "id": "fpocket",
+      "description": "- find potential binding sites in protein structures",
+      "tool_shed_repository": "fpocket",
+      "panel_section_name": "ChemicalToolBox",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/fpocket/fpocket/4.0.0+galaxy0"
+    },
+    {
+      "name": "Pharmacophore alignment",
+      "id": "ctb_alignit",
+      "description": "and optimization (Align-it)",
+      "tool_shed_repository": "align_it",
+      "panel_section_name": "ChemicalToolBox",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/align_it/ctb_alignit/1.0.4+galaxy0"
+    },
+    {
+      "name": "Pharmacophore",
+      "id": "ctb_alignit_create_db",
+      "description": "generation (Align-it)",
+      "tool_shed_repository": "align_it",
+      "panel_section_name": "ChemicalToolBox",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/align_it/ctb_alignit_create_db/0.1"
+    },
+    {
+      "name": "Calculate the box parameters using RDKit",
+      "id": "prepare_box",
+      "description": "for an AutoDock Vina job from a ligand or pocket input file (confounding box)",
+      "tool_shed_repository": "autodock_vina_prepare_box",
+      "panel_section_name": "ChemicalToolBox",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/autodock_vina_prepare_box/prepare_box/2021.03.5+galaxy0"
+    },
+    {
+      "name": "MDTraj file converter",
+      "id": "md_converter",
+      "description": "- interconvert between MD trajectory file formats.",
+      "tool_shed_repository": "md_converter",
+      "panel_section_name": "ChemicalToolBox",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/chemteam/md_converter/md_converter/1.9.6+galaxy0"
+    },
+    {
+      "name": "dcTMD friction correction",
+      "id": "biomd_neqgamma",
+      "description": "for calculating friction and free energy profiles from TMD ensembles",
+      "tool_shed_repository": "biomd_neqgamma",
+      "panel_section_name": "ChemicalToolBox",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/chemteam/biomd_neqgamma/biomd_neqgamma/0.1.5.2+galaxy1"
+    },
+    {
+      "name": "GROMACS production simulation",
+      "id": "gmx_md",
+      "description": "for data collection",
+      "tool_shed_repository": "gmx_md",
+      "panel_section_name": "ChemicalToolBox",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/chemteam/gmx_md/gmx_md/2018.2"
+    },
+    {
+      "name": "Score docked poses using SuCOS",
+      "id": "sucos_docking_scoring",
+      "description": "- compare shape and feature overlap of docked ligand poses to a reference molecule",
+      "tool_shed_repository": "sucos_docking_scoring",
+      "panel_section_name": "ChemicalToolBox",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/sucos_docking_scoring/sucos_docking_scoring/2020.03.4+galaxy1"
+    },
+    {
+      "name": "Search ChEMBL database",
+      "id": "chembl",
+      "description": "for compounds which are similar to a SMILES string",
+      "tool_shed_repository": "chembl",
+      "panel_section_name": "ChemicalToolBox",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/chembl/chembl/0.10.1+galaxy4"
+    },
+    {
+      "name": "ChEMBL structure pipeline",
+      "id": "chembl_structure_pipeline",
+      "description": "for curation and standardizing of molecular structures",
+      "tool_shed_repository": "chembl",
+      "panel_section_name": "ChemicalToolBox",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/chembl/chembl_structure_pipeline/1.0.0+galaxy0"
+    },
+    {
+      "name": "GROMACS structure configuration",
+      "id": "gmx_editconf",
+      "description": "using editconf",
+      "tool_shed_repository": "gmx_editconf",
+      "panel_section_name": "ChemicalToolBox",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/chemteam/gmx_editconf/gmx_editconf/2022+galaxy0"
+    },
+    {
+      "name": "Substructure Search",
+      "id": "openbabel_subsearch",
+      "description": "of fingerprint data sets",
+      "tool_shed_repository": "openbabel_subsearch",
+      "panel_section_name": "ChemicalToolBox",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/openbabel_subsearch/openbabel_subsearch/3.1.1+galaxy0"
+    },
+    {
+      "name": "Hierarchical clustering",
+      "id": "biomd_rmsd_clustering",
+      "description": "from MD RMSD matrix data",
+      "tool_shed_repository": "biomd_rmsd_clustering",
+      "panel_section_name": "ChemicalToolBox",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/chemteam/biomd_rmsd_clustering/biomd_rmsd_clustering/0.1.5.2+galaxy1"
+    },
+    {
+      "name": "Extract clusters of MD trajectories",
+      "id": "biomd_extract_clusters",
+      "description": "from linkage matrix data",
+      "tool_shed_repository": "biomd_extract_clusters",
+      "panel_section_name": "ChemicalToolBox",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/chemteam/biomd_extract_clusters/biomd_extract_clusters/0.1.5.2+galaxy1"
+    },
+    {
+      "name": "Extract RMSD distance matrix data",
+      "id": "mdanalysis_extract_rmsd",
+      "description": "from MD ensemble with MDAnalysis",
+      "tool_shed_repository": "mdanalysis_extract_rmsd",
+      "panel_section_name": "ChemicalToolBox",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/chemteam/mdanalysis_extract_rmsd/mdanalysis_extract_rmsd/1.0.0+galaxy2"
+    },
+    {
+      "name": "Add hydrogen atoms",
+      "id": "openbabel_addh",
+      "description": "at a certain pH value",
+      "tool_shed_repository": "openbabel_addh",
+      "panel_section_name": "ChemicalToolBox",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/openbabel_addh/openbabel_addh/3.1.1+galaxy1"
+    },
+    {
+      "name": "Remove counterions and fragments",
+      "id": "openbabel_remIons",
+      "description": "from a library of compounds",
+      "tool_shed_repository": "openbabel_remions",
+      "panel_section_name": "ChemicalToolBox",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/openbabel_remions/openbabel_remIons/3.1.1+galaxy2"
+    },
+    {
+      "name": "ChEMBL structure pipeline",
+      "id": "chembl_structure_pipeline",
+      "description": "for curation and standardizing of molecular structures",
+      "tool_shed_repository": "chembl_structure_pipeline",
+      "panel_section_name": "ChemicalToolBox",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/chembl_structure_pipeline/chembl_structure_pipeline/1.0.0+galaxy0"
+    },
+    {
+      "name": "Slice MD trajectories",
+      "id": "md_slicer",
+      "description": "using the MDTraj package",
+      "tool_shed_repository": "md_converter",
+      "panel_section_name": "ChemicalToolBox",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/chemteam/md_converter/md_slicer/1.9.7+galaxy0"
+    },
+    {
+      "name": "Drug-likeness",
+      "id": "ctb_silicos_qed",
+      "description": "quantitative estimation (QED) with RDKit",
+      "tool_shed_repository": "qed",
+      "panel_section_name": "ChemicalToolBox",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/qed/ctb_silicos_qed/2021.03.4+galaxy0"
+    },
+    {
+      "name": "Adding New Topology Information",
+      "id": "gromacs_modify_topology",
+      "description": "to a GROMACS topology file",
+      "tool_shed_repository": "gromacs_modify_topology",
+      "panel_section_name": "ChemicalToolBox",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/chemteam/gromacs_modify_topology/gromacs_modify_topology/0+galaxy0"
+    },
+    {
+      "name": "Remove protonation state",
+      "id": "openbabel_remove_protonation_state",
+      "description": "of every atom",
+      "tool_shed_repository": "openbabel_remove_protonation_state",
+      "panel_section_name": "ChemicalToolBox",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/openbabel_remove_protonation_state/openbabel_remove_protonation_state/3.1.1+galaxy1"
+    },
+    {
+      "name": "Ramachandran Analysis",
+      "id": "mdanalysis_ramachandran_protein",
+      "description": "- Ramachandran plot for proteins",
+      "tool_shed_repository": "mdanalysis_ramachandran_protein",
+      "panel_section_name": "ChemicalToolBox",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/chemteam/mdanalysis_ramachandran_protein/mdanalysis_ramachandran_protein/1.0.0+galaxy0"
+    },
+    {
+      "name": "End-to-End Analysis",
+      "id": "mdanalysis_endtoend",
+      "description": "- End-to-End distance timeseries and histogram for the given selections",
+      "tool_shed_repository": "mdanalysis_endtoend",
+      "panel_section_name": "ChemicalToolBox",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/chemteam/mdanalysis_endtoend/mdanalysis_endtoend/1.0.0+galaxy0"
+    },
+    {
+      "name": "Cosine Content",
+      "id": "mdanalysis_cosine_analysis",
+      "description": "- measure the cosine content of the PCA projection",
+      "tool_shed_repository": "mdanalysis_cosine_analysis",
+      "panel_section_name": "ChemicalToolBox",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/chemteam/mdanalysis_cosine_analysis/mdanalysis_cosine_analysis/1.0.0+galaxy0"
+    },
+    {
+      "name": "Hydrogen Bond Analysis",
+      "id": "mdanalysis_hbonds",
+      "description": "- analyze H-bonds between two segments",
+      "tool_shed_repository": "mdanalysis_hbonds",
+      "panel_section_name": "ChemicalToolBox",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/chemteam/mdanalysis_hbonds/mdanalysis_hbonds/1.0.0+galaxy0"
+    },
+    {
+      "name": "Ramachandran Plots",
+      "id": "mdanalysis_ramachandran_plot",
+      "description": "- calculate and plot the distribution of two dihedrals in a trajectory",
+      "tool_shed_repository": "mdanalysis_ramachandran_plot",
+      "panel_section_name": "ChemicalToolBox",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/chemteam/mdanalysis_ramachandran_plot/mdanalysis_ramachandran_plot/1.0.0+galaxy0"
+    },
+    {
+      "name": "Distance Analysis",
+      "id": "mdanalysis_distance",
+      "description": "- time series using MDAnalysis",
+      "tool_shed_repository": "mdanalysis_distance",
+      "panel_section_name": "ChemicalToolBox",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/chemteam/mdanalysis_distance/mdanalysis_distance/1.0.0+galaxy0"
+    },
+    {
+      "name": "Dihedral Analysis",
+      "id": "mdanalysis_dihedral",
+      "description": "Time series of dihedrals",
+      "tool_shed_repository": "mdanalysis_dihedral",
+      "panel_section_name": "ChemicalToolBox",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/chemteam/mdanalysis_dihedral/mdanalysis_dihedral/1.0.0+galaxy0"
+    },
+    {
+      "name": "Change title",
+      "id": "openbabel_change_title",
+      "description": "to metadata value.",
+      "tool_shed_repository": "openbabel_change_title",
+      "panel_section_name": "ChemicalToolBox",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/openbabel_change_title/openbabel_change_title/3.1.1+galaxy0"
+    },
+    {
+      "name": "RDF Analysis",
+      "id": "mdanalysis_rdf",
+      "description": "- Radial Distribution Function between two atoms",
+      "tool_shed_repository": "mdanalysis_rdf",
+      "panel_section_name": "ChemicalToolBox",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/chemteam/mdanalysis_rdf/mdanalysis_rdf/0.20"
+    },
+    {
+      "name": "Spectrophores search",
+      "id": "openbabel_spectrophore_search",
+      "description": "- similarity search based on 1D chemical features",
+      "tool_shed_repository": "openbabel_spectrophore_search",
+      "panel_section_name": "ChemicalToolBox",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/openbabel_spectrophore_search/openbabel_spectrophore_search/3.1.1+galaxy0"
+    },
+    {
+      "name": "Angle Analysis",
+      "id": "mdanalysis_angle",
+      "description": "- time series of Angles",
+      "tool_shed_repository": "mdanalysis_angle",
+      "panel_section_name": "ChemicalToolBox",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/chemteam/mdanalysis_angle/mdanalysis_angle/1.0.0+galaxy0"
+    },
+    {
+      "name": "APoc",
+      "id": "apoc",
+      "description": "Large-scale identification of similar protein pockets",
+      "tool_shed_repository": "apoc",
+      "panel_section_name": "ChemicalToolBox",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/earlhaminst/apoc/apoc/1.0+galaxy1"
+    },
+    {
+      "name": "smina",
+      "id": "smina",
+      "description": "Scoring and Minimization with AutoDock Vina",
+      "tool_shed_repository": "smina",
+      "panel_section_name": "ChemicalToolBox",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/earlhaminst/smina/smina/1.0"
+    },
+    {
+      "name": "Prepare receptor",
+      "id": "prepare_receptor",
+      "description": "Tool to prepare receptor for docking with Autodock Vina",
+      "tool_shed_repository": "autodock_vina_prepare_receptor",
+      "panel_section_name": "ChemicalToolBox",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/autodock_vina_prepare_receptor/prepare_receptor/1.5.7+galaxy0"
+    },
+    {
+      "name": "Enumerate changes",
+      "id": "enumerate_charges",
+      "description": "calculated with Dimorphite DL and RDKit",
+      "tool_shed_repository": "enumerate_charges",
+      "panel_section_name": "ChemicalToolBox",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/enumerate_charges/enumerate_charges/2020.03.4+galaxy0"
+    },
+    {
+      "name": "Extract values from an SD-file",
+      "id": "sdf_to_tab",
+      "description": "into a tabular file using RDKit",
+      "tool_shed_repository": "sdf_to_tab",
+      "panel_section_name": "ChemicalToolBox",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/sdf_to_tab/sdf_to_tab/2020.03.4+galaxy0"
+    },
+    {
+      "name": "Calculate molecular descriptors",
+      "id": "ctb_mordred_descriptors",
+      "description": "with Mordred",
+      "tool_shed_repository": "mordred",
+      "panel_section_name": "ChemicalToolBox",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/mordred/ctb_mordred_descriptors/1.2.0+galaxy0"
+    },
+    {
+      "name": "PubChem Download",
+      "id": "ctb_pubchem_download_as_smiles",
+      "description": "as canonical SMILES",
+      "tool_shed_repository": "get_pubchem",
+      "panel_section_name": "ChemicalToolBox",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/get_pubchem/ctb_pubchem_download_as_smiles/0.3"
+    },
+    {
+      "name": "PubChem Assay Downloader",
+      "id": "ctb_pubchem_download_assays",
+      "description": "as table",
+      "tool_shed_repository": "get_pubchem",
+      "panel_section_name": "ChemicalToolBox",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/get_pubchem/ctb_pubchem_download_assays/0.3"
+    },
+    {
+      "name": "Prepare ligand",
+      "id": "prepare_ligand",
+      "description": "for docking with Autodock Vina",
+      "tool_shed_repository": "autodock_vina_prepare_ligand",
+      "panel_section_name": "ChemicalToolBox",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/autodock_vina_prepare_ligand/prepare_ligand/1.5.7+galaxy0"
+    },
+    {
+      "name": "Remove duplicated molecules",
+      "id": "openbabel_remDuplicates",
+      "description": "from a library of compounds",
+      "tool_shed_repository": "openbabel_remduplicates",
+      "panel_section_name": "ChemicalToolBox",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/openbabel_remduplicates/openbabel_remDuplicates/3.1.1+galaxy0"
+    },
+    {
+      "name": "Filter",
+      "id": "openbabel_filter",
+      "description": "a set of molecules from a file",
+      "tool_shed_repository": "openbabel_filter",
+      "panel_section_name": "ChemicalToolBox",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/openbabel_filter/openbabel_filter/3.1.1+galaxy0"
+    },
+    {
+      "name": "Compound conversion",
+      "id": "openbabel_compound_convert",
+      "description": "- interconvert between various chemistry and molecular modeling data files",
+      "tool_shed_repository": "openbabel_compound_convert",
+      "panel_section_name": "ChemicalToolBox",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/openbabel_compound_convert/openbabel_compound_convert/3.1.1+galaxy0"
+    },
+    {
+      "name": "Visualisation",
+      "id": "openbabel_svg_depiction",
+      "description": "of compounds",
+      "tool_shed_repository": "openbabel_svg_depiction",
+      "panel_section_name": "ChemicalToolBox",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/openbabel_svg_depiction/openbabel_svg_depiction/3.1.1+galaxy0"
+    },
+    {
+      "name": "Compute physico-chemical properties",
+      "id": "openbabel_genProp",
+      "description": "for a set of molecules",
+      "tool_shed_repository": "openbabel_genprop",
+      "panel_section_name": "ChemicalToolBox",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/openbabel_genprop/openbabel_genProp/3.1.1+galaxy0"
+    },
+    {
+      "name": "Compound search",
+      "id": "openbabel_obgrep",
+      "description": "- an advanced molecular search program using SMARTS",
+      "tool_shed_repository": "openbabel_obgrep",
+      "panel_section_name": "ChemicalToolBox",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/openbabel_obgrep/openbabel_obgrep/3.1.1+galaxy0"
+    },
+    {
+      "name": "Remove small molecules",
+      "id": "openbabel_remSmall",
+      "description": "from a library of compounds",
+      "tool_shed_repository": "openbabel_remsmall",
+      "panel_section_name": "ChemicalToolBox",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/openbabel_remsmall/openbabel_remSmall/3.1.1+galaxy0"
+    },
+    {
+      "name": "Prepare ligands for docking",
+      "id": "prepare_ligands_for_docking",
+      "description": "Tool to prepare ligands for docking with tools like Autodock Vina",
+      "tool_shed_repository": "prepare_ligands_for_docking",
+      "panel_section_name": "ChemicalToolBox",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/prepare_ligands_for_docking/prepare_ligands_for_docking/3.1.1+galaxy0"
+    },
+    {
+      "name": "Cluster ligands using SuCOS",
+      "id": "sucos_clustering",
+      "description": "based on the overlap of 3D features",
+      "tool_shed_repository": "sucos_clustering",
+      "panel_section_name": "ChemicalToolBox",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/sucos_clustering/sucos_clustering/2020.03.4+galaxy0"
+    },
+    {
+      "name": "Max SuCOS score",
+      "id": "sucos_max_score",
+      "description": "- determine maximum SuCOS score of ligands against clustered fragment hits",
+      "tool_shed_repository": "sucos_max_score",
+      "panel_section_name": "ChemicalToolBox",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/sucos_max_score/sucos_max_score/2020.03.4+galaxy0"
+    },
+    {
+      "name": "Determine distance to defined points",
+      "id": "openbabel_structure_distance_finder",
+      "description": "- determine the minimum distances between a molecule and a set of 3D points",
+      "tool_shed_repository": "openbabel_structure_distance_finder",
+      "panel_section_name": "ChemicalToolBox",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/openbabel_structure_distance_finder/openbabel_structure_distance_finder/3.1.1+galaxy0"
+    },
+    {
+      "name": "Create Frankenstein ligand",
+      "id": "ctb_frankenstein_ligand",
+      "description": "for docking active site definition",
+      "tool_shed_repository": "ctb_frankenstein_ligand",
+      "panel_section_name": "ChemicalToolBox",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/ctb_frankenstein_ligand/ctb_frankenstein_ligand/2013.1-0+galaxy0"
+    },
+    {
+      "name": "rDock cavity definition",
+      "id": "rdock_rbcavity",
+      "description": "- generate the active site definition needed for rDock docking",
+      "tool_shed_repository": "rdock_rbcavity",
+      "panel_section_name": "ChemicalToolBox",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/rdock_rbcavity/rdock_rbcavity/2013.1-0+galaxy0"
+    },
+    {
+      "name": "rDock docking",
+      "id": "rdock_rbdock",
+      "description": "- perform protein-ligand docking with rDock",
+      "tool_shed_repository": "rdock_rbdock",
+      "panel_section_name": "ChemicalToolBox",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/rdock_rbdock/rdock_rbdock/2013.1-0+galaxy0"
+    },
+    {
+      "name": "rDock docking",
+      "id": "rdock_sort_filter",
+      "description": "using the sdsort provided with rDock",
+      "tool_shed_repository": "rdock_sort_filter",
+      "panel_section_name": "ChemicalToolBox",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/rdock_sort_filter/rdock_sort_filter/2013.1-0+galaxy0"
+    },
+    {
+      "name": "rxDock cavity definition",
+      "id": "rxdock_rbcavity",
+      "description": "- generate the active site definition needed for rxDock docking",
+      "tool_shed_repository": "rxdock_rbcavity",
+      "panel_section_name": "ChemicalToolBox",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/rxdock_rbcavity/rxdock_rbcavity/0.1.5"
+    },
+    {
+      "name": "rxDock docking",
+      "id": "rxdock_rbdock",
+      "description": "- perform protein-ligand docking with rxDock",
+      "tool_shed_repository": "rxdock_rbdock",
+      "panel_section_name": "ChemicalToolBox",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/rxdock_rbdock/rxdock_rbdock/0.1.5"
+    },
+    {
+      "name": "SDF sort and filter",
+      "id": "rxdock_sort_filter",
+      "description": "using the sdsort provided with rxDock",
+      "tool_shed_repository": "rxdock_sort_filter",
+      "panel_section_name": "ChemicalToolBox",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/rxdock_sort_filter/rxdock_sort_filter/0.1.5"
+    },
+    {
+      "name": "Calculate plane of best fit for molecules",
+      "id": "ctb_im_pbf_ev",
+      "description": "using RDKit",
+      "tool_shed_repository": "ctb_im_pbf_ev",
+      "panel_section_name": "ChemicalToolBox",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/ctb_im_pbf_ev/ctb_im_pbf_ev/1.1.4+galaxy0"
+    },
+    {
+      "name": "Reaction SMARTS filter",
+      "id": "ctb_im_rxn_smarts_filter",
+      "description": "using RDKit",
+      "tool_shed_repository": "ctb_im_rxn_smarts_filter",
+      "panel_section_name": "ChemicalToolBox",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/ctb_im_rxn_smarts_filter/ctb_im_rxn_smarts_filter/1.1.4+galaxy0"
+    },
+    {
+      "name": "Generate conformers",
+      "id": "ctb_im_conformers",
+      "description": "using RDKit",
+      "tool_shed_repository": "ctb_im_conformers",
+      "panel_section_name": "ChemicalToolBox",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/ctb_im_conformers/ctb_im_conformers/1.1.4+galaxy0"
+    },
+    {
+      "name": "Constrained conformer generation",
+      "id": "ctb_im_constrained_conf_gen",
+      "description": "with RDKit",
+      "tool_shed_repository": "ctb_im_constrained_conf_gen",
+      "panel_section_name": "ChemicalToolBox",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/ctb_im_constrained_conf_gen/ctb_im_constrained_conf_gen/1.1.4+galaxy0"
+    },
+    {
+      "name": "Butina Cluster Matrix",
+      "id": "ctb_im_cluster_butina_matrix",
+      "description": "using RDKit",
+      "tool_shed_repository": "ctb_im_cluster_butina_matrix",
+      "panel_section_name": "ChemicalToolBox",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/ctb_im_cluster_butina_matrix/ctb_im_cluster_butina_matrix/1.1.4+galaxy0"
+    },
+    {
+      "name": "Open 3D Align",
+      "id": "ctb_im_o3dalign",
+      "description": "with RDKit",
+      "tool_shed_repository": "ctb_im_o3dalign",
+      "panel_section_name": "ChemicalToolBox",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/ctb_im_o3dalign/ctb_im_o3dalign/1.1.4+galaxy0"
+    },
+    {
+      "name": "Standardize SD-files",
+      "id": "ctb_im_standardize",
+      "description": "using RDKit",
+      "tool_shed_repository": "ctb_im_standardize",
+      "panel_section_name": "ChemicalToolBox",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/ctb_im_standardize/ctb_im_standardize/1.1.4+galaxy0"
+    },
+    {
+      "name": "Butina Cluster",
+      "id": "ctb_im_cluster_butina",
+      "description": "using RDKit",
+      "tool_shed_repository": "ctb_im_cluster_butina",
+      "panel_section_name": "ChemicalToolBox",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/ctb_im_cluster_butina/ctb_im_cluster_butina/1.1.4+galaxy0"
+    },
+    {
+      "name": "Pick",
+      "id": "ctb_im_max_min_picker",
+      "description": "diverse compounds from a library with Butina clustering",
+      "tool_shed_repository": "ctb_im_max_min_picker",
+      "panel_section_name": "ChemicalToolBox",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/ctb_im_max_min_picker/ctb_im_max_min_picker/1.1.4+galaxy0"
+    },
+    {
+      "name": "Reaction maker",
+      "id": "ctb_im_rxn_maker",
+      "description": "using RDKit",
+      "tool_shed_repository": "ctb_im_rxn_maker",
+      "panel_section_name": "ChemicalToolBox",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/ctb_im_rxn_maker/ctb_im_rxn_maker/1.1.4+galaxy0"
+    },
+    {
+      "name": "Screen",
+      "id": "ctb_im_screen",
+      "description": "a compound against a library using RDKit",
+      "tool_shed_repository": "ctb_im_screen",
+      "panel_section_name": "ChemicalToolBox",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/ctb_im_screen/ctb_im_screen/1.1.4+galaxy0"
+    },
+    {
+      "name": "XCos",
+      "id": "ctb_im_xcos",
+      "description": "scoring",
+      "tool_shed_repository": "ctb_im_xcos",
+      "panel_section_name": "ChemicalToolBox",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/ctb_im_xcos/ctb_im_xcos/1.1.4+galaxy0"
+    },
+    {
+      "name": "'FeatureStein' fragment overlay scoring",
+      "id": "featurestein",
+      "description": "feature overlay scoring",
+      "tool_shed_repository": "featurestein",
+      "panel_section_name": "ChemicalToolBox",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/featurestein/featurestein/1.1.4+galaxy0"
+    },
+    {
+      "name": "OpenDUck chunk",
+      "id": "openduck_chunk",
+      "description": "for dynamic undocking",
+      "tool_shed_repository": "openduck_chunk",
+      "panel_section_name": "ChemicalToolBox",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/openduck_chunk/openduck_chunk/0.1.1"
+    },
+    {
+      "name": "Run OpenDUck",
+      "id": "openduck_run_smd",
+      "description": "steered molecular dynamics runs",
+      "tool_shed_repository": "openduck_run_smd",
+      "panel_section_name": "ChemicalToolBox",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/openduck_run_smd/openduck_run_smd/0.1.1"
+    },
+    {
+      "name": "XChem TransFS pose scoring",
+      "id": "xchem_transfs_scoring",
+      "description": "using deep learning",
+      "tool_shed_repository": "xchem_transfs_scoring",
+      "panel_section_name": "ChemicalToolBox",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/xchem_transfs_scoring/xchem_transfs_scoring/0.4.0"
+    },
+    {
+      "name": "Molecule to fingerprint",
+      "id": "ctb_chemfp_mol2fps",
+      "description": "conversion to several different fingerprint formats",
+      "tool_shed_repository": "chemfp",
+      "panel_section_name": "ChemicalToolBox",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/chemfp/ctb_chemfp_mol2fps/1.5"
+    },
+    {
+      "name": "NxN clustering",
+      "id": "ctb_chemfp_nxn_clustering",
+      "description": "of molecular fingerprints",
+      "tool_shed_repository": "chemfp",
+      "panel_section_name": "ChemicalToolBox",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/chemfp/ctb_chemfp_nxn_clustering/1.5.1"
+    },
+    {
+      "name": "Taylor-Butina clustering",
+      "id": "ctb_chemfp_butina_clustering",
+      "description": "of molecular fingerprints",
+      "tool_shed_repository": "chemfp",
+      "panel_section_name": "ChemicalToolBox",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/chemfp/ctb_chemfp_butina_clustering/1.5"
+    },
+    {
+      "name": "SDF to Fingerprint",
+      "id": "ctb_sdf2fps",
+      "description": "- extract fingerprints from sdf file metadata",
+      "tool_shed_repository": "chemfp",
+      "panel_section_name": "ChemicalToolBox",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/chemfp/ctb_sdf2fps/1.5"
+    },
+    {
+      "name": "fastpca",
+      "id": "fastpca",
+      "description": "- dimensionality reduction of MD simulations",
+      "tool_shed_repository": "fastpca",
+      "panel_section_name": "ChemicalToolBox",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/chemteam/fastpca/fastpca/0.9.1"
+    },
+    {
+      "name": "Alchemical Analysis",
+      "id": "alchemical_analysis",
+      "description": "Analysis of alchemical free energy calculations",
+      "tool_shed_repository": "alchemical_analysis",
+      "panel_section_name": "ChemicalToolBox",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/chemteam/alchemical_analysis/alchemical_analysis/1.0.2"
+    },
+    {
+      "name": "goseq",
+      "id": "goseq",
+      "description": "tests for overrepresented gene categories",
+      "tool_shed_repository": "goseq",
+      "panel_section_name": "ChemicalToolBox",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/goseq/goseq/0.2.2"
+    },
+    {
+      "name": "Hydrogen Bond Analysis using VMD",
+      "id": "vmd_hbonds",
+      "description": "between two segments of a trajectory",
+      "tool_shed_repository": "vmd_hbonds",
+      "panel_section_name": "ChemicalToolBox",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/chemteam/vmd_hbonds/vmd_hbonds/1.9.3"
+    },
+    {
+      "name": "PCA visualization",
+      "id": "bio3d_pca_visualize",
+      "description": "- generate trajectories of principal components of atomic motion",
+      "tool_shed_repository": "bio3d_pca_visualize",
+      "panel_section_name": "ChemicalToolBox",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/chemteam/bio3d_pca_visualize/bio3d_pca_visualize/2.3.4"
+    },
+    {
+      "name": "RMSF Analysis",
+      "id": "bio3d_rmsf",
+      "description": "using Bio3D",
+      "tool_shed_repository": "bio3d_rmsf",
+      "panel_section_name": "ChemicalToolBox",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/chemteam/bio3d_rmsf/bio3d_rmsf/2.3.4"
+    },
+    {
+      "name": "PCA",
+      "id": "bio3d_pca",
+      "description": "- principal component analysis using Bio3D",
+      "tool_shed_repository": "bio3d_pca",
+      "panel_section_name": "ChemicalToolBox",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/chemteam/bio3d_pca/bio3d_pca/2.3.4"
+    },
+    {
+      "name": "RMSD Analysis",
+      "id": "bio3d_rmsd",
+      "description": "using Bio3D",
+      "tool_shed_repository": "bio3d_rmsd",
+      "panel_section_name": "ChemicalToolBox",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/chemteam/bio3d_rmsd/bio3d_rmsd/2.3.4"
+    },
+    {
+      "name": "DCCM analysis",
+      "id": "bio3d_dccm",
+      "description": "- Dynamical Cross-Correlation Maps using Bio3D (DCCM)",
+      "tool_shed_repository": "bio3d_dccm",
+      "panel_section_name": "ChemicalToolBox",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/chemteam/bio3d_dccm/bio3d_dccm/2.3.4"
+    },
+    {
+      "name": "PACKMOL",
+      "id": "packmol",
+      "description": "- initial configurations for molecular dynamics simulations by packing optimization",
+      "tool_shed_repository": "packmol",
+      "panel_section_name": "ChemicalToolBox",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/chemteam/packmol/packmol/18.169.1"
+    },
+    {
+      "name": "PaDEL descriptor",
+      "id": "padel",
+      "description": "calculator",
+      "tool_shed_repository": "padel",
+      "panel_section_name": "ChemicalToolBox",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/padel/padel/2.21"
+    },
+    {
+      "name": "Online data",
+      "id": "ctb_online_data_fetch",
+      "description": "fetching",
+      "tool_shed_repository": "get_online_data",
+      "panel_section_name": "ChemicalToolBox",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/get_online_data/ctb_online_data_fetch/0.4"
+    },
+    {
+      "name": "Get PDB file",
+      "id": "get_pdb",
+      "description": "from Protein Data Bank",
+      "tool_shed_repository": "get_pdb",
+      "panel_section_name": "ChemicalToolBox",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/get_pdb/get_pdb/0.1.0"
+    },
+    {
+      "name": "Multi Compound Search",
+      "id": "openbabel_multi_obgrep",
+      "description": "an advanced molecular grep program using SMARTS",
+      "tool_shed_repository": "openbabel_multi_obgrep",
+      "panel_section_name": "ChemicalToolBox",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/openbabel_multi_obgrep/openbabel_multi_obgrep/2.4.1.0"
+    },
+    {
+      "name": "Remove counterions and fragments",
+      "id": "ctb_remIons",
+      "description": "",
+      "tool_shed_repository": "openbabel",
+      "panel_section_name": "ChemicalToolBox",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/openbabel/ctb_remIons/1.0"
+    },
+    {
+      "name": "Substructure Search",
+      "id": "ctb_subsearch",
+      "description": "of fingerprint data sets",
+      "tool_shed_repository": "openbabel",
+      "panel_section_name": "ChemicalToolBox",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/openbabel/ctb_subsearch/0.1"
+    },
+    {
+      "name": "Multi Compound Search",
+      "id": "ctb_multi_obgrep",
+      "description": "an advanced molecular grep program using SMARTS",
+      "tool_shed_repository": "openbabel",
+      "panel_section_name": "ChemicalToolBox",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/openbabel/ctb_multi_obgrep/0.1"
+    },
+    {
+      "name": "Spectrophores(TM) search:",
+      "id": "ctb_spectrophore_search",
+      "description": "similarity search based on 1D chemical features",
+      "tool_shed_repository": "openbabel",
+      "panel_section_name": "ChemicalToolBox",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/openbabel/ctb_spectrophore_search/1.0"
+    },
+    {
+      "name": "Molecule recognition",
+      "id": "ctb_osra",
+      "description": "in PDF documents (OSRA)",
+      "tool_shed_repository": "osra",
+      "panel_section_name": "ChemicalToolBox",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/osra/ctb_osra/2.1.0"
+    },
+    {
+      "name": "Natural Product",
+      "id": "ctb_np-likeness-calculator",
+      "description": "likeness calculator",
+      "tool_shed_repository": "natural_product_likeness",
+      "panel_section_name": "ChemicalToolBox",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/natural_product_likeness/ctb_np-likeness-calculator/2.1"
+    },
+    {
+      "name": "Similarity Search",
+      "id": "ctb_simsearch",
+      "description": "of fingerprint data sets",
+      "tool_shed_repository": "simsearch",
+      "panel_section_name": "ChemicalToolBox",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/simsearch/ctb_simsearch/0.2"
+    },
+    {
+      "name": "Conformer calculation",
+      "id": "ctb_confab",
+      "description": "for molecules (confab)",
+      "tool_shed_repository": "confab",
+      "panel_section_name": "ChemicalToolBox",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/confab/ctb_confab/0.4"
+    },
+    {
+      "name": "MDS Scatter Plot",
+      "id": "ctb_mds_plot",
+      "description": "of molecule similarity",
+      "tool_shed_repository": "ctb_machine_learning",
+      "panel_section_name": "ChemicalToolBox",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/ctb_machine_learning/ctb_mds_plot/0.1"
+    },
+    {
+      "name": "Online data",
+      "id": "ctb_online_data_fetch",
+      "description": "fetching ...",
+      "tool_shed_repository": "chemical_data_sources",
+      "panel_section_name": "ChemicalToolBox",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/chemical_data_sources/ctb_online_data_fetch/0.2"
+    },
+    {
+      "name": "PubChem Assay Downloader",
+      "id": "ctb_pubchem_download_assays",
+      "description": "as canonical SMILES",
+      "tool_shed_repository": "chemical_data_sources",
+      "panel_section_name": "ChemicalToolBox",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/chemical_data_sources/ctb_pubchem_download_assays/1.0.0"
+    },
+    {
+      "name": "Open Molecule Generator",
+      "id": "ctb_openmg",
+      "description": "Exhaustive generation of chemical structures",
+      "tool_shed_repository": "openmg",
+      "panel_section_name": "ChemicalToolBox",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/openmg/ctb_openmg/0.1"
+    },
+    {
+      "name": "RGCCA",
+      "id": "rgcca",
+      "description": "performs multiblock data analysis of several sets of variables (blocks) observed on the same group of individuals.",
+      "tool_shed_repository": "rgcca",
+      "panel_section_name": "Statistics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/rgcca/rgcca/3.0.2+galaxy1"
+    },
+    {
+      "name": "Sparse Matrix Functions",
+      "id": "scipy_sparse",
+      "description": "for manipulating 2-D Scipy sparse numeric data",
+      "tool_shed_repository": "scipy_sparse",
+      "panel_section_name": "Statistics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/scipy_sparse/scipy_sparse/1.0.8.3"
+    },
+    {
+      "name": "MINE",
+      "id": "maximal_information_based_nonparametric_exploration",
+      "description": "- Maximal Information-based Nonparametric Exploration",
+      "tool_shed_repository": "mine",
+      "panel_section_name": "Statistics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/mine/maximal_information_based_nonparametric_exploration/0.0.1"
+    },
+    {
+      "name": "Draw ROC plot",
+      "id": "plot_for_lda_output1",
+      "description": "on \"Perform LDA\" output",
+      "tool_shed_repository": "plot_from_lda",
+      "panel_section_name": "Statistics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/plot_from_lda/plot_for_lda_output1/1.0.1"
+    },
+    {
+      "name": "Perform LDA",
+      "id": "lda_analy1",
+      "description": "Linear Discriminant Analysis",
+      "tool_shed_repository": "lda_analysis",
+      "panel_section_name": "Statistics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/lda_analysis/lda_analy1/1.0.1"
+    },
+    {
+      "name": "Generate A Matrix",
+      "id": "generate_matrix_for_pca_and_lda1",
+      "description": "for using PC and LDA",
+      "tool_shed_repository": "generate_pc_lda_matrix",
+      "panel_section_name": "Statistics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/generate_pc_lda_matrix/generate_matrix_for_pca_and_lda1/1.0.0"
+    },
+    {
+      "name": "Count GFF Features",
+      "id": "count_gff_features",
+      "description": "",
+      "tool_shed_repository": "count_gff_features",
+      "panel_section_name": "Statistics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/count_gff_features/count_gff_features/0.2"
+    },
+    {
+      "name": "Correlation",
+      "id": "cor2",
+      "description": "for numeric columns",
+      "tool_shed_repository": "correlation",
+      "panel_section_name": "Statistics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/correlation/cor2/1.0.0"
+    },
+    {
+      "name": "Perform Best-subsets Regression",
+      "id": "BestSubsetsRegression1",
+      "description": "",
+      "tool_shed_repository": "best_regression_subsets",
+      "panel_section_name": "Statistics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/best_regression_subsets/BestSubsetsRegression1/1.0.0"
+    },
+    {
+      "name": "Principal Component Analysis",
+      "id": "pca1",
+      "description": "",
+      "tool_shed_repository": "principal_component_analysis",
+      "panel_section_name": "Statistics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/principal_component_analysis/pca1/1.0.2"
+    },
+    {
+      "name": "Kernel Principal Component Analysis",
+      "id": "kpca1",
+      "description": "",
+      "tool_shed_repository": "kernel_principal_component_analysis",
+      "panel_section_name": "Statistics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/kernel_principal_component_analysis/kpca1/1.0.0"
+    },
+    {
+      "name": "Kernel Canonical Correlation Analysis",
+      "id": "kcca1",
+      "description": "",
+      "tool_shed_repository": "kernel_canonical_correlation_analysis",
+      "panel_section_name": "Statistics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/kernel_canonical_correlation_analysis/kcca1/1.0.0"
+    },
+    {
+      "name": "Canonical Correlation Analysis",
+      "id": "cca1",
+      "description": "",
+      "tool_shed_repository": "canonical_correlation_analysis",
+      "panel_section_name": "Statistics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/canonical_correlation_analysis/cca1/1.0.0"
+    },
+    {
+      "name": "T Test for Two Samples",
+      "id": "t_test_two_samples",
+      "description": "",
+      "tool_shed_repository": "t_test_two_samples",
+      "panel_section_name": "Statistics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/t_test_two_samples/t_test_two_samples/1.0.1"
+    },
+    {
+      "name": "Create a model to recommend tools",
+      "id": "create_tool_recommendation_model",
+      "description": "using deep learning",
+      "tool_shed_repository": "create_tool_recommendation_model",
+      "panel_section_name": "Statistics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/create_tool_recommendation_model/create_tool_recommendation_model/0.0.3"
+    },
+    {
+      "name": "Wavelet variance",
+      "id": "dwt_var1",
+      "description": "using Discrete Wavelet Transfoms",
+      "tool_shed_repository": "dwt_var_perfeature",
+      "panel_section_name": "Statistics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/dwt_var_perfeature/dwt_var1/1.0.2"
+    },
+    {
+      "name": "GraphEmbed",
+      "id": "graphembed",
+      "description": "Compute and plot a 2D embedding of a data matrix given supervised class information",
+      "tool_shed_repository": "graphembed",
+      "panel_section_name": "Statistics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/graphembed/graphembed/2.4.0"
+    },
+    {
+      "name": "Landmark Registration",
+      "id": "ip_landmark_registration",
+      "description": "Landmark Registration",
+      "tool_shed_repository": "landmark_registration",
+      "panel_section_name": "Imaging",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/imgteam/landmark_registration/ip_landmark_registration/0.0.2"
+    },
+    {
+      "name": "Plot actual vs predicted curves and residual plots",
+      "id": "plotly_regression_performance_plots",
+      "description": "of tabular data",
+      "tool_shed_repository": "plotly_regression_performance_plots",
+      "panel_section_name": "Graph/Display Data",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/plotly_regression_performance_plots/plotly_regression_performance_plots/0.1"
+    },
+    {
+      "name": "Plot confusion matrix, precision, recall and ROC and AUC curves",
+      "id": "plotly_ml_performance_plots",
+      "description": "of tabular data",
+      "tool_shed_repository": "plotly_ml_performance_plots",
+      "panel_section_name": "Graph/Display Data",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/plotly_ml_performance_plots/plotly_ml_performance_plots/0.1"
+    },
+    {
+      "name": "Rolling window",
+      "id": "pandas_rolling_window",
+      "description": "over a dataframe (e.g. for data smoothing)",
+      "tool_shed_repository": "pandas_rolling_window",
+      "panel_section_name": "Statistics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/pandas_rolling_window/pandas_rolling_window/0.1"
+    },
+    {
+      "name": "Nearest Neighbors Classification",
+      "id": "nn_classifier",
+      "description": "",
+      "tool_shed_repository": "nn_classifier",
+      "panel_section_name": "Statistics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/nn_classifier/nn_classifier/0.9"
+    },
+    {
+      "name": "Support vector machines (SVMs)",
+      "id": "svm_classifier",
+      "description": "for classification",
+      "tool_shed_repository": "svm_classifier",
+      "panel_section_name": "Statistics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/svm_classifier/svm_classifier/0.9"
+    },
+    {
+      "name": "Anova",
+      "id": "abims_anova",
+      "description": "N-way anova. With ou Without interactions",
+      "tool_shed_repository": "anova",
+      "panel_section_name": "Statistics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/lecorguille/anova/abims_anova/1.2.1"
+    },
+    {
+      "name": "Multivariate",
+      "id": "Multivariate",
+      "description": "PCA, PLS and OPLS",
+      "tool_shed_repository": "multivariate",
+      "panel_section_name": "Statistics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/ethevenot/multivariate/Multivariate/2.3.10"
+    },
+    {
+      "name": "Univariate",
+      "id": "Univariate",
+      "description": "Univariate statistics",
+      "tool_shed_repository": "univariate",
+      "panel_section_name": "Statistics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/ethevenot/univariate/Univariate/2.2.4"
+    },
+    {
+      "name": "IWTomics Plot with Threshold",
+      "id": "iwtomics_plotwithscale",
+      "description": "on Test Scale",
+      "tool_shed_repository": "iwtomics_plotwithscale",
+      "panel_section_name": "Statistics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/iwtomics_plotwithscale/iwtomics_plotwithscale/1.0.0.0"
+    },
+    {
+      "name": "IWTomics Test",
+      "id": "iwtomics_testandplot",
+      "description": "and Plot",
+      "tool_shed_repository": "iwtomics_testandplot",
+      "panel_section_name": "Statistics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/iwtomics_testandplot/iwtomics_testandplot/1.0.0.0"
+    },
+    {
+      "name": "IWTomics Load",
+      "id": "iwtomics_loadandplot",
+      "description": "Smooth and Plot",
+      "tool_shed_repository": "iwtomics_loadandplot",
+      "panel_section_name": "Statistics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/iwtomics_loadandplot/iwtomics_loadandplot/1.0.0.0"
+    },
+    {
+      "name": "Sequence composition",
+      "id": "seq_composition",
+      "description": "Count bases or amino-acids",
+      "tool_shed_repository": "seq_composition",
+      "panel_section_name": "Statistics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/peterjc/seq_composition/seq_composition/0.0.5"
+    },
+    {
+      "name": "Biosigner",
+      "id": "biosigner",
+      "description": "Molecular signature discovery from omics data",
+      "tool_shed_repository": "biosigner",
+      "panel_section_name": "Statistics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/ethevenot/biosigner/biosigner/2.2.7"
+    },
+    {
+      "name": "Transformation",
+      "id": "Transformation",
+      "description": "Transforms the dataMatrix intensity values",
+      "tool_shed_repository": "transformation",
+      "panel_section_name": "Statistics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/ethevenot/transformation/Transformation/2.2.0"
+    },
+    {
+      "name": "Heatmap",
+      "id": "Heatmap",
+      "description": "Heatmap of the dataMatrix",
+      "tool_shed_repository": "heatmap",
+      "panel_section_name": "Statistics",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/ethevenot/heatmap/Heatmap/2.2.2"
+    },
+    {
+      "name": "To categorical",
+      "id": "sklearn_to_categorical",
+      "description": "Converts a class vector (integers) to binary class matrix",
+      "tool_shed_repository": "sklearn_to_categorical",
+      "panel_section_name": "Machine Learning",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/sklearn_to_categorical/sklearn_to_categorical/1.0.8.3"
+    },
+    {
+      "name": "Machine Learning Visualization Extension",
+      "id": "ml_visualization_ex",
+      "description": "includes several types of plotting for machine learning",
+      "tool_shed_repository": "ml_visualization_ex",
+      "panel_section_name": "Machine Learning",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/ml_visualization_ex/ml_visualization_ex/1.0.8.3"
+    },
+    {
+      "name": "LightGBM",
+      "id": "sklearn_lightgbm",
+      "description": "- train and apply LightGBM models",
+      "tool_shed_repository": "sklearn_lightgbm",
+      "panel_section_name": "Machine Learning",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/sklearn_lightgbm/sklearn_lightgbm/1.0.8.3"
+    },
+    {
+      "name": "Split Dataset",
+      "id": "sklearn_train_test_split",
+      "description": "into training and test subsets",
+      "tool_shed_repository": "sklearn_train_test_split",
+      "panel_section_name": "Machine Learning",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/sklearn_train_test_split/sklearn_train_test_split/1.0.8.3"
+    },
+    {
+      "name": "Fit a Pipeline, Ensemble",
+      "id": "sklearn_model_fit",
+      "description": "or other models using a labeled dataset",
+      "tool_shed_repository": "sklearn_model_fit",
+      "panel_section_name": "Machine Learning",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/sklearn_model_fit/sklearn_model_fit/1.0.8.3"
+    },
+    {
+      "name": "Stacking Ensembles",
+      "id": "sklearn_stacking_ensemble_models",
+      "description": "builds stacking, voting ensemble models with numerous base options",
+      "tool_shed_repository": "sklearn_stacking_ensemble_models",
+      "panel_section_name": "Machine Learning",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/sklearn_stacking_ensemble_models/sklearn_stacking_ensemble_models/1.0.8.3"
+    },
+    {
+      "name": "Estimator attributes",
+      "id": "sklearn_estimator_attributes",
+      "description": "get important attributes from an estimator or scikit object",
+      "tool_shed_repository": "sklearn_estimator_attributes",
+      "panel_section_name": "Machine Learning",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/sklearn_estimator_attributes/sklearn_estimator_attributes/1.0.8.3"
+    },
+    {
+      "name": "Model Prediction",
+      "id": "model_prediction",
+      "description": "predicts on new data using a preffited model",
+      "tool_shed_repository": "model_prediction",
+      "panel_section_name": "Machine Learning",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/model_prediction/model_prediction/1.0.8.3"
+    },
+    {
+      "name": "Train, Test and Evaluation",
+      "id": "sklearn_train_test_eval",
+      "description": "fit a model using part of dataset and evaluate using the rest",
+      "tool_shed_repository": "sklearn_train_test_eval",
+      "panel_section_name": "Machine Learning",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/sklearn_train_test_eval/sklearn_train_test_eval/1.0.8.3"
+    },
+    {
+      "name": "Model Validation",
+      "id": "sklearn_model_validation",
+      "description": "includes cross_validate, cross_val_predict, learning_curve, and more",
+      "tool_shed_repository": "sklearn_model_validation",
+      "panel_section_name": "Machine Learning",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/sklearn_model_validation/sklearn_model_validation/1.0.8.3"
+    },
+    {
+      "name": "Discriminant Analysis",
+      "id": "sklearn_discriminant_classifier",
+      "description": "",
+      "tool_shed_repository": "sklearn_discriminant_classifier",
+      "panel_section_name": "Machine Learning",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/sklearn_discriminant_classifier/sklearn_discriminant_classifier/1.0.8.3"
+    },
+    {
+      "name": "Calculate metrics",
+      "id": "sklearn_regression_metrics",
+      "description": "for regression performance",
+      "tool_shed_repository": "sklearn_regression_metrics",
+      "panel_section_name": "Machine Learning",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/sklearn_regression_metrics/sklearn_regression_metrics/1.0.8.3"
+    },
+    {
+      "name": "Feature Selection",
+      "id": "sklearn_feature_selection",
+      "description": "module, including univariate filter selection methods and recursive feature elimination algorithm",
+      "tool_shed_repository": "sklearn_feature_selection",
+      "panel_section_name": "Machine Learning",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/sklearn_feature_selection/sklearn_feature_selection/1.0.8.3"
+    },
+    {
+      "name": "Numeric Clustering",
+      "id": "sklearn_numeric_clustering",
+      "description": "",
+      "tool_shed_repository": "sklearn_numeric_clustering",
+      "panel_section_name": "Machine Learning",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/sklearn_numeric_clustering/sklearn_numeric_clustering/1.0.8.3"
+    },
+    {
+      "name": "Nearest Neighbors Classification",
+      "id": "sklearn_nn_classifier",
+      "description": "",
+      "tool_shed_repository": "sklearn_nn_classifier",
+      "panel_section_name": "Machine Learning",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/sklearn_nn_classifier/sklearn_nn_classifier/1.0.8.3"
+    },
+    {
+      "name": "Pipeline Builder",
+      "id": "sklearn_build_pipeline",
+      "description": "an all-in-one platform to build pipeline, single estimator, preprocessor and custom wrappers",
+      "tool_shed_repository": "sklearn_build_pipeline",
+      "panel_section_name": "Machine Learning",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/sklearn_build_pipeline/sklearn_build_pipeline/1.0.8.3"
+    },
+    {
+      "name": "Hyperparameter Search",
+      "id": "sklearn_searchcv",
+      "description": "performs hyperparameter optimization using various SearchCVs",
+      "tool_shed_repository": "sklearn_searchcv",
+      "panel_section_name": "Machine Learning",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/sklearn_searchcv/sklearn_searchcv/1.0.8.3"
+    },
+    {
+      "name": "Generate",
+      "id": "sklearn_sample_generator",
+      "description": "random samples with controlled size and complexity",
+      "tool_shed_repository": "sklearn_sample_generator",
+      "panel_section_name": "Machine Learning",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/sklearn_sample_generator/sklearn_sample_generator/1.0.8.3"
+    },
+    {
+      "name": "Support vector machines (SVMs)",
+      "id": "sklearn_svm_classifier",
+      "description": "for classification",
+      "tool_shed_repository": "sklearn_svm_classifier",
+      "panel_section_name": "Machine Learning",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/sklearn_svm_classifier/sklearn_svm_classifier/1.0.8.3"
+    },
+    {
+      "name": "Evaluate pairwise distances",
+      "id": "sklearn_pairwise_metrics",
+      "description": "or compute affinity or kernel for sets of samples",
+      "tool_shed_repository": "sklearn_pairwise_metrics",
+      "panel_section_name": "Machine Learning",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/sklearn_pairwise_metrics/sklearn_pairwise_metrics/1.0.8.3"
+    },
+    {
+      "name": "Ensemble methods",
+      "id": "sklearn_ensemble",
+      "description": "for classification and regression",
+      "tool_shed_repository": "sklearn_ensemble",
+      "panel_section_name": "Machine Learning",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/sklearn_ensemble/sklearn_ensemble/1.0.8.3"
+    },
+    {
+      "name": "Preprocess",
+      "id": "sklearn_data_preprocess",
+      "description": "raw feature vectors into standardized datasets",
+      "tool_shed_repository": "sklearn_data_preprocess",
+      "panel_section_name": "Machine Learning",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/sklearn_data_preprocess/sklearn_data_preprocess/1.0.8.3"
+    },
+    {
+      "name": "Calculate metrics",
+      "id": "sklearn_clf_metrics",
+      "description": "for classification performance",
+      "tool_shed_repository": "sklearn_clf_metrics",
+      "panel_section_name": "Machine Learning",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/sklearn_clf_metrics/sklearn_clf_metrics/1.0.8.3"
+    },
+    {
+      "name": "Generalized linear models",
+      "id": "sklearn_generalized_linear",
+      "description": "for classification and regression",
+      "tool_shed_repository": "sklearn_generalized_linear",
+      "panel_section_name": "Machine Learning",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/sklearn_generalized_linear/sklearn_generalized_linear/1.0.8.3"
+    },
+    {
+      "name": "Evaluate a Fitted Model",
+      "id": "sklearn_fitted_model_eval",
+      "description": "using a new batch of labeled data",
+      "tool_shed_repository": "sklearn_fitted_model_eval",
+      "panel_section_name": "Machine Learning",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/sklearn_fitted_model_eval/sklearn_fitted_model_eval/1.0.8.3"
+    },
+    {
+      "name": "Principal component analysis",
+      "id": "sklearn_pca",
+      "description": "with scikit-learn",
+      "tool_shed_repository": "sklearn_pca",
+      "panel_section_name": "Machine Learning",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/sklearn_pca/sklearn_pca/1.0.8.3+galaxy0"
+    },
+    {
+      "name": "Deep learning training and evaluation",
+      "id": "keras_train_and_eval",
+      "description": "conduct deep training and evaluation either implicitly or explicitly",
+      "tool_shed_repository": "keras_train_and_eval",
+      "panel_section_name": "Machine Learning",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/keras_train_and_eval/keras_train_and_eval/1.0.8.3"
+    },
+    {
+      "name": "Build Deep learning Batch Training Models",
+      "id": "keras_batch_models",
+      "description": "with online data generator for Genomic/Protein sequences and images",
+      "tool_shed_repository": "keras_batch_models",
+      "panel_section_name": "Machine Learning",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/keras_batch_models/keras_batch_models/0.5.0"
+    },
+    {
+      "name": "Create deep learning model",
+      "id": "keras_model_builder",
+      "description": "with an optimizer, loss function and fit parameters",
+      "tool_shed_repository": "keras_model_builder",
+      "panel_section_name": "Machine Learning",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/keras_model_builder/keras_model_builder/0.5.0"
+    },
+    {
+      "name": "Create a deep learning model architecture",
+      "id": "keras_model_config",
+      "description": "using Keras",
+      "tool_shed_repository": "keras_model_config",
+      "panel_section_name": "Machine Learning",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/keras_model_config/keras_model_config/0.5.0"
+    },
+    {
+      "name": "Sparse Matrix Functions",
+      "id": "scipy_sparse",
+      "description": "for manipulating 2-D Scipy sparse numeric data",
+      "tool_shed_repository": "scipy_sparse",
+      "panel_section_name": "Machine Learning",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/scipy_sparse/scipy_sparse/1.0.8.1"
+    },
+    {
+      "name": "Create a model to recommend tools",
+      "id": "create_tool_recommendation_model",
+      "description": "using deep learning",
+      "tool_shed_repository": "create_tool_recommendation_model",
+      "panel_section_name": "Machine Learning",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/create_tool_recommendation_model/create_tool_recommendation_model/0.0.1"
+    },
+    {
+      "name": "heatmap2",
+      "id": "ggplot2_heatmap2",
+      "description": "",
+      "tool_shed_repository": "ggplot2_heatmap2",
+      "panel_section_name": "Graph/Display Data",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/ggplot2_heatmap2/ggplot2_heatmap2/3.1.1+galaxy1"
+    },
+    {
+      "name": "pyGenomeTracks",
+      "id": "pygenomeTracks",
+      "description": "plot genomic data tracks",
+      "tool_shed_repository": "pygenometracks",
+      "panel_section_name": "Graph/Display Data",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/pygenometracks/pygenomeTracks/3.6+galaxy1"
+    },
+    {
+      "name": "Circos: Alignments to links",
+      "id": "circos_aln_to_links",
+      "description": "reformats alignment files to prepare for Circos",
+      "tool_shed_repository": "circos",
+      "panel_section_name": "Graph/Display Data",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/circos/circos_aln_to_links/0.69.8+galaxy9"
+    },
+    {
+      "name": "Circos: Link Density Track",
+      "id": "circos_binlinks",
+      "description": "reduce links to a density plot",
+      "tool_shed_repository": "circos",
+      "panel_section_name": "Graph/Display Data",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/circos/circos_binlinks/0.69.8+galaxy9"
+    },
+    {
+      "name": "Circos: Bundle Links",
+      "id": "circos_bundlelinks",
+      "description": "reduce numbers of links in datasets before plotting",
+      "tool_shed_repository": "circos",
+      "panel_section_name": "Graph/Display Data",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/circos/circos_bundlelinks/0.69.8+galaxy9"
+    },
+    {
+      "name": "GC Skew",
+      "id": "circos_gc_skew",
+      "description": "calculates skew over genomic sequences",
+      "tool_shed_repository": "circos",
+      "panel_section_name": "Graph/Display Data",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/circos/circos_gc_skew/0.69.8+galaxy9"
+    },
+    {
+      "name": "Circos: Resample 1/2D data",
+      "id": "circos_resample",
+      "description": "reduce numbers of points in a dataset before plotting",
+      "tool_shed_repository": "circos",
+      "panel_section_name": "Graph/Display Data",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/circos/circos_resample/0.69.8+galaxy9"
+    },
+    {
+      "name": "Circos: bigWig to Scatter",
+      "id": "circos_wiggle_to_scatter",
+      "description": "reformats bigWig files to prepare for Circos 2d scatter/line/histogram plots",
+      "tool_shed_repository": "circos",
+      "panel_section_name": "Graph/Display Data",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/circos/circos_wiggle_to_scatter/0.69.8+galaxy9"
+    },
+    {
+      "name": "Circos: Stack bigWigs as Histogram",
+      "id": "circos_wiggle_to_stacked",
+      "description": "reformats for use in Circos stacked histogram plots",
+      "tool_shed_repository": "circos",
+      "panel_section_name": "Graph/Display Data",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/circos/circos_wiggle_to_stacked/0.69.8+galaxy9"
+    },
+    {
+      "name": "Circos: Table viewer",
+      "id": "circos_tableviewer",
+      "description": "easily creates circos plots from tabular data",
+      "tool_shed_repository": "circos",
+      "panel_section_name": "Graph/Display Data",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/circos/circos_tableviewer/0.69.8+galaxy9"
+    },
+    {
+      "name": "Circos: Interval to Circos Text Labels",
+      "id": "circos_interval_to_text",
+      "description": "reformats interval files to prepare for Circos text labels",
+      "tool_shed_repository": "circos",
+      "panel_section_name": "Graph/Display Data",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/circos/circos_interval_to_text/0.69.8+galaxy9"
+    },
+    {
+      "name": "Circos: Interval to Tiles",
+      "id": "circos_interval_to_tile",
+      "description": "reformats interval files to prepare for Circos tile plots",
+      "tool_shed_repository": "circos",
+      "panel_section_name": "Graph/Display Data",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/circos/circos_interval_to_tile/0.69.8+galaxy9"
+    },
+    {
+      "name": "Pretext Snapshot",
+      "id": "pretext_snapshot",
+      "description": "image generator for Pretext contact maps",
+      "tool_shed_repository": "pretext_snapshot",
+      "panel_section_name": "Graph/Display Data",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/pretext_snapshot/pretext_snapshot/0.0.3+galaxy1"
+    },
+    {
+      "name": "Pairwise intersection",
+      "id": "intervene_pairwise",
+      "description": "and heatmap for genomic intervals",
+      "tool_shed_repository": "intervene",
+      "panel_section_name": "Graph/Display Data",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/intervene/intervene_pairwise/0.6.5"
+    },
+    {
+      "name": "UpSet diagram",
+      "id": "intervene_upset",
+      "description": "of intersection of genomic regions or list sets",
+      "tool_shed_repository": "intervene",
+      "panel_section_name": "Graph/Display Data",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/intervene/intervene_upset/0.6.5"
+    },
+    {
+      "name": "Volcano Plot",
+      "id": "volcanoplot",
+      "description": "create a volcano plot",
+      "tool_shed_repository": "volcanoplot",
+      "panel_section_name": "Graph/Display Data",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/volcanoplot/volcanoplot/0.0.5"
+    },
+    {
+      "name": "JBrowse - Data Directory to Standalone",
+      "id": "jbrowse_to_standalone",
+      "description": "upgrades the bare data directory to a full JBrowse instance",
+      "tool_shed_repository": "jbrowse",
+      "panel_section_name": "Graph/Display Data",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/jbrowse/jbrowse_to_standalone/1.16.11+galaxy1"
+    },
+    {
+      "name": "Paired-end histogram",
+      "id": "pe_histogram",
+      "description": "of insert size frequency",
+      "tool_shed_repository": "pe_histogram",
+      "panel_section_name": "Graph/Display Data",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/pe_histogram/pe_histogram/1.0.1"
+    },
+    {
+      "name": "Build custom track",
+      "id": "build_ucsc_custom_track_1",
+      "description": "for UCSC genome browser",
+      "tool_shed_repository": "ucsc_custom_track",
+      "panel_section_name": "Graph/Display Data",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/ucsc_custom_track/build_ucsc_custom_track_1/1.0.1"
+    },
+    {
+      "name": "Scatterplot",
+      "id": "scatterplot_rpy",
+      "description": "of two numeric columns",
+      "tool_shed_repository": "scatterplot",
+      "panel_section_name": "Graph/Display Data",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/scatterplot/scatterplot_rpy/1.0.3"
+    },
+    {
+      "name": "Histogram",
+      "id": "histogram_rpy",
+      "description": "of a numeric column",
+      "tool_shed_repository": "histogram",
+      "panel_section_name": "Graph/Display Data",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/histogram/histogram_rpy/1.0.4"
+    },
+    {
+      "name": "GMAJ",
+      "id": "gmaj_1",
+      "description": "Multiple Alignment Viewer",
+      "tool_shed_repository": "gmaj",
+      "panel_section_name": "Graph/Display Data",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/gmaj/gmaj_1/2.0.1"
+    },
+    {
+      "name": "Plotting tool",
+      "id": "XY_Plot_1",
+      "description": "for multiple series and graph types",
+      "tool_shed_repository": "xy_plot",
+      "panel_section_name": "Graph/Display Data",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/xy_plot/XY_Plot_1/1.0.2"
+    },
+    {
+      "name": "BAM Coverage Plotter",
+      "id": "jvarkit_wgscoverageplotter",
+      "description": "Plot read coverage across a genomic contig",
+      "tool_shed_repository": "jvarkit_wgscoverageplotter",
+      "panel_section_name": "Graph/Display Data",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/jvarkit_wgscoverageplotter/jvarkit_wgscoverageplotter/20201223+galaxy0"
+    },
+    {
+      "name": "Plot confusion matrix, precision, recall and ROC and AUC curves",
+      "id": "plotly_ml_performance_plots",
+      "description": "of tabular data",
+      "tool_shed_repository": "plotly_ml_performance_plots",
+      "panel_section_name": "Graph/Display Data",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/plotly_ml_performance_plots/plotly_ml_performance_plots/0.2"
+    },
+    {
+      "name": "Newick Display",
+      "id": "newick_display",
+      "description": "visualize a phylogenetic tree",
+      "tool_shed_repository": "newick_utils",
+      "panel_section_name": "Graph/Display Data",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/newick_utils/newick_display/1.6+galaxy1"
+    },
+    {
+      "name": "Krona pie chart",
+      "id": "taxonomy_krona_chart",
+      "description": "from taxonomic profile",
+      "tool_shed_repository": "taxonomy_krona_chart",
+      "panel_section_name": "Graph/Display Data",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/crs4/taxonomy_krona_chart/taxonomy_krona_chart/2.6.1"
+    },
+    {
+      "name": "Export to GraPhlAn",
+      "id": "export2graphlan",
+      "description": "",
+      "tool_shed_repository": "export2graphlan",
+      "panel_section_name": "Graph/Display Data",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/export2graphlan/export2graphlan/0.20+galaxy0"
+    },
+    {
+      "name": "Venn Diagram",
+      "id": "venn_list",
+      "description": "from lists",
+      "tool_shed_repository": "venn_list",
+      "panel_section_name": "Graph/Display Data",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/peterjc/venn_list/venn_list/0.1.1"
+    },
+    {
+      "name": "Plot actual vs predicted curves and residual plots",
+      "id": "plotly_regression_performance_plots",
+      "description": "of tabular data",
+      "tool_shed_repository": "plotly_regression_performance_plots",
+      "panel_section_name": "Graph/Display Data",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/plotly_regression_performance_plots/plotly_regression_performance_plots/0.1"
+    },
+    {
+      "name": "Parallel Coordinates Plot",
+      "id": "plotly_parallel_coordinates_plot",
+      "description": "of tabular data",
+      "tool_shed_repository": "plotly_parallel_coordinates_plot",
+      "panel_section_name": "Graph/Display Data",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/plotly_parallel_coordinates_plot/plotly_parallel_coordinates_plot/0.1"
+    },
+    {
+      "name": "Fasta nucleotide color plot",
+      "id": "four_color_plot",
+      "description": "",
+      "tool_shed_repository": "fasta_nucleotide_color_plot",
+      "panel_section_name": "Graph/Display Data",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/fasta_nucleotide_color_plot/four_color_plot/1.0.0"
+    },
+    {
+      "name": "GraPhlAn",
+      "id": "graphlan",
+      "description": "to produce graphical output of an input tree",
+      "tool_shed_repository": "graphlan",
+      "panel_section_name": "Graph/Display Data",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/graphlan/graphlan/1.0.0.0"
+    },
+    {
+      "name": "Generation, personalization and annotation of tree",
+      "id": "graphlan_annotate",
+      "description": "for GraPhlAn",
+      "tool_shed_repository": "graphlan_annotate",
+      "panel_section_name": "Graph/Display Data",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/graphlan_annotate/graphlan_annotate/1.0.0.0"
+    },
+    {
+      "name": "rtsne",
+      "id": "tsne",
+      "description": "",
+      "tool_shed_repository": "tsne",
+      "panel_section_name": "Graph/Display Data",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/tsne/tsne/0.0.2"
+    },
+    {
+      "name": "Visualize  with Krona",
+      "id": "krona-text",
+      "description": "Visualise any hierarchical data",
+      "tool_shed_repository": "krona_text",
+      "panel_section_name": "Graph/Display Data",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/saskia-hiltemann/krona_text/krona-text/1"
+    },
+    {
+      "name": "Fasta nucleotide color plot",
+      "id": "fasta_nucleotide_color_plot",
+      "description": "",
+      "tool_shed_repository": "fasta_nucleotide_color_plot",
+      "panel_section_name": "Graph/Display Data",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/fasta_nucleotide_color_plot/fasta_nucleotide_color_plot/1.0.1"
+    },
+    {
+      "name": "MUMmer dotplot",
+      "id": "mummerplot_wrapper",
+      "description": "Combine mummer/nucmer/promer with mummerplot",
+      "tool_shed_repository": "mummer",
+      "panel_section_name": "Graph/Display Data",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/peterjc/mummer/mummerplot_wrapper/0.0.7"
+    },
+    {
+      "name": "Karyotype Plotting tool",
+      "id": "karyotype_Plot_1",
+      "description": "for multiple series",
+      "tool_shed_repository": "karyotype_plot",
+      "panel_section_name": "Graph/Display Data",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/guru-ananda/karyotype_plot/karyotype_Plot_1/1.0.0"
+    },
+    {
+      "name": "codeML",
+      "id": "codeml",
+      "description": "Detects positive selection (paml package)",
+      "tool_shed_repository": "codeml",
+      "panel_section_name": "Evolution",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/codeml/codeml/4.9+galaxy2"
+    },
+    {
+      "name": "IQ-TREE",
+      "id": "iqtree",
+      "description": "Phylogenomic / evolutionary tree construction from multiple sequences",
+      "tool_shed_repository": "iqtree",
+      "panel_section_name": "Evolution",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/iqtree/iqtree/2.1.2+galaxy2"
+    },
+    {
+      "name": "TN93 Cluster",
+      "id": "tn93_cluster",
+      "description": "sequences that lie within a specific distance of each other",
+      "tool_shed_repository": "tn93_cluster",
+      "panel_section_name": "Evolution",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/tn93_cluster/tn93_cluster/1.0.6"
+    },
+    {
+      "name": "TN93",
+      "id": "tn93",
+      "description": "compute distances between aligned sequences",
+      "tool_shed_repository": "tn93",
+      "panel_section_name": "Evolution",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/tn93/tn93/1.0.6"
+    },
+    {
+      "name": "Join neighbors",
+      "id": "rapidnj",
+      "description": "rapidly with RapidNJ",
+      "tool_shed_repository": "rapidnj",
+      "panel_section_name": "Evolution",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/rapidnj/rapidnj/2.3.2"
+    },
+    {
+      "name": "TN93 Filter",
+      "id": "tn93_filter",
+      "description": "- remove sequences from a reference that are within a given distance of of a cluster",
+      "tool_shed_repository": "tn93_filter",
+      "panel_section_name": "Evolution",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/tn93_filter/tn93_filter/1.0.6"
+    },
+    {
+      "name": "Mutate Codons",
+      "id": "mutate_snp_codon_1",
+      "description": "with SNPs",
+      "tool_shed_repository": "mutate_snp_codon",
+      "panel_section_name": "Evolution",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/mutate_snp_codon/mutate_snp_codon_1/1.0.0"
+    },
+    {
+      "name": "Merge matching reads",
+      "id": "tn93_readreduce",
+      "description": "into clusters with TN-93",
+      "tool_shed_repository": "tn93_readreduce",
+      "panel_section_name": "Evolution",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/tn93_readreduce/tn93_readreduce/1.0.6"
+    },
+    {
+      "name": "MEME-ChIP",
+      "id": "meme_chip",
+      "description": "- motif discovery, enrichment analysis and clustering on large nucleotide datasets",
+      "tool_shed_repository": "meme_chip",
+      "panel_section_name": "Motif Tools",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/meme_chip/meme_chip/4.11.2+galaxy1"
+    },
+    {
+      "name": "Sequence Logo",
+      "id": "rgweblogo3",
+      "description": "generator for fasta (eg Clustal alignments)",
+      "tool_shed_repository": "weblogo3",
+      "panel_section_name": "Motif Tools",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/weblogo3/rgweblogo3/3.5.0"
+    },
+    {
+      "name": "MEME psp-gen",
+      "id": "meme_psp_gen",
+      "description": "- perform discriminative motif discovery",
+      "tool_shed_repository": "meme_psp_gen",
+      "panel_section_name": "Motif Tools",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/meme_psp_gen/meme_psp_gen/5.0.5.0"
+    },
+    {
+      "name": "DREME",
+      "id": "meme_dreme",
+      "description": "- Discriminative Regular Expression Motif Elicitation",
+      "tool_shed_repository": "meme_dreme",
+      "panel_section_name": "Motif Tools",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/meme_dreme/meme_dreme/4.11.2.0"
+    },
+    {
+      "name": "ChIPpeakAnno annoPeaks",
+      "id": "chipeakanno_annopeaks",
+      "description": "annotate peaks by annoGR object in the given range",
+      "tool_shed_repository": "chipeakanno_annopeaks",
+      "panel_section_name": "Test Tools",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/kpbioteam/chipeakanno_annopeaks/chipeakanno_annopeaks/0.1.0"
+    },
+    {
+      "name": "Cluster Profiler Bitr",
+      "id": "clusterprofiler_bitr",
+      "description": "converting ID types",
+      "tool_shed_repository": "clusterprofiler_bitr",
+      "panel_section_name": "Test Tools",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/kpbioteam/clusterprofiler_bitr/clusterprofiler_bitr/0.1.0"
+    },
+    {
+      "name": "Cluster Profiler GO",
+      "id": "clusterprofiler_go",
+      "description": "run GO Analysis",
+      "tool_shed_repository": "clusterprofiler_go",
+      "panel_section_name": "Test Tools",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/kpbioteam/clusterprofiler_go/clusterprofiler_go/0.1.0"
+    },
+    {
+      "name": "hifive",
+      "id": "hifive",
+      "description": "manipulate, analyze, and plot HiC and 5C chromatin interaction data",
+      "tool_shed_repository": "hifive",
+      "panel_section_name": "Test Tools",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/sauria/hifive/hifive/0.1.0"
+    },
+    {
+      "name": "NetCDF xarray map plotting",
+      "id": "xarray_mapplot",
+      "description": "Visualize netCDF variables on a geographical map",
+      "tool_shed_repository": "xarray_mapplot",
+      "panel_section_name": "GIS Data Handling",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/ecology/xarray_mapplot/xarray_mapplot/0.20.2+galaxy0"
+    },
+    {
+      "name": "NetCDF xarray Coordinate Info",
+      "id": "xarray_coords_info",
+      "description": "Get values for each coordinate of a Netcdf file",
+      "tool_shed_repository": "xarray_coords_info",
+      "panel_section_name": "GIS Data Handling",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/ecology/xarray_coords_info/xarray_coords_info/0.20.2+galaxy0"
+    },
+    {
+      "name": "NetCDF xarray Metadata Info",
+      "id": "xarray_metadata_info",
+      "description": "summarize content of a Netcdf file",
+      "tool_shed_repository": "xarray_metadata_info",
+      "panel_section_name": "GIS Data Handling",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/ecology/xarray_metadata_info/xarray_metadata_info/0.20.2+galaxy0"
+    },
+    {
+      "name": "NetCDF xarray Selection",
+      "id": "xarray_select",
+      "description": "extracts variable values with custom conditions on dimensions",
+      "tool_shed_repository": "xarray_select",
+      "panel_section_name": "GIS Data Handling",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/ecology/xarray_select/xarray_select/0.20.2+galaxy0"
+    },
+    {
+      "name": "NetCDF xarray operations",
+      "id": "xarray_netcdf2netcdf",
+      "description": "manipulate xarray from netCDF and save back to netCDF",
+      "tool_shed_repository": "xarray_netcdf2netcdf",
+      "panel_section_name": "GIS Data Handling",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/ecology/xarray_netcdf2netcdf/xarray_netcdf2netcdf/0.20.2+galaxy0"
+    },
+    {
+      "name": "OGR Informations",
+      "id": "gdal_ogrinfo",
+      "description": "lists information about an OGR supported data source",
+      "tool_shed_repository": "gdal_ogrinfo",
+      "panel_section_name": "GIS Data Handling",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/ecology/gdal_ogrinfo/gdal_ogrinfo/3.0.0"
+    },
+    {
+      "name": "OGR2ogr",
+      "id": "gdal_ogr2ogr",
+      "description": "converts simple features data between file formats",
+      "tool_shed_repository": "gdal_ogr2ogr",
+      "panel_section_name": "GIS Data Handling",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/ecology/gdal_ogr2ogr/gdal_ogr2ogr/3.0.0"
+    },
+    {
+      "name": "GDAL Warp",
+      "id": "gdal_gdalwarp",
+      "description": "image reprojection and warping utility",
+      "tool_shed_repository": "gdal_gdalwarp",
+      "panel_section_name": "GIS Data Handling",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/ecology/gdal_gdalwarp/gdal_gdalwarp/3.0.0"
+    },
+    {
+      "name": "GDAL Translate",
+      "id": "gdal_gdal_translate",
+      "description": "converts raster data between different formats.",
+      "tool_shed_repository": "gdal_gdal_translate",
+      "panel_section_name": "GIS Data Handling",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/ecology/gdal_gdal_translate/gdal_gdal_translate/3.0.0"
+    },
+    {
+      "name": "GDAL Merge",
+      "id": "gdal_gdal_merge",
+      "description": "mosaics a set of images",
+      "tool_shed_repository": "gdal_gdal_merge",
+      "panel_section_name": "GIS Data Handling",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/ecology/gdal_gdal_merge/gdal_gdal_merge/3.0.0"
+    },
+    {
+      "name": "GDAL Informations",
+      "id": "gdal_gdalinfo",
+      "description": "lists information about a raster dataset",
+      "tool_shed_repository": "gdal_gdalinfo",
+      "panel_section_name": "GIS Data Handling",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/ecology/gdal_gdalinfo/gdal_gdalinfo/3.0.0"
+    },
+    {
+      "name": "GDAL Build VRT",
+      "id": "gdal_gdalbuildvrt",
+      "description": "builds a VRT from a list of datasets",
+      "tool_shed_repository": "gdal_gdalbuildvrt",
+      "panel_section_name": "GIS Data Handling",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/ecology/gdal_gdalbuildvrt/gdal_gdalbuildvrt/3.0.0"
+    },
+    {
+      "name": "GDAL addo",
+      "id": "gdal_gdaladdo",
+      "description": "builds or rebuilds overview images",
+      "tool_shed_repository": "gdal_gdaladdo",
+      "panel_section_name": "GIS Data Handling",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/ecology/gdal_gdaladdo/gdal_gdaladdo/3.0.0"
+    },
+    {
+      "name": "Get species occurrences data",
+      "id": "spocc_occ",
+      "description": "from GBIF, ALA, iNAT and others",
+      "tool_shed_repository": "spocc_occ",
+      "panel_section_name": "Animal Detection on Acoustic Recordings",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/ecology/spocc_occ/spocc_occ/0.9.0"
+    },
+    {
+      "name": "Advanced restitution: 'Point fixe' protocol",
+      "id": "vigiechiro_bilanenrichipf",
+      "description": "from Animal Detection on Acoustic Recordings",
+      "tool_shed_repository": "vigiechiro_bilanenrichipf",
+      "panel_section_name": "Animal Detection on Acoustic Recordings",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/ecology/vigiechiro_bilanenrichipf/vigiechiro_bilanenrichipf/0.1.1"
+    },
+    {
+      "name": "Advanced restitution: 'Routier'or 'Pedestre' protocols",
+      "id": "vigiechiro_bilanenrichirp",
+      "description": "from Animal Detection on Acoustic Recordings",
+      "tool_shed_repository": "vigiechiro_bilanenrichirp",
+      "panel_section_name": "Animal Detection on Acoustic Recordings",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/ecology/vigiechiro_bilanenrichirp/vigiechiro_bilanenrichirp/0.1.1"
+    },
+    {
+      "name": "Tadarida data cleaner",
+      "id": "vigiechiro_idcorrect_2ndlayer",
+      "description": "clean data from animal detection on acoustic recordings",
+      "tool_shed_repository": "vigiechiro_idcorrect_2ndlayer",
+      "panel_section_name": "Animal Detection on Acoustic Recordings",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/ecology/vigiechiro_idcorrect_2ndlayer/vigiechiro_idcorrect_2ndlayer/0.1.1"
+    },
+    {
+      "name": "Tadarida identifications validation",
+      "id": "vigiechiro_idvalid",
+      "description": "Integrate identifications from animal detection on acoustic recordings",
+      "tool_shed_repository": "vigiechiro_idvalid",
+      "panel_section_name": "Animal Detection on Acoustic Recordings",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/ecology/vigiechiro_idvalid/vigiechiro_idvalid/0.1.1"
+    },
+    {
+      "name": "Fetch Indels",
+      "id": "indels_3way",
+      "description": "from 3-way alignments",
+      "tool_shed_repository": "indels_3way",
+      "panel_section_name": "Regional Variation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/indels_3way/indels_3way/1.0.3"
+    },
+    {
+      "name": "Draw Stacked Bar Plots",
+      "id": "draw_stacked_barplots",
+      "description": "for different categories and different criteria",
+      "tool_shed_repository": "draw_stacked_barplots",
+      "panel_section_name": "Regional Variation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/draw_stacked_barplots/draw_stacked_barplots/1.0.0"
+    },
+    {
+      "name": "Delete Overlapping Indels",
+      "id": "delete_overlapping_indels",
+      "description": "from a chromosome indels file",
+      "tool_shed_repository": "delete_overlapping_indels",
+      "panel_section_name": "Regional Variation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/delete_overlapping_indels/delete_overlapping_indels/1.0.0"
+    },
+    {
+      "name": "Compute Motif Frequencies",
+      "id": "compute_motifs_frequency",
+      "description": "in indel flanking regions",
+      "tool_shed_repository": "compute_motifs_frequency",
+      "panel_section_name": "Regional Variation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/compute_motifs_frequency/compute_motifs_frequency/1.0.0"
+    },
+    {
+      "name": "Compute Motif Frequencies For All Motifs",
+      "id": "compute_motif_frequencies_for_all_motifs",
+      "description": "motif by motif",
+      "tool_shed_repository": "compute_motif_frequencies_for_all_motifs",
+      "panel_section_name": "Regional Variation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/compute_motif_frequencies_for_all_motifs/compute_motif_frequencies_for_all_motifs/1.0.0"
+    },
+    {
+      "name": "Categorize Elements",
+      "id": "categorize_elements_satisfying_criteria",
+      "description": "satisfying criteria",
+      "tool_shed_repository": "categorize_elements_satisfying_criteria",
+      "panel_section_name": "Regional Variation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/categorize_elements_satisfying_criteria/categorize_elements_satisfying_criteria/1.0.0"
+    },
+    {
+      "name": "Feature coverage",
+      "id": "featureCoverage1",
+      "description": "",
+      "tool_shed_repository": "featurecounter",
+      "panel_section_name": "Regional Variation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/featurecounter/featureCoverage1/2.0.0"
+    },
+    {
+      "name": "FASTTREE",
+      "id": "fasttree",
+      "description": "build maximum-likelihood phylogenetic trees",
+      "tool_shed_repository": "fasttree",
+      "panel_section_name": "Genome Diversity",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/fasttree/fasttree/2.1.10+galaxy1"
+    },
+    {
+      "name": "Make File",
+      "id": "gd_make_gd_file",
+      "description": ": Build a gd_snp or gd_genotype file",
+      "tool_shed_repository": "genome_diversity",
+      "panel_section_name": "Genome Diversity",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/miller-lab/genome_diversity/gd_make_gd_file/1.0.0"
+    },
+    {
+      "name": "Specify Individuals",
+      "id": "gd_specify",
+      "description": ": Define a collection of individuals from a gd_snp dataset",
+      "tool_shed_repository": "genome_diversity",
+      "panel_section_name": "Genome Diversity",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/miller-lab/genome_diversity/gd_specify/1.1.0"
+    },
+    {
+      "name": "Nucleotide Diversity",
+      "id": "gd_nucleotide_diversity_pi",
+      "description": ": &pi; and &theta;",
+      "tool_shed_repository": "genome_diversity",
+      "panel_section_name": "Genome Diversity",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/miller-lab/genome_diversity/gd_nucleotide_diversity_pi/1.0.0"
+    },
+    {
+      "name": "Founders sequenced",
+      "id": "gd_offspring_heterozygosity_pedigree",
+      "description": ": Offspring estimated heterozygosity from a pedigree with sequenced founders",
+      "tool_shed_repository": "genome_diversity",
+      "panel_section_name": "Genome Diversity",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/miller-lab/genome_diversity/gd_offspring_heterozygosity_pedigree/1.0.0"
+    },
+    {
+      "name": "Matings",
+      "id": "gd_assignment_of_optimal_breeding_pairs",
+      "description": ": Assignment of optimal breeding pairs",
+      "tool_shed_repository": "genome_diversity",
+      "panel_section_name": "Genome Diversity",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/miller-lab/genome_diversity/gd_assignment_of_optimal_breeding_pairs/1.0.0"
+    },
+    {
+      "name": "Phylogenetic Tree",
+      "id": "gd_phylogenetic_tree",
+      "description": ": Show genetic relationships among individuals",
+      "tool_shed_repository": "genome_diversity",
+      "panel_section_name": "Genome Diversity",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/miller-lab/genome_diversity/gd_phylogenetic_tree/1.1.0"
+    },
+    {
+      "name": "Admixture",
+      "id": "gd_dpmix",
+      "description": ": Map genomic intervals resembling specified source populations",
+      "tool_shed_repository": "genome_diversity",
+      "panel_section_name": "Genome Diversity",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/miller-lab/genome_diversity/gd_dpmix/1.2.0"
+    },
+    {
+      "name": "Phylip",
+      "id": "gd_make_phylip",
+      "description": ": prepare data for phylogenetic analysis",
+      "tool_shed_repository": "genome_diversity",
+      "panel_section_name": "Genome Diversity",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/miller-lab/genome_diversity/gd_make_phylip/1.1.0"
+    },
+    {
+      "name": "Diversity",
+      "id": "gd_diversity_pi",
+      "description": ": pi, allowing for unsequenced intervals",
+      "tool_shed_repository": "genome_diversity",
+      "panel_section_name": "Genome Diversity",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/miller-lab/genome_diversity/gd_diversity_pi/1.1.0"
+    },
+    {
+      "name": "Draw variants",
+      "id": "gd_draw_variants",
+      "description": ": show positions of SNVs and unsequenced intervals",
+      "tool_shed_repository": "genome_diversity",
+      "panel_section_name": "Genome Diversity",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/miller-lab/genome_diversity/gd_draw_variants/1.1.0"
+    },
+    {
+      "name": "Remarkable Intervals",
+      "id": "gd_find_intervals",
+      "description": ": Find high-scoring runs of SNPs",
+      "tool_shed_repository": "genome_diversity",
+      "panel_section_name": "Genome Diversity",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/miller-lab/genome_diversity/gd_find_intervals/1.1.0"
+    },
+    {
+      "name": "Differential Cleavage",
+      "id": "gd_specify_restriction_enzymes",
+      "description": ": Select SNPs differentially cut by specified restriction enzymes",
+      "tool_shed_repository": "genome_diversity",
+      "panel_section_name": "Genome Diversity",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/miller-lab/genome_diversity/gd_specify_restriction_enzymes/1.0.0"
+    },
+    {
+      "name": "Reorder individuals",
+      "id": "gd_reorder",
+      "description": ": exchange rows in the above picture",
+      "tool_shed_repository": "genome_diversity",
+      "panel_section_name": "Genome Diversity",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/miller-lab/genome_diversity/gd_reorder/1.0.0"
+    },
+    {
+      "name": "Pairs sequenced",
+      "id": "gd_offspring_heterozygosity",
+      "description": ": Offspring estimated heterozygosity of sequenced pairs",
+      "tool_shed_repository": "genome_diversity",
+      "panel_section_name": "Genome Diversity",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/miller-lab/genome_diversity/gd_offspring_heterozygosity/1.0.0"
+    },
+    {
+      "name": "Inbreeding and kinship",
+      "id": "gd_inbreeding_and_kinship",
+      "description": ": Analyze the pedigree without genomic data",
+      "tool_shed_repository": "genome_diversity",
+      "panel_section_name": "Genome Diversity",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/miller-lab/genome_diversity/gd_inbreeding_and_kinship/1.0.0"
+    },
+    {
+      "name": "Ancestry",
+      "id": "gd_population_structure",
+      "description": ": Characterize ancestries w.r.t. inferred ancestral populations",
+      "tool_shed_repository": "genome_diversity",
+      "panel_section_name": "Genome Diversity",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/miller-lab/genome_diversity/gd_population_structure/1.0.0"
+    },
+    {
+      "name": "Population Complexity",
+      "id": "gd_evaluate_population_numbers",
+      "description": ": Evaluate possible numbers of ancestral populations",
+      "tool_shed_repository": "genome_diversity",
+      "panel_section_name": "Genome Diversity",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/miller-lab/genome_diversity/gd_evaluate_population_numbers/1.0.0"
+    },
+    {
+      "name": "Prepare Input",
+      "id": "gd_prepare_population_structure",
+      "description": ": Filter and convert to the format needed for these tools",
+      "tool_shed_repository": "genome_diversity",
+      "panel_section_name": "Genome Diversity",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/miller-lab/genome_diversity/gd_prepare_population_structure/1.2.0"
+    },
+    {
+      "name": "Aggregate Individuals",
+      "id": "gd_sum_gd_snp",
+      "description": ": Append summary columns for a population",
+      "tool_shed_repository": "genome_diversity",
+      "panel_section_name": "Genome Diversity",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/miller-lab/genome_diversity/gd_sum_gd_snp/1.1.0"
+    },
+    {
+      "name": "RAxML",
+      "id": "gd_raxml",
+      "description": ": construct a maximum-likelihood phylogenetic tree",
+      "tool_shed_repository": "genome_diversity",
+      "panel_section_name": "Genome Diversity",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/miller-lab/genome_diversity/gd_raxml/1.0.0"
+    },
+    {
+      "name": "Phyogenetic reconstruction with RAxML",
+      "id": "raxml",
+      "description": "- Maximum Likelihood based inference of large phylogenetic trees",
+      "tool_shed_repository": "raxml",
+      "panel_section_name": "Genome Diversity",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/raxml/raxml/8.2.4+galaxy2"
+    },
+    {
+      "name": "gd_snp to VCF",
+      "id": "gd_gd_snp2vcf",
+      "description": ": Convert from gd_snp or gd_genotype to VCF format, for submission to dbSNP",
+      "tool_shed_repository": "genome_diversity",
+      "panel_section_name": "Genome Diversity",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/miller-lab/genome_diversity/gd_gd_snp2vcf/1.1.0"
+    },
+    {
+      "name": "Overall FST",
+      "id": "gd_average_fst",
+      "description": ": Estimate the relative fixation index between two populations",
+      "tool_shed_repository": "genome_diversity",
+      "panel_section_name": "Genome Diversity",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/miller-lab/genome_diversity/gd_average_fst/1.3.0"
+    },
+    {
+      "name": "Pathway Image",
+      "id": "gd_pathway_image",
+      "description": ": Draw a KEGG pathway, highlighting specified gene modules",
+      "tool_shed_repository": "genome_diversity",
+      "panel_section_name": "Genome Diversity",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/miller-lab/genome_diversity/gd_pathway_image/1.1.0"
+    },
+    {
+      "name": "Close relatives",
+      "id": "gd_discover_familial_relationships",
+      "description": ": Discover familial relationships",
+      "tool_shed_repository": "genome_diversity",
+      "panel_section_name": "Genome Diversity",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/miller-lab/genome_diversity/gd_discover_familial_relationships/1.0.0"
+    },
+    {
+      "name": "PCA",
+      "id": "gd_pca",
+      "description": ": Principal Components Analysis of genotype data",
+      "tool_shed_repository": "genome_diversity",
+      "panel_section_name": "Genome Diversity",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/miller-lab/genome_diversity/gd_pca/1.0.0"
+    },
+    {
+      "name": "Filter SNPs",
+      "id": "gd_filter_gd_snp",
+      "description": ": Discard some SNPs based on coverage, quality or spacing",
+      "tool_shed_repository": "genome_diversity",
+      "panel_section_name": "Genome Diversity",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/miller-lab/genome_diversity/gd_filter_gd_snp/1.2.0"
+    },
+    {
+      "name": "Coverage Distributions",
+      "id": "gd_coverage_distributions",
+      "description": ": Examine sequence coverage for SNPs",
+      "tool_shed_repository": "genome_diversity",
+      "panel_section_name": "Genome Diversity",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/miller-lab/genome_diversity/gd_coverage_distributions/1.0.0"
+    },
+    {
+      "name": "Pick Primers",
+      "id": "gd_extract_primers",
+      "description": ": Find suitable PCR primers for SNPs",
+      "tool_shed_repository": "genome_diversity",
+      "panel_section_name": "Genome Diversity",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/miller-lab/genome_diversity/gd_extract_primers/1.0.0"
+    },
+    {
+      "name": "Flanking Sequence",
+      "id": "gd_extract_flanking_dna",
+      "description": ": Fetch DNA sequence for intervals surrounding the given SNPs",
+      "tool_shed_repository": "genome_diversity",
+      "panel_section_name": "Genome Diversity",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/miller-lab/genome_diversity/gd_extract_flanking_dna/1.0.0"
+    },
+    {
+      "name": "Rank Pathways",
+      "id": "gd_calc_freq",
+      "description": ": Assess the impact of a gene set on KEGG pathways",
+      "tool_shed_repository": "genome_diversity",
+      "panel_section_name": "Genome Diversity",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/miller-lab/genome_diversity/gd_calc_freq/1.2.0"
+    },
+    {
+      "name": "Per-SNP FSTs",
+      "id": "gd_add_fst_column",
+      "description": ": Compute a fixation index score for each SNP",
+      "tool_shed_repository": "genome_diversity",
+      "panel_section_name": "Genome Diversity",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/miller-lab/genome_diversity/gd_add_fst_column/1.2.0"
+    },
+    {
+      "name": "Sample SNPs",
+      "id": "gd_select_snps",
+      "description": ": Select a specified number of SNPs, uniformly spaced",
+      "tool_shed_repository": "genome_diversity",
+      "panel_section_name": "Genome Diversity",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/miller-lab/genome_diversity/gd_select_snps/1.0.0"
+    },
+    {
+      "name": "Restore Attributes",
+      "id": "gd_restore_attributes",
+      "description": ": Fill in missing properties for a gd_snp or gd_genotype dataset",
+      "tool_shed_repository": "genome_diversity",
+      "panel_section_name": "Genome Diversity",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/miller-lab/genome_diversity/gd_restore_attributes/1.1.0"
+    },
+    {
+      "name": "Convert",
+      "id": "gd_multiple_to_gd_genotype",
+      "description": ": CSV, FSTAT, Genepop or VCF to either gd_snp or gd_genotype",
+      "tool_shed_repository": "genome_diversity",
+      "panel_section_name": "Genome Diversity",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/miller-lab/genome_diversity/gd_multiple_to_gd_genotype/1.0.0"
+    },
+    {
+      "name": "Rank Terms",
+      "id": "gd_rank_terms",
+      "description": ": Assess the enrichment/depletion of a gene set for GO terms",
+      "tool_shed_repository": "genome_diversity",
+      "panel_section_name": "Genome Diversity",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/miller-lab/genome_diversity/gd_rank_terms/1.1.0"
+    },
+    {
+      "name": "Get Pathways",
+      "id": "gd_new_oscar",
+      "description": ": Look up KEGG pathways for given Ensembl transcripts",
+      "tool_shed_repository": "genome_diversity",
+      "panel_section_name": "Genome Diversity",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/miller-lab/genome_diversity/gd_new_oscar/1.0.0"
+    },
+    {
+      "name": "Cluster KEGG",
+      "id": "gd_cluster_kegg",
+      "description": ": Group gene categories connected by shared genes",
+      "tool_shed_repository": "genome_diversity",
+      "panel_section_name": "Genome Diversity",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/miller-lab/genome_diversity/gd_cluster_kegg/1.0.0"
+    },
+    {
+      "name": "CDO get info",
+      "id": "cdo_info",
+      "description": "Climate Data Information Operators to get information on Climate and NWP model data",
+      "tool_shed_repository": "cdo_info",
+      "panel_section_name": "Climate Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/climate/cdo_info/cdo_info/2.0.0+galaxy0"
+    },
+    {
+      "name": "CDO Operations",
+      "id": "cdo_operations",
+      "description": "Climate Data Manipulation Operators operations for standard processing of climate and NWP model output.",
+      "tool_shed_repository": "cdo_operations",
+      "panel_section_name": "Climate Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/climate/cdo_operations/cdo_operations/2.0.0+galaxy0"
+    },
+    {
+      "name": "EODIE",
+      "id": "eodie",
+      "description": "converts simple features data between file formats",
+      "tool_shed_repository": "eodie",
+      "panel_section_name": "Climate Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/climate/eodie/eodie/1.0.2"
+    },
+    {
+      "name": "Copernicus Atmosphere Data Store",
+      "id": "cads",
+      "description": "for retrieving data from the Atmosphere Monitoring Service",
+      "tool_shed_repository": "cads",
+      "panel_section_name": "Climate Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/climate/cads/cads/0.1.0"
+    },
+    {
+      "name": "CESM",
+      "id": "cesm",
+      "description": "Community Earth System Model",
+      "tool_shed_repository": "cesm",
+      "panel_section_name": "Climate Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/climate/cesm/cesm/2.1.3+galaxy0"
+    },
+    {
+      "name": "Copernicus Climate Data Store",
+      "id": "c3s",
+      "description": "for retrieveing climate data",
+      "tool_shed_repository": "c3s",
+      "panel_section_name": "Climate Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/climate/c3s/c3s/0.1.0"
+    },
+    {
+      "name": "CTSM/FATES-EMERALD",
+      "id": "ctsm_fates",
+      "description": "Functionally Assembled Terrestrial Ecosystem Simulator",
+      "tool_shed_repository": "ctsm_fates",
+      "panel_section_name": "Climate Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/climate/ctsm_fates/ctsm_fates/2.0.1.1"
+    },
+    {
+      "name": "Copernicus Essential Climate Variables",
+      "id": "cds_essential_variability",
+      "description": "for assessing climate variability",
+      "tool_shed_repository": "cds_essential_variability",
+      "panel_section_name": "Climate Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/climate/cds_essential_variability/cds_essential_variability/0.2.0"
+    },
+    {
+      "name": "climate stripes",
+      "id": "climate_stripes",
+      "description": "from timeseries",
+      "tool_shed_repository": "climate_stripes",
+      "panel_section_name": "Climate Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/climate/climate_stripes/climate_stripes/1.0.1"
+    },
+    {
+      "name": "map plot",
+      "id": "psy_maps",
+      "description": "gridded (lat/lon) netCDF data",
+      "tool_shed_repository": "psy_maps",
+      "panel_section_name": "Climate Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/climate/psy_maps/psy_maps/1.2.1"
+    },
+    {
+      "name": "zonal statistics",
+      "id": "mean_per_zone",
+      "description": "over each area",
+      "tool_shed_repository": "mean_per_zone",
+      "panel_section_name": "Climate Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/climate/mean_per_zone/mean_per_zone/0.2.0"
+    },
+    {
+      "name": "shift longitudes",
+      "id": "shyft_longitudes",
+      "description": "from netCDF data",
+      "tool_shed_repository": "shift_longitudes",
+      "panel_section_name": "Climate Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/climate/shift_longitudes/shyft_longitudes/0.1.0"
+    },
+    {
+      "name": "Retrieve JBrowse",
+      "id": "fetch_jbrowse",
+      "description": "for an organism, from Apollo",
+      "tool_shed_repository": "apollo_fetch_jbrowse",
+      "panel_section_name": "Apollo",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/gga/apollo_fetch_jbrowse/fetch_jbrowse/4.2.13+galaxy0"
+    },
+    {
+      "name": "GFF3 to Apollo Annotations",
+      "id": "feat_from_gff3",
+      "description": "",
+      "tool_shed_repository": "apollo_feat_from_gff3",
+      "panel_section_name": "Apollo",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/gga/apollo_feat_from_gff3/feat_from_gff3/4.2.13+galaxy0"
+    },
+    {
+      "name": "Retrieve Data",
+      "id": "export",
+      "description": "from Apollo into Galaxy",
+      "tool_shed_repository": "apollo_export",
+      "panel_section_name": "Apollo",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/gga/apollo_export/export/4.2.13+galaxy0"
+    },
+    {
+      "name": "Annotate",
+      "id": "iframe",
+      "description": "opens an IFrame to Apollo",
+      "tool_shed_repository": "apollo_iframe",
+      "panel_section_name": "Apollo",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/gga/apollo_iframe/iframe/4.2.13+galaxy0"
+    },
+    {
+      "name": "Create or Update Organism",
+      "id": "create_or_update",
+      "description": "will create the organism if it doesn't exist, and update otherwise",
+      "tool_shed_repository": "apollo_create_or_update",
+      "panel_section_name": "Apollo",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/gga/apollo_create_or_update/create_or_update/4.2.13+galaxy0"
+    },
+    {
+      "name": "Delete an Apollo record",
+      "id": "delete_organism",
+      "description": "",
+      "tool_shed_repository": "apollo_delete_organism",
+      "panel_section_name": "Apollo",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/gga/apollo_delete_organism/delete_organism/4.2.13+galaxy0"
+    },
+    {
+      "name": "Register Account",
+      "id": "create_account",
+      "description": "with Apollo",
+      "tool_shed_repository": "apollo_create_account",
+      "panel_section_name": "Apollo",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/gga/apollo_create_account/create_account/4.2.13+galaxy0"
+    },
+    {
+      "name": "List Organisms",
+      "id": "list_organism",
+      "description": "in Apollo",
+      "tool_shed_repository": "apollo_list_organism",
+      "panel_section_name": "Apollo",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/gga/apollo_list_organism/list_organism/4.2.13+galaxy0"
+    },
+    {
+      "name": "Delete all annotations from an Apollo record",
+      "id": "delete_features",
+      "description": "",
+      "tool_shed_repository": "apollo_delete_features",
+      "panel_section_name": "Apollo",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/gga/apollo_delete_features/delete_features/4.2.13+galaxy0"
+    },
+    {
+      "name": "Projective Transformation",
+      "id": "ip_projective_transformation",
+      "description": "of 2D images",
+      "tool_shed_repository": "projective_transformation",
+      "panel_section_name": "Imaging",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/imgteam/projective_transformation/ip_projective_transformation/0.1.2"
+    },
+    {
+      "name": "Image Registration",
+      "id": "ip_image_registration",
+      "description": "based on intensity information",
+      "tool_shed_repository": "image_registration_affine",
+      "panel_section_name": "Imaging",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/imgteam/image_registration_affine/ip_image_registration/0.0.3"
+    },
+    {
+      "name": "Overlay Images",
+      "id": "ip_overlay_images",
+      "description": "for visualization",
+      "tool_shed_repository": "overlay_images",
+      "panel_section_name": "Imaging",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/imgteam/overlay_images/ip_overlay_images/0.0.1"
+    },
+    {
+      "name": "Landmark Registration",
+      "id": "ip_landmark_registration_ls",
+      "description": "using least squares",
+      "tool_shed_repository": "landmark_registration_ls",
+      "panel_section_name": "Imaging",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/imgteam/landmark_registration_ls/ip_landmark_registration_ls/0.0.2"
+    },
+    {
+      "name": "Local Threshold",
+      "id": "ip_localthreshold",
+      "description": "applies a local threshold algorithm to an image",
+      "tool_shed_repository": "2d_local_threshold",
+      "panel_section_name": "Imaging",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/imgteam/2d_local_threshold/ip_localthreshold/0.0.3"
+    },
+    {
+      "name": "Auto Threshold",
+      "id": "ip_threshold",
+      "description": "applies a standard thresholding algorithm to an image",
+      "tool_shed_repository": "2d_auto_threshold",
+      "panel_section_name": "Imaging",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/imgteam/2d_auto_threshold/ip_threshold/0.0.5"
+    },
+    {
+      "name": "Projective Transformation",
+      "id": "ip_projective_transformation_points",
+      "description": "of ROIs defined by pixel (point) coordinates",
+      "tool_shed_repository": "projective_transformation_points",
+      "panel_section_name": "Imaging",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/imgteam/projective_transformation_points/ip_projective_transformation_points/0.1.1"
+    },
+    {
+      "name": "IDR/OMERO Download",
+      "id": "idr_download_by_ids",
+      "description": "- download images from any OMERO instance using image IDs",
+      "tool_shed_repository": "idr_download_by_ids",
+      "panel_section_name": "Imaging",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/idr_download_by_ids/idr_download_by_ids/0.44"
+    },
+    {
+      "name": "Spot Detection",
+      "id": "ip_spot_detection_2d",
+      "description": "in a 2D image (sequence)",
+      "tool_shed_repository": "spot_detection_2d",
+      "panel_section_name": "Imaging",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/imgteam/spot_detection_2d/ip_spot_detection_2d/0.0.2"
+    },
+    {
+      "name": "Association of points",
+      "id": "ip_points_association_nn",
+      "description": "in consecutive frames (slices) using the nearest neighbor algorithm",
+      "tool_shed_repository": "points_association_nn",
+      "panel_section_name": "Imaging",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/imgteam/points_association_nn/ip_points_association_nn/0.0.2"
+    },
+    {
+      "name": "Curve Fitting",
+      "id": "ip_curve_fitting",
+      "description": "to data points using (1st- or 2nd-degree) polynomial function",
+      "tool_shed_repository": "curve_fitting",
+      "panel_section_name": "Imaging",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/imgteam/curve_fitting/ip_curve_fitting/0.0.1"
+    },
+    {
+      "name": "CellProfiler",
+      "id": "cp_cellprofiler",
+      "description": "run a CellProfiler pipeline",
+      "tool_shed_repository": "cp_cellprofiler",
+      "panel_section_name": "Imaging",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/cp_cellprofiler/cp_cellprofiler/3.1.9+galaxy0"
+    },
+    {
+      "name": "Starting Modules",
+      "id": "cp_common",
+      "description": "load images and metadata into CellProfiler (Images, Metadata, NamesAndTypes, Groups)",
+      "tool_shed_repository": "cp_common",
+      "panel_section_name": "Imaging",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/cp_common/cp_common/3.1.9+galaxy1"
+    },
+    {
+      "name": "ColorToGray",
+      "id": "cp_color_to_gray",
+      "description": "converts color and channel-stacked images to grayscale",
+      "tool_shed_repository": "cp_color_to_gray",
+      "panel_section_name": "Imaging",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/cp_color_to_gray/cp_color_to_gray/3.1.9+galaxy0"
+    },
+    {
+      "name": "Tile",
+      "id": "cp_tile",
+      "description": "tiles images together to form large montage images",
+      "tool_shed_repository": "cp_tile",
+      "panel_section_name": "Imaging",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/cp_tile/cp_tile/3.1.9+galaxy0"
+    },
+    {
+      "name": "TrackObjects",
+      "id": "cp_track_objects",
+      "description": "tracking objects throughout sequential frames of a series of images",
+      "tool_shed_repository": "cp_track_objects",
+      "panel_section_name": "Imaging",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/cp_track_objects/cp_track_objects/3.1.9+galaxy0"
+    },
+    {
+      "name": "Landmark Registration",
+      "id": "ip_landmark_registration",
+      "description": "estimates the affine transformation matrix",
+      "tool_shed_repository": "landmark_registration",
+      "panel_section_name": "Imaging",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/imgteam/landmark_registration/ip_landmark_registration/0.0.4"
+    },
+    {
+      "name": "OverlayOutlines",
+      "id": "cp_overlay_outlines",
+      "description": "places outlines of objects over a desired image.",
+      "tool_shed_repository": "cp_overlay_outlines",
+      "panel_section_name": "Imaging",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/cp_overlay_outlines/cp_overlay_outlines/3.1.9+galaxy0"
+    },
+    {
+      "name": "ConvertObjectsToImage",
+      "id": "cp_convert_objects_to_image",
+      "description": "convert the identified objects into an image",
+      "tool_shed_repository": "cp_convert_objects_to_image",
+      "panel_section_name": "Imaging",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/cp_convert_objects_to_image/cp_convert_objects_to_image/3.1.9+galaxy0"
+    },
+    {
+      "name": "DisplayDataOnImage",
+      "id": "cp_display_data_on_image",
+      "description": "produce an image with data on top of identified objects",
+      "tool_shed_repository": "cp_display_data_on_image",
+      "panel_section_name": "Imaging",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/cp_display_data_on_image/cp_display_data_on_image/3.1.9+galaxy0"
+    },
+    {
+      "name": "EnhanceOrSuppressFeatures",
+      "id": "cp_enhance_or_suppress_features",
+      "description": "to improve subsequent identification of objects",
+      "tool_shed_repository": "cp_enhance_or_suppress_features",
+      "panel_section_name": "Imaging",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/cp_enhance_or_suppress_features/cp_enhance_or_suppress_features/3.1.9+galaxy0"
+    },
+    {
+      "name": "ExportToSpreadsheet",
+      "id": "cp_export_to_spreadsheet",
+      "description": "export measurements into one or more files",
+      "tool_shed_repository": "cp_export_to_spreadsheet",
+      "panel_section_name": "Imaging",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/cp_export_to_spreadsheet/cp_export_to_spreadsheet/3.1.9+galaxy1"
+    },
+    {
+      "name": "GrayToColor",
+      "id": "cp_gray_to_color",
+      "description": "take grayscale images and produces a color image from them",
+      "tool_shed_repository": "cp_gray_to_color",
+      "panel_section_name": "Imaging",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/cp_gray_to_color/cp_gray_to_color/3.1.9+galaxy0"
+    },
+    {
+      "name": "IdentifyPrimaryObjects",
+      "id": "cp_identify_primary_objects",
+      "description": "identify biological objects of interest",
+      "tool_shed_repository": "cp_identify_primary_objects",
+      "panel_section_name": "Imaging",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/cp_identify_primary_objects/cp_identify_primary_objects/3.1.9+galaxy1"
+    },
+    {
+      "name": "MaskImage",
+      "id": "cp_mask_image",
+      "description": "hide portions of an image based on previously identified objects",
+      "tool_shed_repository": "cp_mask_image",
+      "panel_section_name": "Imaging",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/cp_mask_image/cp_mask_image/3.1.9+galaxy0"
+    },
+    {
+      "name": "MeasureGranularity",
+      "id": "cp_measure_granularity",
+      "description": "output spectra of size measurements of the textures",
+      "tool_shed_repository": "cp_measure_granularity",
+      "panel_section_name": "Imaging",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/cp_measure_granularity/cp_measure_granularity/3.1.9+galaxy0"
+    },
+    {
+      "name": "MeasureImageAreaOccupied",
+      "id": "cp_measure_image_area_occupied",
+      "description": "measure the area in an image occupied by objects",
+      "tool_shed_repository": "cp_measure_image_area_occupied",
+      "panel_section_name": "Imaging",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/cp_measure_image_area_occupied/cp_measure_image_area_occupied/3.1.9+galaxy0"
+    },
+    {
+      "name": "MeasureImageIntensity",
+      "id": "cp_measure_image_intensity",
+      "description": "measure several intensity features across an entire image",
+      "tool_shed_repository": "cp_measure_image_intensity",
+      "panel_section_name": "Imaging",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/cp_measure_image_intensity/cp_measure_image_intensity/3.1.9+galaxy0"
+    },
+    {
+      "name": "MeasureImageQuality",
+      "id": "cp_measure_image_quality",
+      "description": "measure features that indicate image quality",
+      "tool_shed_repository": "cp_measure_image_quality",
+      "panel_section_name": "Imaging",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/cp_measure_image_quality/cp_measure_image_quality/3.1.9+galaxy0"
+    },
+    {
+      "name": "MeasureObjectIntensity",
+      "id": "cp_measure_object_intensity",
+      "description": "measure several intensity features for identified objects",
+      "tool_shed_repository": "cp_measure_object_intensity",
+      "panel_section_name": "Imaging",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/cp_measure_object_intensity/cp_measure_object_intensity/3.1.9+galaxy0"
+    },
+    {
+      "name": "MeasureObjectSizeShape",
+      "id": "cp_measure_object_size_shape",
+      "description": "measure area and shape features of identified objects",
+      "tool_shed_repository": "cp_measure_object_size_shape",
+      "panel_section_name": "Imaging",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/cp_measure_object_size_shape/cp_measure_object_size_shape/3.1.9+galaxy0"
+    },
+    {
+      "name": "MeasureTexture",
+      "id": "cp_measure_texture",
+      "description": "quantify the roughness and smoothness of the textures",
+      "tool_shed_repository": "cp_measure_texture",
+      "panel_section_name": "Imaging",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/cp_measure_texture/cp_measure_texture/3.1.9+galaxy0"
+    },
+    {
+      "name": "RelateObjects",
+      "id": "cp_relate_objects",
+      "description": "assign relationships parent-children between objects",
+      "tool_shed_repository": "cp_relate_objects",
+      "panel_section_name": "Imaging",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/cp_relate_objects/cp_relate_objects/3.1.9+galaxy0"
+    },
+    {
+      "name": "SaveImages",
+      "id": "cp_save_images",
+      "description": "or movie files",
+      "tool_shed_repository": "cp_save_images",
+      "panel_section_name": "Imaging",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/cp_save_images/cp_save_images/3.1.9+galaxy1"
+    },
+    {
+      "name": "ImageMath",
+      "id": "cp_image_math",
+      "description": "perform simple mathematical operations on images",
+      "tool_shed_repository": "cp_image_math",
+      "panel_section_name": "Imaging",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/cp_image_math/cp_image_math/3.1.9+galaxy0"
+    },
+    {
+      "name": "SpyBOAT",
+      "id": "spyboat",
+      "description": "wavelet analyzes image stacks",
+      "tool_shed_repository": "spyboat",
+      "panel_section_name": "Imaging",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/spyboat/spyboat/0.1.1"
+    },
+    {
+      "name": "Convert binary image to EDM",
+      "id": "imagej2_binary_to_edm",
+      "description": "(Euclidean Distance Map)",
+      "tool_shed_repository": "imagej2_binary_to_edm",
+      "panel_section_name": "Imaging",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/imgteam/imagej2_binary_to_edm/imagej2_binary_to_edm/3.0.1"
+    },
+    {
+      "name": "Skeletonize",
+      "id": "imagej2_skeletonize3d",
+      "description": "",
+      "tool_shed_repository": "imagej2_skeletonize3d",
+      "panel_section_name": "Imaging",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/imgteam/imagej2_skeletonize3d/imagej2_skeletonize3d/3.0.1"
+    },
+    {
+      "name": "Find edges",
+      "id": "imagej2_find_edges",
+      "description": "",
+      "tool_shed_repository": "imagej2_find_edges",
+      "panel_section_name": "Imaging",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/imgteam/imagej2_find_edges/imagej2_find_edges/3.0.1"
+    },
+    {
+      "name": "Add shadow effect",
+      "id": "imagej2_shadows",
+      "description": "",
+      "tool_shed_repository": "imagej2_shadows",
+      "panel_section_name": "Imaging",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/imgteam/imagej2_shadows/imagej2_shadows/3.0.1"
+    },
+    {
+      "name": "Enhance contrast",
+      "id": "imagej2_enhance_contrast",
+      "description": "",
+      "tool_shed_repository": "imagej2_enhance_contrast",
+      "panel_section_name": "Imaging",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/imgteam/imagej2_enhance_contrast/imagej2_enhance_contrast/3.0.1"
+    },
+    {
+      "name": "Find maxima",
+      "id": "imagej2_find_maxima",
+      "description": "",
+      "tool_shed_repository": "imagej2_find_maxima",
+      "panel_section_name": "Imaging",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/imgteam/imagej2_find_maxima/imagej2_find_maxima/3.0.1"
+    },
+    {
+      "name": "Watershed segmentation",
+      "id": "imagej2_watershed_binary",
+      "description": "of binary image",
+      "tool_shed_repository": "imagej2_watershed_binary",
+      "panel_section_name": "Imaging",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/imgteam/imagej2_watershed_binary/imagej2_watershed_binary/3.0.1"
+    },
+    {
+      "name": "Apply raw transformation",
+      "id": "imagej2_bunwarpj_raw_transform",
+      "description": "with bUnwarpJ",
+      "tool_shed_repository": "imagej2_bunwarpj_raw_transform",
+      "panel_section_name": "Imaging",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/imgteam/imagej2_bunwarpj_raw_transform/imagej2_bunwarpj_raw_transform/3.0.1"
+    },
+    {
+      "name": "Operate on pixels",
+      "id": "imagej2_math",
+      "description": "with a mathematical expression",
+      "tool_shed_repository": "imagej2_math",
+      "panel_section_name": "Imaging",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/imgteam/imagej2_math/imagej2_math/3.0.1"
+    },
+    {
+      "name": "Apply elastic transformation",
+      "id": "imagej2_bunwarpj_elastic_transform",
+      "description": "with bUnwarpJ",
+      "tool_shed_repository": "imagej2_bunwarpj_elastic_transform",
+      "panel_section_name": "Imaging",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/imgteam/imagej2_bunwarpj_elastic_transform/imagej2_bunwarpj_elastic_transform/3.0.1"
+    },
+    {
+      "name": "Overlay",
+      "id": "ip_viz_overlay_moving_and_fixed_image",
+      "description": "moving and fixed image",
+      "tool_shed_repository": "overlay_moving_and_fixed_image",
+      "panel_section_name": "Imaging",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/imgteam/overlay_moving_and_fixed_image/ip_viz_overlay_moving_and_fixed_image/0.0.2"
+    },
+    {
+      "name": "Extract top view",
+      "id": "ip_wsi_extract_top_view",
+      "description": "from whole-slice image",
+      "tool_shed_repository": "wsi_extract_top_view",
+      "panel_section_name": "Imaging",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/imgteam/wsi_extract_top_view/ip_wsi_extract_top_view/0.2"
+    },
+    {
+      "name": "GeneSeqToFamily preparation",
+      "id": "gstf_preparation",
+      "description": "converts data for the workflow",
+      "tool_shed_repository": "gstf_preparation",
+      "panel_section_name": "Imaging",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/earlhaminst/gstf_preparation/gstf_preparation/0.4.1"
+    },
+    {
+      "name": "Image Converter",
+      "id": "graphicsmagick_image_convert",
+      "description": "",
+      "tool_shed_repository": "graphicsmagick_image_convert",
+      "panel_section_name": "Imaging",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/bgruening/graphicsmagick_image_convert/graphicsmagick_image_convert/1.3.31"
+    },
+    {
+      "name": "Adapt an elastic transformation",
+      "id": "imagej2_bunwarpj_adapt_transform",
+      "description": "to a new image size with bUnwarpJ",
+      "tool_shed_repository": "imagej2_bunwarpj_adapt_transform",
+      "panel_section_name": "Imaging",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/imgteam/imagej2_bunwarpj_adapt_transform/imagej2_bunwarpj_adapt_transform/3.0.0"
+    },
+    {
+      "name": "Adjust threshold",
+      "id": "imagej2_adjust_threshold_binary",
+      "description": "of binary image",
+      "tool_shed_repository": "imagej2_adjust_threshold_binary",
+      "panel_section_name": "Imaging",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/imgteam/imagej2_adjust_threshold_binary/imagej2_adjust_threshold_binary/3.0.0"
+    },
+    {
+      "name": "Compose two elastic transformations",
+      "id": "imagej2_bunwarpj_compose_elastic",
+      "description": "into a raw transformation with bUnwarpJ",
+      "tool_shed_repository": "imagej2_bunwarpj_compose_elastic",
+      "panel_section_name": "Imaging",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/imgteam/imagej2_bunwarpj_compose_elastic/imagej2_bunwarpj_compose_elastic/3.0.0"
+    },
+    {
+      "name": "Sharpen",
+      "id": "imagej2_sharpen",
+      "description": "",
+      "tool_shed_repository": "imagej2_sharpen",
+      "panel_section_name": "Imaging",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/imgteam/imagej2_sharpen/imagej2_sharpen/3.0.0"
+    },
+    {
+      "name": "Convert to binary",
+      "id": "imagej2_make_binary",
+      "description": "(black and white)",
+      "tool_shed_repository": "imagej2_make_binary",
+      "panel_section_name": "Imaging",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/imgteam/imagej2_make_binary/imagej2_make_binary/3.0.0"
+    },
+    {
+      "name": "Convert elastic transformation to raw",
+      "id": "imagej2_bunwarpj_convert_to_raw",
+      "description": "with bUnwarpJ",
+      "tool_shed_repository": "imagej2_bunwarpj_convert_to_raw",
+      "panel_section_name": "Imaging",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/imgteam/imagej2_bunwarpj_convert_to_raw/imagej2_bunwarpj_convert_to_raw/3.0.0"
+    },
+    {
+      "name": "Compare two raw deformations",
+      "id": "imagej2_bunwarpj_compare_raw",
+      "description": "by warping index with bUnwarpJ",
+      "tool_shed_repository": "imagej2_bunwarpj_compare_raw",
+      "panel_section_name": "Imaging",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/imgteam/imagej2_bunwarpj_compare_raw/imagej2_bunwarpj_compare_raw/3.0.0"
+    },
+    {
+      "name": "Compare opposite elastic deformations",
+      "id": "imagej2_bunwarpj_compare_elastic",
+      "description": "by warping index with bUnwarpJ",
+      "tool_shed_repository": "imagej2_bunwarpj_compare_elastic",
+      "panel_section_name": "Imaging",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/imgteam/imagej2_bunwarpj_compare_elastic/imagej2_bunwarpj_compare_elastic/3.0.0"
+    },
+    {
+      "name": "Analyze skeleton",
+      "id": "imagej2_analyze_skeleton",
+      "description": "",
+      "tool_shed_repository": "imagej2_analyze_skeleton",
+      "panel_section_name": "Imaging",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/imgteam/imagej2_analyze_skeleton/imagej2_analyze_skeleton/3.0.0"
+    },
+    {
+      "name": "Smooth",
+      "id": "imagej2_smooth",
+      "description": "",
+      "tool_shed_repository": "imagej2_smooth",
+      "panel_section_name": "Imaging",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/imgteam/imagej2_smooth/imagej2_smooth/3.0.0"
+    },
+    {
+      "name": "Align two images",
+      "id": "imagej2_bunwarpj_align",
+      "description": "with bUnwarpJ",
+      "tool_shed_repository": "imagej2_bunwarpj_align",
+      "panel_section_name": "Imaging",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/imgteam/imagej2_bunwarpj_align/imagej2_bunwarpj_align/3.0.0"
+    },
+    {
+      "name": "Compose two raw transformations",
+      "id": "imagej2_bunwarpj_compose_raw",
+      "description": "into another raw transformation with bUnwarpJ",
+      "tool_shed_repository": "imagej2_bunwarpj_compose_raw",
+      "panel_section_name": "Imaging",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/imgteam/imagej2_bunwarpj_compose_raw/imagej2_bunwarpj_compose_raw/3.0.0"
+    },
+    {
+      "name": "Add or remove noise",
+      "id": "imagej2_noise",
+      "description": "",
+      "tool_shed_repository": "imagej2_noise",
+      "panel_section_name": "Imaging",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/imgteam/imagej2_noise/imagej2_noise/3.0.0"
+    },
+    {
+      "name": "Create new image",
+      "id": "imagej2_create_image",
+      "description": "",
+      "tool_shed_repository": "imagej2_create_image",
+      "panel_section_name": "Imaging",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/imgteam/imagej2_create_image/imagej2_create_image/3.0.0"
+    },
+    {
+      "name": "Analyze particles",
+      "id": "imagej2_analyze_particles_binary",
+      "description": "of binary image",
+      "tool_shed_repository": "imagej2_analyze_particles_binary",
+      "panel_section_name": "Imaging",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/imgteam/imagej2_analyze_particles_binary/imagej2_analyze_particles_binary/3.0.0"
+    },
+    {
+      "name": "Compose a raw and an elastic transformation",
+      "id": "imagej2_bunwarpj_compose_raw_elastic",
+      "description": "into a raw transformation with bUnwarpJ",
+      "tool_shed_repository": "imagej2_bunwarpj_compose_raw_elastic",
+      "panel_section_name": "Imaging",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/imgteam/imagej2_bunwarpj_compose_raw_elastic/imagej2_bunwarpj_compose_raw_elastic/3.0.0"
+    },
+    {
+      "name": "Compare elastic and raw deformation",
+      "id": "imagej2_bunwarpj_compare_elastic_raw",
+      "description": "by warping index with bUnwarpJ",
+      "tool_shed_repository": "imagej2_bunwarpj_compare_elastic_raw",
+      "panel_section_name": "Imaging",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/imgteam/imagej2_bunwarpj_compare_elastic_raw/imagej2_bunwarpj_compare_elastic_raw/3.0.0"
+    },
+    {
+      "name": "Image Info",
+      "id": "ip_imageinfo",
+      "description": "Show Image Info",
+      "tool_shed_repository": "image_info",
+      "panel_section_name": "Imaging",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/imgteam/image_info/ip_imageinfo/0.2"
+    },
+    {
+      "name": "Detection Visualization",
+      "id": "ip_detection_viz",
+      "description": "Detection Visualization",
+      "tool_shed_repository": "detection_viz",
+      "panel_section_name": "Imaging",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/imgteam/detection_viz/ip_detection_viz/0.3"
+    },
+    {
+      "name": "Histogram equalization",
+      "id": "ip_histogram_equalization",
+      "description": "automatic histogram equalization",
+      "tool_shed_repository": "2d_histogram_equalization",
+      "panel_section_name": "Imaging",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/imgteam/2d_histogram_equalization/ip_histogram_equalization/0.0.1"
+    },
+    {
+      "name": "Convert image",
+      "id": "ip_convertimage",
+      "description": "Convert image",
+      "tool_shed_repository": "bfconvert",
+      "panel_section_name": "Imaging",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/imgteam/bfconvert/ip_convertimage/0.4"
+    },
+    {
+      "name": "Colocalization",
+      "id": "ip_colocalization",
+      "description": "of two segmentation maps",
+      "tool_shed_repository": "colocalization_viz",
+      "panel_section_name": "Imaging",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/imgteam/colocalization_viz/ip_colocalization/0.0.8"
+    },
+    {
+      "name": "2D Feature Extraction",
+      "id": "ip_2d_feature_extraction",
+      "description": "Feature Extraction",
+      "tool_shed_repository": "2d_feature_extraction",
+      "panel_section_name": "Imaging",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/imgteam/2d_feature_extraction/ip_2d_feature_extraction/0.1.1"
+    },
+    {
+      "name": "Permutate image",
+      "id": "ip_permutate_axis",
+      "description": "along an axis",
+      "tool_shed_repository": "permutate_axis",
+      "panel_section_name": "Imaging",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/imgteam/permutate_axis/ip_permutate_axis/0.2"
+    },
+    {
+      "name": "Label to Points",
+      "id": "ip_labelimage_to_points",
+      "description": "Converts label image to points",
+      "tool_shed_repository": "labelimage2points",
+      "panel_section_name": "Imaging",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/imgteam/labelimage2points/ip_labelimage_to_points/0.2"
+    },
+    {
+      "name": "Points to Label",
+      "id": "ip_points_to_label",
+      "description": "Points to Label Image",
+      "tool_shed_repository": "points2labelimage",
+      "panel_section_name": "Imaging",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/imgteam/points2labelimage/ip_points_to_label/0.3"
+    },
+    {
+      "name": "Concatenate images",
+      "id": "ip_concat_channels",
+      "description": "",
+      "tool_shed_repository": "concat_channels",
+      "panel_section_name": "Imaging",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/imgteam/concat_channels/ip_concat_channels/0.2"
+    },
+    {
+      "name": "Scale Image",
+      "id": "ip_scale_image",
+      "description": "Scales image",
+      "tool_shed_repository": "scale_image",
+      "panel_section_name": "Imaging",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/imgteam/scale_image/ip_scale_image/0.4"
+    },
+    {
+      "name": "Merge Neighbours in Label",
+      "id": "ip_merge_neighbours_in_label",
+      "description": "Merge Neighbours in Label Image",
+      "tool_shed_repository": "mergeneighboursinlabelimage",
+      "panel_section_name": "Imaging",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/imgteam/mergeneighboursinlabelimage/ip_merge_neighbours_in_label/0.3"
+    },
+    {
+      "name": "Binary 2 Label",
+      "id": "ip_binary_to_labelimage",
+      "description": "Converts Binary to Label Image",
+      "tool_shed_repository": "binary2labelimage",
+      "panel_section_name": "Imaging",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/imgteam/binary2labelimage/ip_binary_to_labelimage/0.4"
+    },
+    {
+      "name": "Filter segmentation",
+      "id": "ip_2d_filter_segmentation_by_features",
+      "description": "Filter segmentation by rules",
+      "tool_shed_repository": "2d_filter_segmentation_by_features",
+      "panel_section_name": "Imaging",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/imgteam/2d_filter_segmentation_by_features/ip_2d_filter_segmentation_by_features/0.0.1"
+    },
+    {
+      "name": "Split objects",
+      "id": "ip_2d_split_binaryimage_by_watershed",
+      "description": "Split binary image by using watershed",
+      "tool_shed_repository": "2d_split_binaryimage_by_watershed",
+      "panel_section_name": "Imaging",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/imgteam/2d_split_binaryimage_by_watershed/ip_2d_split_binaryimage_by_watershed/0.0.1"
+    },
+    {
+      "name": "Anisotropic Diffusion",
+      "id": "ip_anisotropic_diffusion",
+      "description": "Edge-preserving, Anisotropic diffusion",
+      "tool_shed_repository": "anisotropic_diffusion",
+      "panel_section_name": "Imaging",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/imgteam/anisotropic_diffusion/ip_anisotropic_diffusion/0.2"
+    },
+    {
+      "name": "Color Deconvolution",
+      "id": "ip_color_deconvolution",
+      "description": "Color deconvolution",
+      "tool_shed_repository": "color_deconvolution",
+      "panel_section_name": "Imaging",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/imgteam/color_deconvolution/ip_color_deconvolution/0.8"
+    },
+    {
+      "name": "Filter Image",
+      "id": "ip_filter_standard",
+      "description": "applies a standard filter to an image",
+      "tool_shed_repository": "2d_simple_filter",
+      "panel_section_name": "Imaging",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/imgteam/2d_simple_filter/ip_filter_standard/0.0.3"
+    },
+    {
+      "name": "Points to Label",
+      "id": "ip_points_to_labe",
+      "description": "Points to Label Image",
+      "tool_shed_repository": "points2labelimage",
+      "panel_section_name": "Imaging",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/imgteam/points2labelimage/ip_points_to_labe/0.2"
+    },
+    {
+      "name": "Switch axis coordinates",
+      "id": "imagecoordinates_flipaxis",
+      "description": "Switches the axes of an image and flips the y axis.",
+      "tool_shed_repository": "imagecoordinates_flipaxis",
+      "panel_section_name": "Imaging",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/imgteam/imagecoordinates_flipaxis/imagecoordinates_flipaxis/0.1"
+    },
+    {
+      "name": "Coordinates of ROI",
+      "id": "ip_coordinates_of_roi",
+      "description": "",
+      "tool_shed_repository": "coordinates_of_roi",
+      "panel_section_name": "Imaging",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/imgteam/coordinates_of_roi/ip_coordinates_of_roi/0.0.4"
+    },
+    {
+      "name": "Count Objects",
+      "id": "ip_count_objects",
+      "description": "in labled images",
+      "tool_shed_repository": "count_objects",
+      "panel_section_name": "Imaging",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/imgteam/count_objects/ip_count_objects/0.0.4"
+    },
+    {
+      "name": "Mahotas-features",
+      "id": "ip_mahotas_features",
+      "description": "Compute features using mahotas",
+      "tool_shed_repository": "mahotas_features",
+      "panel_section_name": "Imaging",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/imgteam/mahotas_features/ip_mahotas_features/0.7"
+    },
+    {
+      "name": "Overlay Segmentation Mask",
+      "id": "ip_overlay_segmentation",
+      "description": "Overlay Segmentation Mask",
+      "tool_shed_repository": "overlay_segmentation_mask",
+      "panel_section_name": "Imaging",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/imgteam/overlay_segmentation_mask/ip_overlay_segmentation/0.0.6"
+    },
+    {
+      "name": "Points to Binary Image",
+      "id": "ip_points_to_binaryimage",
+      "description": "Converts points to a binary image",
+      "tool_shed_repository": "points2binaryimage",
+      "panel_section_name": "Imaging",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/imgteam/points2binaryimage/ip_points_to_binaryimage/0.1"
+    },
+    {
+      "name": "Visceral",
+      "id": "ip_visceral_evaluatesegmentation",
+      "description": "Evaluate Segmentation",
+      "tool_shed_repository": "visceral_evaluatesegmentation",
+      "panel_section_name": "Imaging",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/imgteam/visceral_evaluatesegmentation/ip_visceral_evaluatesegmentation/0.5"
+    },
+    {
+      "name": "Binary To Points",
+      "id": "ip_binaryimage_to_points",
+      "description": "Converts Binary Image to Points",
+      "tool_shed_repository": "binaryimage2points",
+      "panel_section_name": "Imaging",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/imgteam/binaryimage2points/ip_binaryimage_to_points/0.1"
+    },
+    {
+      "name": "Slice Image",
+      "id": "ip_slice_image",
+      "description": "into smaller patches",
+      "tool_shed_repository": "slice_image",
+      "panel_section_name": "Imaging",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/imgteam/slice_image/ip_slice_image/0.2"
+    },
+    {
+      "name": "Split Labelmap",
+      "id": "ip_split_labelmap",
+      "description": "",
+      "tool_shed_repository": "split_labelmap",
+      "panel_section_name": "Imaging",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/imgteam/split_labelmap/ip_split_labelmap/0.1"
+    },
+    {
+      "name": "Compute GLM on population data",
+      "id": "pampa_glmsp",
+      "description": "Compute a GLM of your choice on population data",
+      "tool_shed_repository": "pampa_glmsp",
+      "panel_section_name": "Species abundance",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/ecology/pampa_glmsp/pampa_glmsp/0.0.2"
+    },
+    {
+      "name": "Compute GLM on community data",
+      "id": "pampa_glmcomm",
+      "description": "Compute a GLM of your choice on community data",
+      "tool_shed_repository": "pampa_glmcomm",
+      "panel_section_name": "Species abundance",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/ecology/pampa_glmcomm/pampa_glmcomm/0.0.2"
+    },
+    {
+      "name": "Temporal trend indicator",
+      "id": "stoceps_trend_indic",
+      "description": "using GlmmTMB or GAM models",
+      "tool_shed_repository": "stoc_trend_indic",
+      "panel_section_name": "Species abundance",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/ecology/stoc_trend_indic/stoceps_trend_indic/0.0.2"
+    },
+    {
+      "name": "Estimate temporal population variation",
+      "id": "stoceps_glm_group",
+      "description": "by specialization group",
+      "tool_shed_repository": "stoc_mainglm_group",
+      "panel_section_name": "Species abundance",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/ecology/stoc_mainglm_group/stoceps_glm_group/0.0.2"
+    },
+    {
+      "name": "Estimate temporal population variation",
+      "id": "stoceps_glm",
+      "description": "by species",
+      "tool_shed_repository": "stoc_mainglm",
+      "panel_section_name": "Species abundance",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/ecology/stoc_mainglm/stoceps_glm/0.0.2"
+    },
+    {
+      "name": "Filter species",
+      "id": "stoceps_filteringsp",
+      "description": "with rare and low abundances",
+      "tool_shed_repository": "stoc_filteringsp",
+      "panel_section_name": "Species abundance",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/ecology/stoc_filteringsp/stoceps_filteringsp/0.0.2"
+    },
+    {
+      "name": "Preprocess population data",
+      "id": "stoceps_maketablecarrer",
+      "description": "for evolution trend analyzes",
+      "tool_shed_repository": "stoc_maketable",
+      "panel_section_name": "Species abundance",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/ecology/stoc_maketable/stoceps_maketablecarrer/0.0.2"
+    },
+    {
+      "name": "NetCDF xarray Metadata Info",
+      "id": "xarray_metadata_info",
+      "description": "summarize content of a Netcdf file",
+      "tool_shed_repository": "xarray_metadata_info",
+      "panel_section_name": "Species abundance",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/ecology/xarray_metadata_info/xarray_metadata_info/0.15.1"
+    },
+    {
+      "name": "NetCDF xarray Selection",
+      "id": "xarray_select",
+      "description": "extracts variable values with custom conditions on dimensions",
+      "tool_shed_repository": "xarray_select",
+      "panel_section_name": "Species abundance",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/ecology/xarray_select/xarray_select/0.15.1"
+    },
+    {
+      "name": "Calculate community metrics",
+      "id": "pampa_communitymetrics",
+      "description": "calculate community metrics from abundance data",
+      "tool_shed_repository": "pampa_communitymetrics",
+      "panel_section_name": "Species abundance",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/ecology/pampa_communitymetrics/pampa_communitymetrics/0.0.2"
+    },
+    {
+      "name": "Calculate presence absence table",
+      "id": "pampa_presabs",
+      "description": "calculate presence absence table from observation data",
+      "tool_shed_repository": "pampa_presabs",
+      "panel_section_name": "Species abundance",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/ecology/pampa_presabs/pampa_presabs/0.0.2"
+    },
+    {
+      "name": "Create a plot from GLM data",
+      "id": "pampa_plotglm",
+      "description": "as temporal trend",
+      "tool_shed_repository": "pampa_plotglm",
+      "panel_section_name": "Species abundance",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/ecology/pampa_plotglm/pampa_plotglm/0.0.2"
+    },
+    {
+      "name": "Model temporal trend",
+      "id": "regionalgam_gls",
+      "description": "with a simple linear regression",
+      "tool_shed_repository": "regionalgam_gls",
+      "panel_section_name": "Species abundance",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/ecology/regionalgam_gls/regionalgam_gls/1.5"
+    },
+    {
+      "name": "Flight curve",
+      "id": "regionalgam_flight_curve",
+      "description": "compute the regional expected pattern of abundance",
+      "tool_shed_repository": "regionalgam_flight_curve",
+      "panel_section_name": "Species abundance",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/ecology/regionalgam_flight_curve/regionalgam_flight_curve/1.5"
+    },
+    {
+      "name": "Autocorrelation test",
+      "id": "regionalgam_autocor_acf",
+      "description": "check for temporal autocorrelation in the residuals",
+      "tool_shed_repository": "regionalgam_autocor_acf",
+      "panel_section_name": "Species abundance",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/ecology/regionalgam_autocor_acf/regionalgam_autocor_acf/1.5"
+    },
+    {
+      "name": "Expected temporal trend",
+      "id": "regionalgam_glmmpql",
+      "description": "of species abundance",
+      "tool_shed_repository": "regionalgam_glmmpql",
+      "panel_section_name": "Species abundance",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/ecology/regionalgam_glmmpql/regionalgam_glmmpql/1.5"
+    },
+    {
+      "name": "Linear regression ajusted",
+      "id": "regionalgam_gls_adjusted",
+      "description": "for autocorrelation in the residuals",
+      "tool_shed_repository": "regionalgam_gls_adjusted",
+      "panel_section_name": "Species abundance",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/ecology/regionalgam_gls_adjusted/regionalgam_gls_adjusted/1.5"
+    },
+    {
+      "name": "Plot abundance",
+      "id": "regionalgam_plot_trend",
+      "description": "with trend line",
+      "tool_shed_repository": "regionalgam_plot_trend",
+      "panel_section_name": "Species abundance",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/ecology/regionalgam_plot_trend/regionalgam_plot_trend/1.5"
+    },
+    {
+      "name": "Abundance index",
+      "id": "regionalgam_ab_index",
+      "description": "computation across species, sites and years",
+      "tool_shed_repository": "regionalgam_ab_index",
+      "panel_section_name": "Species abundance",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/ecology/regionalgam_ab_index/regionalgam_ab_index/1.5"
+    },
+    {
+      "name": "Get the ancestor terms of a given OBO term",
+      "id": "onto_tk_get_ancestor_terms",
+      "description": "Collects the ancestor terms from a given term in the given OBO ontology",
+      "tool_shed_repository": "onto_tk_get_ancestor_terms",
+      "panel_section_name": "OBO Ontology manipulation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/onto_tk_get_ancestor_terms/onto_tk_get_ancestor_terms/1.45.1"
+    },
+    {
+      "name": "Get all the relationship types",
+      "id": "onto_tk_get_relationship_types",
+      "description": "from the given OBO ontology",
+      "tool_shed_repository": "onto_tk_get_relationship_types",
+      "panel_section_name": "OBO Ontology manipulation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/onto_tk_get_relationship_types/onto_tk_get_relationship_types/1.45.0"
+    },
+    {
+      "name": "Convert OBO to RDF",
+      "id": "onto_tk_obo2rdf",
+      "description": "",
+      "tool_shed_repository": "onto_tk_obo2rdf",
+      "panel_section_name": "OBO Ontology manipulation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/onto_tk_obo2rdf/onto_tk_obo2rdf/1.45.0"
+    },
+    {
+      "name": "Get the parent terms",
+      "id": "onto_tk_get_parent_terms",
+      "description": "of a given OBO term",
+      "tool_shed_repository": "onto_tk_get_parent_terms",
+      "panel_section_name": "OBO Ontology manipulation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/onto_tk_get_parent_terms/onto_tk_get_parent_terms/1.45.0"
+    },
+    {
+      "name": "Get the terms",
+      "id": "onto_tk_get_parent_terms_by_relationship_type",
+      "description": "filtered by a relationship type",
+      "tool_shed_repository": "onto_tk_get_parent_terms_by_relationship_type",
+      "panel_section_name": "OBO Ontology manipulation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/onto_tk_get_parent_terms_by_relationship_type/onto_tk_get_parent_terms_by_relationship_type/1.45.0"
+    },
+    {
+      "name": "Get all terms",
+      "id": "onto_tk_get_terms",
+      "description": "of a given OBO term",
+      "tool_shed_repository": "onto_tk_get_terms",
+      "panel_section_name": "OBO Ontology manipulation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/onto_tk_get_terms/onto_tk_get_terms/1.45.0"
+    },
+    {
+      "name": "Convert OBO to OWL",
+      "id": "onto_tk_obo2owl",
+      "description": "",
+      "tool_shed_repository": "onto_tk_obo2owl",
+      "panel_section_name": "OBO Ontology manipulation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/onto_tk_obo2owl/onto_tk_obo2owl/1.45.0"
+    },
+    {
+      "name": "Get all the relationship IDs and namespaces",
+      "id": "onto_tk_get_relationship_id_vs_relationship_namespace",
+      "description": "from the given OBO ontology",
+      "tool_shed_repository": "onto_tk_get_relationship_id_vs_relationship_namespace",
+      "panel_section_name": "OBO Ontology manipulation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/onto_tk_get_relationship_id_vs_relationship_namespace/onto_tk_get_relationship_id_vs_relationship_namespace/1.45.0"
+    },
+    {
+      "name": "Get all term synonyms",
+      "id": "onto_tk_get_term_synonyms",
+      "description": "of a given OBO term",
+      "tool_shed_repository": "onto_tk_get_term_synonyms",
+      "panel_section_name": "OBO Ontology manipulation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/onto_tk_get_term_synonyms/onto_tk_get_term_synonyms/1.45.0"
+    },
+    {
+      "name": "Get the descendent terms",
+      "id": "onto_tk_get_descendent_terms",
+      "description": "of a given OBO term",
+      "tool_shed_repository": "onto_tk_get_descendent_terms",
+      "panel_section_name": "OBO Ontology manipulation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/onto_tk_get_descendent_terms/onto_tk_get_descendent_terms/1.45.0"
+    },
+    {
+      "name": "Get all the term IDs and term names",
+      "id": "onto_tk_term_id_vs_term_name",
+      "description": "of a given OBO ontology",
+      "tool_shed_repository": "onto_tk_term_id_vs_term_name",
+      "panel_section_name": "OBO Ontology manipulation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/onto_tk_term_id_vs_term_name/onto_tk_term_id_vs_term_name/1.45.0"
+    },
+    {
+      "name": "Get child terms",
+      "id": "onto_tk_get_child_terms",
+      "description": "of a given OBO term",
+      "tool_shed_repository": "onto_tk_get_child_terms",
+      "panel_section_name": "OBO Ontology manipulation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/onto_tk_get_child_terms/onto_tk_get_child_terms/1.45.0"
+    },
+    {
+      "name": "Get subontology",
+      "id": "onto_tk_get_subontology_from",
+      "description": "from a given OBO term",
+      "tool_shed_repository": "onto_tk_get_subontology_from",
+      "panel_section_name": "OBO Ontology manipulation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/onto_tk_get_subontology_from/onto_tk_get_subontology_from/1.45.0"
+    },
+    {
+      "name": "Get all the relationship IDs and definitions",
+      "id": "onto_tk_get_relationship_id_vs_relationship_def",
+      "description": "from the given OBO ontology",
+      "tool_shed_repository": "onto_tk_get_relationship_id_vs_relationship_def",
+      "panel_section_name": "OBO Ontology manipulation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/onto_tk_get_relationship_id_vs_relationship_def/onto_tk_get_relationship_id_vs_relationship_def/1.45.0"
+    },
+    {
+      "name": "Get the terms that are related",
+      "id": "onto_tk_get_terms_by_relationship_type",
+      "description": "by a concrete relationship type",
+      "tool_shed_repository": "onto_tk_get_terms_by_relationship_type",
+      "panel_section_name": "OBO Ontology manipulation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/onto_tk_get_terms_by_relationship_type/onto_tk_get_terms_by_relationship_type/1.45.0"
+    },
+    {
+      "name": "Get the root terms",
+      "id": "onto_tk_get_root_terms",
+      "description": "of a given OBO term",
+      "tool_shed_repository": "onto_tk_get_root_terms",
+      "panel_section_name": "OBO Ontology manipulation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/onto_tk_get_root_terms/onto_tk_get_root_terms/1.45.0"
+    },
+    {
+      "name": "Get all the relationship IDs and names",
+      "id": "onto_tk_get_relationship_id_vs_relationship_name",
+      "description": "from the given OBO ontology",
+      "tool_shed_repository": "onto_tk_get_relationship_id_vs_relationship_name",
+      "panel_section_name": "OBO Ontology manipulation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/onto_tk_get_relationship_id_vs_relationship_name/onto_tk_get_relationship_id_vs_relationship_name/1.45.0"
+    },
+    {
+      "name": "UCSC Cell Browser",
+      "id": "ucsc_cell_browser",
+      "description": "displays single-cell clusterized data in an interactive web application.",
+      "tool_shed_repository": "ucsc_cell_browser",
+      "panel_section_name": "HCA-Single Cell",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/ucsc_cell_browser/ucsc_cell_browser/1.0.0+galaxy0"
+    },
+    {
+      "name": "Scanpy FindMarkers",
+      "id": "scanpy_find_markers",
+      "description": "to find differentially expressed genes between groups",
+      "tool_shed_repository": "scanpy_find_markers",
+      "panel_section_name": "HCA-Single Cell",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_find_markers/scanpy_find_markers/1.6.0+galaxy4"
+    },
+    {
+      "name": "Scanpy ScaleData",
+      "id": "scanpy_scale_data",
+      "description": "to make expression variance the same for all genes",
+      "tool_shed_repository": "scanpy_scale_data",
+      "panel_section_name": "HCA-Single Cell",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_scale_data/scanpy_scale_data/1.4.3+galaxy0"
+    },
+    {
+      "name": "Scanpy RunUMAP",
+      "id": "scanpy_run_umap",
+      "description": "visualise cell clusters using UMAP",
+      "tool_shed_repository": "scanpy_run_umap",
+      "panel_section_name": "HCA-Single Cell",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_run_umap/scanpy_run_umap/1.4.3+galaxy1"
+    },
+    {
+      "name": "Scanpy RunTSNE",
+      "id": "scanpy_run_tsne",
+      "description": "visualise cell clusters using tSNE",
+      "tool_shed_repository": "scanpy_run_tsne",
+      "panel_section_name": "HCA-Single Cell",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_run_tsne/scanpy_run_tsne/1.4.3+galaxy1"
+    },
+    {
+      "name": "Scanpy RunPCA",
+      "id": "scanpy_run_pca",
+      "description": "for dimensionality reduction",
+      "tool_shed_repository": "scanpy_run_pca",
+      "panel_section_name": "HCA-Single Cell",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_run_pca/scanpy_run_pca/1.4.3+galaxy0"
+    },
+    {
+      "name": "Scanpy Read10x",
+      "id": "scanpy_read_10x",
+      "description": "into hdf5 object handled by scanpy",
+      "tool_shed_repository": "scanpy_read_10x",
+      "panel_section_name": "HCA-Single Cell",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_read_10x/scanpy_read_10x/1.4.3+galaxy0"
+    },
+    {
+      "name": "Scanpy NormaliseData",
+      "id": "scanpy_normalise_data",
+      "description": "to make all cells having the same total expression",
+      "tool_shed_repository": "scanpy_normalise_data",
+      "panel_section_name": "HCA-Single Cell",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_normalise_data/scanpy_normalise_data/1.4.3+galaxy1"
+    },
+    {
+      "name": "Scanpy FindVariableGenes",
+      "id": "scanpy_find_variable_genes",
+      "description": "based on normalised dispersion of expression",
+      "tool_shed_repository": "scanpy_find_variable_genes",
+      "panel_section_name": "HCA-Single Cell",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_find_variable_genes/scanpy_find_variable_genes/1.4.3+galaxy0"
+    },
+    {
+      "name": "Scanpy FindCluster",
+      "id": "scanpy_find_cluster",
+      "description": "based on community detection on KNN graph",
+      "tool_shed_repository": "scanpy_find_cluster",
+      "panel_section_name": "HCA-Single Cell",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_find_cluster/scanpy_find_cluster/1.4.3+galaxy1"
+    },
+    {
+      "name": "Scanpy FilterGenes",
+      "id": "scanpy_filter_genes",
+      "description": "based on counts and numbers of cells expressed",
+      "tool_shed_repository": "scanpy_filter_genes",
+      "panel_section_name": "HCA-Single Cell",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_filter_genes/scanpy_filter_genes/1.4.3+galaxy2"
+    },
+    {
+      "name": "Scanpy FilterCells",
+      "id": "scanpy_filter_cells",
+      "description": "based on counts and numbers of genes expressed",
+      "tool_shed_repository": "scanpy_filter_cells",
+      "panel_section_name": "HCA-Single Cell",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_filter_cells/scanpy_filter_cells/1.4.3+galaxy0"
+    },
+    {
+      "name": "Scanpy ComputeGraph",
+      "id": "scanpy_compute_graph",
+      "description": "to derive kNN graph",
+      "tool_shed_repository": "scanpy_compute_graph",
+      "panel_section_name": "HCA-Single Cell",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_compute_graph/scanpy_compute_graph/1.4.3+galaxy0"
+    },
+    {
+      "name": "Human Cell Atlas Matrix Downloader",
+      "id": "hca_matrix_downloader",
+      "description": "retrieves expression matrices and metadata from the Human Cell Atlas.",
+      "tool_shed_repository": "hca_matrix_downloader",
+      "panel_section_name": "HCA-Single Cell",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/hca_matrix_downloader/hca_matrix_downloader/v0.0.3+galaxy0"
+    },
+    {
+      "name": "GTF2GeneList",
+      "id": "_ensembl_gtf2gene_list",
+      "description": "extracts a complete annotation table or subsets thereof from an Ensembl GTF using rtracklayer",
+      "tool_shed_repository": "gtf2gene_list",
+      "panel_section_name": "HCA-Single Cell",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/gtf2gene_list/_ensembl_gtf2gene_list/1.42.1+galaxy4"
+    },
+    {
+      "name": "Scanpy ParameterIterator",
+      "id": "scanpy_parameter_iterator",
+      "description": "produce an iteration over a defined parameter",
+      "tool_shed_repository": "scanpy_parameter_iterator",
+      "panel_section_name": "HCA-Single Cell",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_parameter_iterator/scanpy_parameter_iterator/0.0.1+galaxy3"
+    },
+    {
+      "name": "Scanpy PlotTrajectory",
+      "id": "scanpy_plot_trajectory",
+      "description": "visualise cell trajectories",
+      "tool_shed_repository": "scanpy_plot_trajectory",
+      "panel_section_name": "HCA-Single Cell",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_plot_trajectory/scanpy_plot_trajectory/1.4.3+galaxy6"
+    },
+    {
+      "name": "Scmap index cells",
+      "id": "scmap_index_cell",
+      "description": "creates a cell index for a dataset to enable fast approximate nearest neighbour search",
+      "tool_shed_repository": "scmap_index_cell",
+      "panel_section_name": "HCA-Single Cell",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scmap_index_cell/scmap_index_cell/1.6.0+galaxy2"
+    },
+    {
+      "name": "EBI SCXA Data Retrieval",
+      "id": "retrieve_scxa",
+      "description": "Retrieves expression matrixes and metadata from EBI Single Cell Expression Atlas (SCXA)",
+      "tool_shed_repository": "retrieve_scxa",
+      "panel_section_name": "HCA-Single Cell",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/retrieve_scxa/retrieve_scxa/v0.0.2+galaxy2"
+    },
+    {
+      "name": "Filter pileup",
+      "id": "pileup_parser",
+      "description": "on coverage and SNPs",
+      "tool_shed_repository": "pileup_parser",
+      "panel_section_name": "SAM/BAM Manipulation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/pileup_parser/pileup_parser/1.0.2"
+    },
+    {
+      "name": "Convert SAM",
+      "id": "sam2interval",
+      "description": "to interval",
+      "tool_shed_repository": "sam2interval",
+      "panel_section_name": "SAM/BAM Manipulation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/sam2interval/sam2interval/1.0.1"
+    },
+    {
+      "name": "Merge BAM Files",
+      "id": "sam_merge2",
+      "description": "merges BAM files together",
+      "tool_shed_repository": "sam_merge",
+      "panel_section_name": "SAM/BAM Manipulation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/sam_merge/sam_merge2/1.1.2"
+    },
+    {
+      "name": "Generate pileup",
+      "id": "sam_pileup",
+      "description": "from BAM dataset",
+      "tool_shed_repository": "sam_pileup",
+      "panel_section_name": "SAM/BAM Manipulation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/sam_pileup/sam_pileup/1.1.1"
+    },
+    {
+      "name": "flagstat",
+      "id": "samtools_flagstat",
+      "description": "provides simple stats on BAM files",
+      "tool_shed_repository": "samtools_flagstat",
+      "panel_section_name": "SAM/BAM Manipulation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/samtools_flagstat/samtools_flagstat/1.0.0"
+    },
+    {
+      "name": "MPileup",
+      "id": "samtools_mpileup",
+      "description": "SNP and indel caller",
+      "tool_shed_repository": "samtools_mpileup",
+      "panel_section_name": "SAM/BAM Manipulation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/samtools_mpileup/samtools_mpileup/0.0.1"
+    },
+    {
+      "name": "rmdup",
+      "id": "samtools_rmdup",
+      "description": "remove PCR duplicates",
+      "tool_shed_repository": "samtools_rmdup",
+      "panel_section_name": "SAM/BAM Manipulation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/samtools_rmdup/samtools_rmdup/1.0.0"
+    },
+    {
+      "name": "Slice BAM",
+      "id": "samtools_slice_bam",
+      "description": "by provided regions",
+      "tool_shed_repository": "samtools_slice_bam",
+      "panel_section_name": "SAM/BAM Manipulation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/samtools_slice_bam/samtools_slice_bam/0.0.1"
+    },
+    {
+      "name": "Pileup-to-Interval",
+      "id": "pileup_interval",
+      "description": "condenses pileup format into ranges of bases",
+      "tool_shed_repository": "pileup_interval",
+      "panel_section_name": "SAM/BAM Manipulation",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/pileup_interval/pileup_interval/1.0.0"
+    },
+    {
+      "name": "Summarize taxonomy",
+      "id": "t2t_report",
+      "description": "",
+      "tool_shed_repository": "t2t_report",
+      "panel_section_name": "Metagenomic Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/t2t_report/t2t_report/1.0.0"
+    },
+    {
+      "name": "Draw phylogeny",
+      "id": "Draw_phylogram",
+      "description": "",
+      "tool_shed_repository": "t2ps",
+      "panel_section_name": "Metagenomic Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/t2ps/Draw_phylogram/1.0.0"
+    },
+    {
+      "name": "Poisson two-sample test",
+      "id": "poisson2test",
+      "description": "",
+      "tool_shed_repository": "poisson2test",
+      "panel_section_name": "Metagenomic Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/poisson2test/poisson2test/1.0.0"
+    },
+    {
+      "name": "Find lowest diagnostic rank",
+      "id": "lca1",
+      "description": "",
+      "tool_shed_repository": "lca_wrapper",
+      "panel_section_name": "Metagenomic Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/lca_wrapper/lca1/1.0.1"
+    },
+    {
+      "name": "Fetch taxonomic representation",
+      "id": "Fetch Taxonomic Ranks",
+      "description": "",
+      "tool_shed_repository": "gi2taxonomy",
+      "panel_section_name": "Metagenomic Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/gi2taxonomy/Fetch Taxonomic Ranks/1.1.0"
+    },
+    {
+      "name": "Find diagnostic hits",
+      "id": "find_diag_hits",
+      "description": "",
+      "tool_shed_repository": "find_diag_hits",
+      "panel_section_name": "Metagenomic Analysis",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/find_diag_hits/find_diag_hits/1.0.0"
+    },
+    {
+      "name": "Count Covariates",
+      "id": "gatk_count_covariates",
+      "description": "on BAM files",
+      "tool_shed_repository": "count_covariates",
+      "panel_section_name": "GATK Tools",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/devteam/count_covariates/gatk_count_covariates/0.0.5"
+    },
+    {
+      "name": "DBKit Merge",
+      "id": "ffindex_dbkit_merge",
+      "description": "two databases",
+      "tool_shed_repository": "ffindex_dbkit_merge",
+      "panel_section_name": "Other Tools",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/guerler/ffindex_dbkit_merge/ffindex_dbkit_merge/0.2+galaxy0"
+    },
+    {
+      "name": "DBKit Extract",
+      "id": "ffindex_dbkit_extract",
+      "description": "entries",
+      "tool_shed_repository": "ffindex_dbkit_extract",
+      "panel_section_name": "Other Tools",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/guerler/ffindex_dbkit_extract/ffindex_dbkit_extract/0.2+galaxy0"
+    },
+    {
+      "name": "SPRING Model",
+      "id": "spring_model",
+      "description": "complex structures",
+      "tool_shed_repository": "spring_model",
+      "panel_section_name": "Other Tools",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/guerler/spring_model/spring_model/0.2+galaxy0"
+    },
+    {
+      "name": "SPRING Min-Z",
+      "id": "spring_minz",
+      "description": "filter operation",
+      "tool_shed_repository": "spring_minz",
+      "panel_section_name": "Other Tools",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/guerler/spring_minz/spring_minz/0.2+galaxy0"
+    },
+    {
+      "name": "SPRING Cross",
+      "id": "spring_cross",
+      "description": "reference builder",
+      "tool_shed_repository": "spring_cross",
+      "panel_section_name": "Other Tools",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/guerler/spring_cross/spring_cross/0.2+galaxy0"
+    },
+    {
+      "name": "PubMed query",
+      "id": "pubmed_by_queries",
+      "description": "download a defined number of abstracts or PMIDs from PubMed",
+      "tool_shed_repository": "pubmed_by_queries",
+      "panel_section_name": "Other Tools",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/pubmed_by_queries/pubmed_by_queries/0.0.2"
+    },
+    {
+      "name": "Text to wordmatrix",
+      "id": "text_to_wordmatrix",
+      "description": "by extracting most frequent words",
+      "tool_shed_repository": "text_to_wordmatrix",
+      "panel_section_name": "Other Tools",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/text_to_wordmatrix/text_to_wordmatrix/0.0.2"
+    },
+    {
+      "name": "Get PubMed abstracts",
+      "id": "abstracts_by_pmids",
+      "description": "by PMID IDs",
+      "tool_shed_repository": "abstracts_by_pmids",
+      "panel_section_name": "Other Tools",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/abstracts_by_pmids/abstracts_by_pmids/0.0.2"
+    },
+    {
+      "name": "PMIDs to PubTator",
+      "id": "pmids_to_pubtator_matrix",
+      "description": "binary matrix",
+      "tool_shed_repository": "pmids_to_pubtator_matrix",
+      "panel_section_name": "Other Tools",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/pmids_to_pubtator_matrix/pmids_to_pubtator_matrix/0.0.2"
+    },
+    {
+      "name": "SPRING Model-All",
+      "id": "spring_model_all",
+      "description": "complex structures",
+      "tool_shed_repository": "spring_model_all",
+      "panel_section_name": "Other Tools",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/guerler/spring_model_all/spring_model_all/0.2+galaxy0"
+    },
+    {
+      "name": "SPRING Map",
+      "id": "spring_map",
+      "description": "with BLAST",
+      "tool_shed_repository": "spring_map",
+      "panel_section_name": "Other Tools",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/guerler/spring_map/spring_map/0.2+galaxy0"
+    },
+    {
+      "name": "SPRING MCC",
+      "id": "spring_mcc",
+      "description": "plot generator",
+      "tool_shed_repository": "spring_mcc",
+      "panel_section_name": "Other Tools",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/guerler/spring_mcc/spring_mcc/0.2+galaxy0"
+    },
+    {
+      "name": "DBKit Create",
+      "id": "ffindex_dbkit_create",
+      "description": "database",
+      "tool_shed_repository": "ffindex_dbkit_create",
+      "panel_section_name": "Other Tools",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/guerler/ffindex_dbkit_create/ffindex_dbkit_create/0.2+galaxy0"
+    },
+    {
+      "name": "Statistics on presence-absence",
+      "id": "ecology_stat_presence_abs",
+      "description": "of a numeric variable",
+      "tool_shed_repository": "ecology_stat_presence_abs",
+      "panel_section_name": "Biodiversity data exploration",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/ecology/ecology_stat_presence_abs/ecology_stat_presence_abs/0.0.0"
+    },
+    {
+      "name": "Variables exploration",
+      "id": "ecology_link_between_var",
+      "description": "Shows interaction, correlation, colinearity, produces a PCA and computes VIF for biodiversity abundance data",
+      "tool_shed_repository": "ecology_link_between_var",
+      "panel_section_name": "Biodiversity data exploration",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/ecology/ecology_link_between_var/ecology_link_between_var/0.0.0"
+    },
+    {
+      "name": "Local Contributions to Beta Diversity (LCBD)",
+      "id": "ecology_beta_diversity",
+      "description": "Computes a measure of beta diversity, SCBD and representations",
+      "tool_shed_repository": "ecology_beta_diversity",
+      "panel_section_name": "Biodiversity data exploration",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/ecology/ecology_beta_diversity/ecology_beta_diversity/0.0.0"
+    },
+    {
+      "name": "Homoscedasticity and normality",
+      "id": "ecology_homogeneity_normality",
+      "description": "Checks the homogeneity of the variance and the normality of the distribution",
+      "tool_shed_repository": "ecology_homogeneity_normality",
+      "panel_section_name": "Biodiversity data exploration",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/ecology/ecology_homogeneity_normality/ecology_homogeneity_normality/0.0.0"
+    },
+    {
+      "name": "Presence-absence and abundance",
+      "id": "ecology_presence_abs_abund",
+      "description": "Community abundance map, presence barplot and rarefaction curves",
+      "tool_shed_repository": "ecology_presence_abs_abund",
+      "panel_section_name": "Biodiversity data exploration",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/ecology/ecology_presence_abs_abund/ecology_presence_abs_abund/0.0.0"
+    },
+    {
+      "name": "Spatial coordinates anonymization",
+      "id": "tool_anonymization",
+      "description": "without loss of the spatial relationships",
+      "tool_shed_repository": "tool_anonymization",
+      "panel_section_name": "Biodiversity data exploration",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/ecology/tool_anonymization/tool_anonymization/0.0.0"
+    },
+    {
+      "name": "tracy Assemble",
+      "id": "tracy_assemble",
+      "description": "genomic region from tiled, overlapping Sanger Chromatogram trace files",
+      "tool_shed_repository": "tracy_assemble",
+      "panel_section_name": "Sanger Sequencing",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/tracy_assemble/tracy_assemble/0.6.1+galaxy0"
+    },
+    {
+      "name": "tracy Basecall",
+      "id": "tracy_basecall",
+      "description": "from Sanger chromatogram tracefile",
+      "tool_shed_repository": "tracy_basecall",
+      "panel_section_name": "Sanger Sequencing",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/tracy_basecall/tracy_basecall/0.6.1+galaxy0"
+    },
+    {
+      "name": "tracy Decompose",
+      "id": "tracy_decompose",
+      "description": "heterozygous mutations (and call variants)",
+      "tool_shed_repository": "tracy_decompose",
+      "panel_section_name": "Sanger Sequencing",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/tracy_decompose/tracy_decompose/0.6.1+galaxy0"
+    },
+    {
+      "name": "tracy Align",
+      "id": "tracy_align",
+      "description": "chromatogram to a FASTA reference",
+      "tool_shed_repository": "tracy_align",
+      "panel_section_name": "Sanger Sequencing",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/tracy_align/tracy_align/0.6.1+galaxy0"
+    },
+    {
+      "name": "Gene length and GC content",
+      "id": "length_and_gc_content",
+      "description": "from GTF and FASTA file",
+      "tool_shed_repository": "length_and_gc_content",
+      "panel_section_name": "Extract Features",
+      "help": "",
+      "guid": "toolshed.g2.bx.psu.edu/repos/iuc/length_and_gc_content/length_and_gc_content/0.1.2"
+    }
+  ]
+  


### PR DESCRIPTION
For the front-end, two new methods using new `results` Array-of-Objects format which labels the `id` (tool name) and `score` (weights) elements from Whoosh. Previously, the `results` was an Array-of-Strings format from Whoosh (only an unlabeled tool name). (Note: This code assumes prior codebase related to Sorting methods was working properly.)

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
