### PR TITLE
[25.1] Syncs fork 25.1 with main repo

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -8,6 +8,12 @@ on:
       - 'release_*'
   pull_request_target:
     types: [opened, reopened, synchronize]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to use for the release draft (optional)'
+        required: false
+        type: string
 
 permissions:
   contents: read
@@ -34,9 +40,38 @@ jobs:
           echo "version=${RELEASE_VERSION}" >> $GITHUB_OUTPUT
           echo "Galaxy release version: ${RELEASE_VERSION}"
 
+      - name: Check if we should update draft
+        id: check-draft
+        run: |
+          VERSION="${{ inputs.version || steps.galaxy-version.outputs.version }}"
+
+          # Check if this version is already published
+          PUBLISHED=$(gh release view "v${VERSION}" --json isDraft --jq '.isDraft' 2>/dev/null || echo "not_found")
+
+          if [ "$PUBLISHED" = "false" ]; then
+            echo "Published release v${VERSION} already exists. Skipping."
+            echo "skip=true" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          # Check if a draft exists for a DIFFERENT version (only one draft at a time)
+          EXISTING_DRAFT=$(gh release list --limit 50 --json tagName,isDraft --jq '.[] | select(.isDraft == true) | .tagName' | head -1)
+
+          if [ -n "$EXISTING_DRAFT" ] && [ "$EXISTING_DRAFT" != "v${VERSION}" ]; then
+            echo "Draft release $EXISTING_DRAFT already exists (for different version). Skipping v${VERSION}."
+            echo "Only one draft release at a time is supported."
+            echo "skip=true" >> $GITHUB_OUTPUT
+          else
+            echo "Proceeding with draft for v${VERSION}."
+            echo "skip=false" >> $GITHUB_OUTPUT
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - uses: release-drafter/release-drafter@v6
+        if: steps.check-draft.outputs.skip == 'false'
         with:
           config-name: release-drafter.yml
-          version: ${{ steps.galaxy-version.outputs.version }}
+          version: ${{ inputs.version || steps.galaxy-version.outputs.version }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
but also adds a check for drafts

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
